### PR TITLE
Allow micronaut-build commit directly to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_TOKEN }}
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK
         uses: actions/setup-java@v1
@@ -18,6 +20,8 @@ jobs:
         run: echo ::set-output name=release_version::${GITHUB_REF:11}
       - name: Run pre-release
         uses: micronaut-projects/github-actions/pre-release@master
+        env:
+          MICRONAUT_BUILD_EMAIL: ${{ secrets.MICRONAUT_BUILD_EMAIL }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to Grade Plugin Portal
@@ -28,5 +32,7 @@ jobs:
       - name: Run post-release
         if: success()
         uses: micronaut-projects/github-actions/post-release@master
+        env:
+          MICRONAUT_BUILD_EMAIL: ${{ secrets.MICRONAUT_BUILD_EMAIL }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We've lost all the tags since 1.0.0.RC1 (included). All the commits with the arrow are not commited into master branch (and lost)

![DeepinScreenshot_select-area_20200922164021](https://user-images.githubusercontent.com/559192/93897537-79903300-fcf2-11ea-939c-6951d69e3b92.png)
