### PR TITLE
Modifies jvm system property to look for graalvm

### DIFF
--- a/src/main/java/io/micronaut/gradle/graalvm/GraalUtil.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/GraalUtil.java
@@ -11,7 +11,7 @@ public final class GraalUtil {
      * @return Return whether the JVM in use a GraalVM JVM.
      */
     public static boolean isGraalJVM() {
-        String vv = System.getProperty("java.vendor.version");
-        return vv != null && vv.toLowerCase(Locale.ENGLISH).contains("graalvm");
+        String vv = System.getProperty("jvmci.Compiler");
+        return vv != null && vv.toLowerCase(Locale.ENGLISH).contains("graal");
     }
 }


### PR DESCRIPTION
Some version of the GraalVM JDK might not have `java.vendor.version` set