### PR TITLE
Make AnnotationProcessingConfigBuilder public

### DIFF
--- a/src/main/java/io/micronaut/gradle/AnnotationProcessingConfigBuilder.java
+++ b/src/main/java/io/micronaut/gradle/AnnotationProcessingConfigBuilder.java
@@ -3,7 +3,7 @@ package io.micronaut.gradle;
 /**
  * Allows configuration of annotation processing.
  */
-interface AnnotationProcessingConfigBuilder {
+public interface AnnotationProcessingConfigBuilder {
     /**
      * Whether incremental processing is enabled.
      * @param incremental True if incremental processing is enabled


### PR DESCRIPTION
This will fix the warning in IntelliJ IDEA:

Type AnnotationProcessingConfigBuilder! is inaccessible in this context due to: public/*package*/ interface AnnotationProcessingConfigBuilder defined in io.micronaut.gradle in file AnnotationProcessingConfigBuilder.class


<img width="849" alt="image" src="https://user-images.githubusercontent.com/139017/92997121-65567400-f543-11ea-8a31-43c6005ba81e.png">
