### PR TITLE
Allowing a developer to add further instructions to the generated Dockerfile for additional customisation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,20 @@ dockerfileNative {
 
 The above configuration uses a max heap setting of 128m for Java and 64m for native image for the application. 
 
+To add additional docker instructions to the generated Dockerfile, such as adding a HEALTHCHECK, you can do the following 
+```groovy
+dockerfile {
+ args("-Xmx128m")
+ instruction 'HEALTHCHECK CMD curl -s localhost:8090/health | grep \'"status":"UP"\''   
+}
+dockerfileNative {
+ args("-Xmx64m")
+ instruction 'HEALTHCHECK CMD curl -s localhost:8090/health | grep \'"status":"UP"\''
+}
+```
+
+You can also add any of the other instructions/commands that the docker plugin supports, see https://github.com/bmuschko/gradle-docker-plugin/blob/master/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy 
+
 ### Micronaut Runtimes
 
 A higher level concept of "runtimes" is included in the Micronaut Gradle plugin which essentially allows the plugin to decide which server runtime to include in the dependencies of the application when building the application. For example consider this minimal build:

--- a/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
+++ b/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
@@ -8,7 +8,6 @@ import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage;
 import com.bmuschko.gradle.docker.tasks.image.DockerPushImage;
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
 import io.micronaut.gradle.MicronautApplicationPlugin;
-import io.micronaut.gradle.MicronautExtension;
 import io.micronaut.gradle.MicronautRuntime;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
@@ -33,7 +32,6 @@ public class MicronautDockerPlugin implements Plugin<Project> {
         TaskContainer tasks = project.getTasks();
         ExtensionContainer extensions = project.getExtensions();
         extensions.create("docker", DockerExtension.class);
-        MicronautExtension micronautExtension = extensions.getByType(MicronautExtension.class);
         File applicationLayout = new File(project.getBuildDir(), "layers");
         TaskProvider<Jar> runnerJar = tasks.register("runnerJar", Jar.class, jar -> {
             jar.dependsOn(tasks.findByName("classes"));
@@ -132,7 +130,7 @@ public class MicronautDockerPlugin implements Plugin<Project> {
         }
 
         configureDockerBuild(project, tasks, buildLayersTask);
-        configureNativeDockerBuild(project, tasks, micronautExtension, buildLayersTask);
+        configureNativeDockerBuild(project, tasks, buildLayersTask);
     }
 
     private void configureDockerBuild(Project project, TaskContainer tasks, TaskProvider<Task> buildLayersTask) {
@@ -147,7 +145,7 @@ public class MicronautDockerPlugin implements Plugin<Project> {
                     }
             );
         } else {
-            dockerFileTask = tasks.register("dockerfile", MicronautDockerfile.class);
+            dockerFileTask = tasks.register("dockerfile", MicronautDockerfile.class, MicronautDockerfile::setupDockerfileInstructions);
             dockerFileTask.configure(task -> {
                 MicronautRuntime mr = MicronautApplicationPlugin.resolveRuntime(project);
                 if (mr != MicronautRuntime.NONE) {
@@ -180,16 +178,18 @@ public class MicronautDockerPlugin implements Plugin<Project> {
         });
     }
 
-    private void configureNativeDockerBuild(Project project, TaskContainer tasks, MicronautExtension micronautExtension, TaskProvider<Task> buildLayersTask) {
+    private void configureNativeDockerBuild(Project project, TaskContainer tasks, TaskProvider<Task> buildLayersTask) {
         File f = project.file("DockerfileNative");
 
         TaskProvider<NativeImageDockerfile> dockerFileTask;
         if (f.exists()) {
             dockerFileTask = tasks.register("dockerfileNative", NativeImageDockerfile.class, task -> {
+                task.setGroup(BasePlugin.BUILD_GROUP);
+                task.setDescription("Builds a Native Docker File");
                 task.instructionsFromTemplate(f);
             });
         } else {
-            dockerFileTask = tasks.register("dockerfileNative", NativeImageDockerfile.class);
+            dockerFileTask = tasks.register("dockerfileNative", NativeImageDockerfile.class, NativeImageDockerfile::setupDockerfileInstructions);
             dockerFileTask.configure(task -> {
                 MicronautRuntime mr = MicronautApplicationPlugin.resolveRuntime(project);
                 if (mr != MicronautRuntime.NONE) {

--- a/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
@@ -1,7 +1,6 @@
 package io.micronaut.gradle.docker;
 
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
-import io.micronaut.gradle.MicronautRuntime;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
@@ -10,14 +9,13 @@ import org.gradle.api.plugins.JavaApplication;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.jvm.Jvm;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class MicronautDockerfile extends Dockerfile implements DockerBuildOptions  {
 
@@ -57,9 +55,7 @@ public class MicronautDockerfile extends Dockerfile implements DockerBuildOption
         return defaultCommand;
     }
 
-    @Override
-    @TaskAction
-    public void create() {
+    public void setupDockerfileInstructions() {
         DockerBuildStrategy buildStrategy = this.buildStrategy.getOrElse(DockerBuildStrategy.DEFAULT);
         JavaApplication javaApplication = getProject().getExtensions().getByType(JavaApplication.class);
         String from = getBaseImage().getOrNull();
@@ -96,7 +92,6 @@ public class MicronautDockerfile extends Dockerfile implements DockerBuildOption
                     return newList;
                 }));
         }
-        super.create();
     }
 
     /**

--- a/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -12,6 +12,7 @@ import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.StopActionException;
 import org.gradle.internal.jvm.Jvm;
 
 import javax.annotation.Nullable;
@@ -143,12 +144,12 @@ public class NativeImageDockerfile extends Dockerfile implements DockerBuildOpti
     }
 
     public void setupDockerfileInstructions() {
-        DockerBuildStrategy buildStrategy = this.buildStrategy.getOrElse(DockerBuildStrategy.DEFAULT);
-        JavaApplication javaApplication = getProject().getExtensions().getByType(JavaApplication.class);
         JavaPluginExtension javaPluginExtension = getProject().getExtensions().getByType(JavaPluginExtension.class);
         if (javaPluginExtension.getTargetCompatibility().isJava12Compatible()) {
-            throw new RuntimeException("To build native images you must set the Java target byte code level to Java 11 or below");
+            throw new StopActionException("To build native images you must set the Java target byte code level to Java 11 or below");
         }
+        DockerBuildStrategy buildStrategy = this.buildStrategy.getOrElse(DockerBuildStrategy.DEFAULT);
+        JavaApplication javaApplication = getProject().getExtensions().getByType(JavaApplication.class);
         if (buildStrategy == DockerBuildStrategy.LAMBDA) {
             from(new From("amazonlinux:latest").withStage("graalvm"));
             environmentVariable("LANG", "en_US.UTF-8");
@@ -174,7 +175,7 @@ public class NativeImageDockerfile extends Dockerfile implements DockerBuildOpti
         if (nit instanceof NativeImageTask) {
             nativeImageTask = (NativeImageTask) nit;
         } else {
-            throw new IllegalStateException("No native image task present! Must be used in conjunction with a NativeImageTask.");
+            throw new StopActionException("No native image task present! Must be used in conjunction with a NativeImageTask.");
         }
 
         // clear out classpath
@@ -274,7 +275,6 @@ public class NativeImageDockerfile extends Dockerfile implements DockerBuildOpti
                 }));
             break;
         }
-        super.create();
     }
 
     /**

--- a/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -8,7 +8,6 @@ import org.gradle.api.Task;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaApplication;
-import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -144,10 +143,6 @@ public class NativeImageDockerfile extends Dockerfile implements DockerBuildOpti
     }
 
     public void setupDockerfileInstructions() {
-        JavaPluginExtension javaPluginExtension = getProject().getExtensions().getByType(JavaPluginExtension.class);
-        if (javaPluginExtension.getTargetCompatibility().isJava12Compatible()) {
-            throw new StopActionException("To build native images you must set the Java target byte code level to Java 11 or below");
-        }
         DockerBuildStrategy buildStrategy = this.buildStrategy.getOrElse(DockerBuildStrategy.DEFAULT);
         JavaApplication javaApplication = getProject().getExtensions().getByType(JavaApplication.class);
         if (buildStrategy == DockerBuildStrategy.LAMBDA) {

--- a/src/main/java/io/micronaut/gradle/graalvm/NativeImageTask.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/NativeImageTask.java
@@ -95,6 +95,9 @@ public class NativeImageTask extends AbstractExecTask<NativeImageTask>
         }
 
         // set the main class
+        if (!getMain().isPresent()) {
+            throw new IllegalStateException("Main class must be set");
+        }
         String main = getMain().get();
         args("-H:Class=" + main);
 


### PR DESCRIPTION
In relation to the issue that was raised ( https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/98 ) regarding the customisation of the Dockerfile generated, here is a PR that allows the addition of further instructions to be added.
The primary change was how the dockerfile and dockerfileNative tasks were being setup and executed.