### PR TITLE
Allow running tests with the native image server

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -23,10 +23,12 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Set GraalVM CE
+      - name: Setup GraalVM CE
         uses: DeLaGuardo/setup-graalvm@2.0
         with:
           graalvm-version: ${{ matrix.graalvm }}
+      - name: Install Native Image
+        run: gu install native-image
       - name: Build with Gradle
         run: ./gradlew check --parallel --continue
         env:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-projectVersion=1.0.6.BUILD-SNAPSHOT
+projectVersion=1.1.0.BUILD-SNAPSHOT
 githubBranch=master

--- a/src/main/java/io/micronaut/gradle/graalvm/NativeImageTestTask.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/NativeImageTestTask.java
@@ -1,0 +1,113 @@
+package io.micronaut.gradle.graalvm;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.testing.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.Random;
+import java.util.Scanner;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class NativeImageTestTask extends DefaultTask {
+
+    /**
+     * The minimum port number.
+     */
+    private static final int MIN_PORT_RANGE = 1025;
+
+    /**
+     * The maximum port number.
+     */
+    private static final int MAX_PORT_RANGE = 65535;
+
+    @SuppressWarnings("ConstantName")
+    private static final Random random = new Random(System.currentTimeMillis());
+
+    public NativeImageTestTask() {
+    }
+
+    @TaskAction
+    public void exec() {
+        Project project = getProject();
+        NativeImageTask nativeImage = (NativeImageTask) project.getTasks().findByName("nativeImage");
+        Test test = (Test) project.getTasks().findByName("test");
+        File file = nativeImage.getNativeImageOutput();
+        ExecutorService es = Executors.newSingleThreadExecutor();
+        CompletableFuture<Process> processFuture = new CompletableFuture<>();
+        int port = findAvailableTcpPort();
+        es.submit(() -> {
+            ProcessBuilder processBuilder = new ProcessBuilder();
+            processBuilder.command(
+                    file.getAbsolutePath(),
+                    "-Dmicronaut.server.host=localhost",
+                    "-Dmicronaut.server.port=" + port
+            );
+            try {
+                Process start = processBuilder.start();
+                processFuture.complete(start);
+                inheritIO(start.getInputStream());
+                inheritIO(start.getErrorStream());
+            } catch (IOException e) {
+                processFuture.completeExceptionally(new RuntimeException("Error starting native image server: " + e.getMessage(), e));
+            }
+        });
+
+        try {
+            Process process = processFuture.get();
+            test.doLast((task) -> process.destroy());
+            test.systemProperty("micronaut.test.server.url", "http://localhost:" + port);
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException("Error starting native image server: " + e.getMessage(), e);
+        }
+
+    }
+
+    private void inheritIO(final InputStream src) {
+        PrintStream out = System.out;
+        new Thread(() -> {
+            Scanner sc = new Scanner(src);
+            while (sc.hasNextLine()) {
+                out.println(sc.nextLine());
+            }
+        }).start();
+    }
+
+    /**
+     * Finds an available TCP port.
+     *
+     * @return The available port
+     */
+    private static int findAvailableTcpPort() {
+        int currentPort = nextPort();
+        while (!isTcpPortAvailable(currentPort)) {
+            currentPort = nextPort();
+        }
+        return currentPort;
+    }
+
+
+    private static boolean isTcpPortAvailable(int currentPort) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(InetAddress.getLocalHost(), currentPort), 20);
+            return false;
+        } catch (Throwable e) {
+            return true;
+        }
+    }
+
+    private static int nextPort() {
+        int seed = NativeImageTestTask.MAX_PORT_RANGE - NativeImageTestTask.MIN_PORT_RANGE;
+        return random.nextInt(seed) + NativeImageTestTask.MIN_PORT_RANGE;
+    }
+}

--- a/src/test/groovy/io/micronaut/gradle/NativeImageTestTaskSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/NativeImageTestTaskSpec.groovy
@@ -1,0 +1,148 @@
+package io.micronaut.gradle
+
+import io.micronaut.gradle.graalvm.GraalUtil
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Requires
+import spock.lang.Specification
+
+@Requires({ GraalUtil.isGraalJVM() })
+class NativeImageTestTaskSpec extends Specification {
+    @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+
+    File settingsFile
+    File buildFile
+
+    def setup() {
+        settingsFile = testProjectDir.newFile('settings.gradle')
+        buildFile = testProjectDir.newFile('build.gradle')
+    }
+
+    def "test execute tests against native image"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.application"
+                id "com.adarshr.test-logger" version "2.1.1"
+            }
+            
+            micronaut {
+                version "2.1.2"
+                runtime "netty"
+                testRuntime "junit5"
+            }
+            
+            repositories {
+                jcenter()
+                mavenCentral()
+                maven { url "https://oss.jfrog.org/oss-snapshot-local" }
+            }
+            
+            dependencies {
+                runtimeOnly("org.slf4j:slf4j-simple")
+                testImplementation("io.micronaut:micronaut-http-client")
+                testImplementation("io.micronaut.test:micronaut-test-core:2.2.0.BUILD-SNAPSHOT") {
+                    version {
+                        strictly("2.2.0.BUILD-SNAPSHOT")
+                    }
+                }
+            }
+            
+            mainClassName="example.Application"
+            
+            testlogger {
+               showStandardStreams true
+            }
+        """
+        testProjectDir.newFolder("src", "main", "java", "example")
+        def javaFile = testProjectDir.newFile("src/main/java/example/Application.java")
+        javaFile.parentFile.mkdirs()
+        javaFile << """
+package example;
+
+import io.micronaut.runtime.Micronaut;
+
+class Application {
+    public static void main(String... args) {
+        Micronaut.run(args);    
+    }
+}
+"""
+        def controllerFile = testProjectDir.newFile("src/main/java/example/FooController.java")
+        controllerFile.parentFile.mkdirs()
+        controllerFile << """
+package example;
+
+import io.micronaut.http.annotation.*;
+
+@Controller("/foo")
+public class FooController {
+
+    @Get(uri="/", produces="text/plain")
+    public String index() {
+        System.out.println("Executing Controller");
+        return "Example Response";
+    }
+}
+"""
+
+        testProjectDir.newFolder("src", "test", "resources")
+        def loggingConfig = testProjectDir.newFile("src/test/resources/simplelogger.properties")
+        loggingConfig.parentFile.mkdirs()
+        loggingConfig << '''
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.log.io.micronaut=info
+'''
+        testProjectDir.newFolder("src", "test", "java", "example")
+        def testJavaFile = testProjectDir.newFile("src/test/java/example/FooControllerTest.java")
+        testJavaFile.parentFile.mkdirs()
+        testJavaFile << """
+package example;
+
+import io.micronaut.http.*;
+import io.micronaut.http.client.RxHttpClient;
+import io.micronaut.test.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import io.micronaut.http.client.annotation.*;
+import javax.inject.Inject;
+import static org.junit.jupiter.api.Assertions.*;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.test.support.server.TestEmbeddedServer;
+
+@MicronautTest
+public class FooControllerTest {
+
+    @Inject
+    @Client("/")
+    RxHttpClient client;
+    
+    @Inject
+    EmbeddedServer embeddedServer;
+
+    @Test
+    public void testIndex() throws Exception {
+        assertTrue(
+            embeddedServer instanceof TestEmbeddedServer
+        );
+        HttpResponse<String> response = client.toBlocking().exchange("/foo", String.class);
+        assertEquals(HttpStatus.OK, response.status());
+        assertEquals("Example Response", response.body());
+    }
+}
+"""
+
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('testNativeImage')
+                .withPluginClasspath()
+                .build()
+
+        def task = result.task(":testNativeImage")
+        expect:
+        result.output.contains("Executing Controller")
+        task.outcome == TaskOutcome.SUCCESS
+    }
+}


### PR DESCRIPTION
This PR starts the native image server and configures Micronaut Test to use so that integration tests can also test the native image build