### PR TITLE
Apply graal annotation processor if native image tasks present in graph

### DIFF
--- a/src/main/java/io/micronaut/gradle/MicronautExtension.java
+++ b/src/main/java/io/micronaut/gradle/MicronautExtension.java
@@ -2,6 +2,7 @@ package io.micronaut.gradle;
 
 import io.micronaut.gradle.graalvm.GraalUtil;
 import org.gradle.api.Action;
+import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 
@@ -30,7 +31,7 @@ public class MicronautExtension {
         this.processing = objectFactory.newInstance(AnnotationProcessing.class);
         this.version = objectFactory.property(String.class);
         this.enableNativeImage = objectFactory.property(Boolean.class)
-                                    .convention(GraalUtil.isGraalJVM());
+                                    .convention(true);
         this.runtime = objectFactory.property(MicronautRuntime.class)
                                     .convention(MicronautRuntime.NONE);
         this.testRuntime = objectFactory.property(MicronautTestRuntime.class)


### PR DESCRIPTION
This fixes the case where you use a non-Graal JDK to build in which cases the `resource-config.json` is not generated