### PR TITLE
Remove '--no-server' because it's the default in GraalVM 20.2.0

### DIFF
--- a/src/main/java/io/micronaut/gradle/graalvm/NativeImageOptions.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/NativeImageOptions.java
@@ -232,9 +232,4 @@ public interface NativeImageOptions {
     @Input
     Property<Boolean> isVerbose();
 
-    /**
-     * @return Should the build run on a server (defaults to false).
-     */
-    @Input
-    Property<Boolean> isServerBuild();
 }

--- a/src/main/java/io/micronaut/gradle/graalvm/NativeImageTask.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/NativeImageTask.java
@@ -30,7 +30,6 @@ public class NativeImageTask extends AbstractExecTask<NativeImageTask>
     private final Property<Boolean> isDebug;
     private final Property<Boolean> isFallback;
     private final Property<Boolean> isVerbose;
-    private final Property<Boolean> isServerBuild;
     private final Map<BooleanSupplier, String> booleanCmds;
 
     /**
@@ -51,12 +50,10 @@ public class NativeImageTask extends AbstractExecTask<NativeImageTask>
         this.isDebug = objectFactory.property(Boolean.class).convention(false);
         this.isFallback = objectFactory.property(Boolean.class).convention(false);
         this.isVerbose = objectFactory.property(Boolean.class).convention(false);
-        this.isServerBuild = objectFactory.property(Boolean.class).convention(false);
         this.booleanCmds = new LinkedHashMap<>(3);
         booleanCmds.put(isDebug::get, "-H:GenerateDebugInfo=1");
         booleanCmds.put(() -> !isFallback.get(), "--no-fallback");
         booleanCmds.put(isVerbose::get,  "--verbose");
-        booleanCmds.put(() -> !isServerBuild.get(), "--no-server");
     }
 
     @Override
@@ -268,10 +265,5 @@ public class NativeImageTask extends AbstractExecTask<NativeImageTask>
     @Override
     public Property<Boolean> isVerbose() {
         return isVerbose;
-    }
-
-    @Override
-    public Property<Boolean> isServerBuild() {
-        return isServerBuild;
     }
 }


### PR DESCRIPTION
This PR removes the option `--no-server` because since GraalVM 20.2.0 is the default option. Also, the GraalVM team has mentioned some times that there are still issues when using a server for the build, so it's not really recommended to use it.