### PR TITLE
Update Open API groupId

### DIFF
--- a/src/main/java/io/micronaut/gradle/MicronautLibraryPlugin.java
+++ b/src/main/java/io/micronaut/gradle/MicronautLibraryPlugin.java
@@ -34,7 +34,7 @@ public class MicronautLibraryPlugin implements Plugin<Project> {
 
     static {
         GROUP_TO_PROCESSOR_MAP.put(
-            "io.swagger.core.v3", "io.micronaut.configuration:micronaut-openapi"
+            "io.swagger.core.v3", "io.micronaut.openapi:micronaut-openapi"
         );
         GROUP_TO_PROCESSOR_MAP.put(
             "io.micronaut.data", "io.micronaut.data:micronaut-data-processor"

--- a/src/test/groovy/io/micronaut/gradle/MicronautLibraryPluginSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/MicronautLibraryPluginSpec.groovy
@@ -87,7 +87,7 @@ public class Foo {
             }
             
             micronaut {
-                version "2.0.0.RC2"
+                version "2.1.0.M1"
                 
                 processing {
                     incremental true
@@ -302,7 +302,7 @@ class Foo {}
             }
             
             micronaut {
-                version "2.0.0.RC2"
+                version "2.0.1.M1"
             }
             
             repositories {


### PR DESCRIPTION
The related Open API test fails at this moment because we need a Micronaut version that includes the new groupId. I've put 2.1.0.M1 in the test (we may want to chage it to 2.1.0.RC1) so once the first 2.1 version is published we can merge this.