### PR TITLE
Add memory options and remove library path from AWS custom runtime

### DIFF
--- a/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -245,7 +245,7 @@ public class NativeImageDockerfile extends Dockerfile implements DockerBuildOpti
                     List<String> newList = new ArrayList<>(strings.size() + 1);
                     newList.add("./func");
                     newList.addAll(strings);
-                    newList.add("-Djava.library.path=$(pwd)");
+                    newList.add("-Xmx512m");
                     return newList;
                 }).get());
                 runCommand("echo \"#!/bin/sh\" >> bootstrap && echo \"set -euo pipefail\" >> bootstrap && echo \"" + funcCmd + "\" >> bootstrap");


### PR DESCRIPTION
Adding the library path shouldn't be necessary anymore because with the most recent versions of GraalVM it's not necessary to pass libraries like we used to do with `libsunec.so` in the past.

I've replaced that with the memory settings that we had before in Starter: https://github.com/micronaut-projects/micronaut-starter/pull/379/commits/5a38c0e2ee081a1c48f8c5555b3996eb2e43b8ed