### PR TITLE
Use alpine-glibc:3.12 as base image

### DIFF
--- a/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -213,7 +213,7 @@ public class NativeImageDockerfile extends Dockerfile implements DockerBuildOpti
             break;
             default:
                 if (baseImage == null) {
-                    baseImage = "frolvlad/alpine-glibc";
+                    baseImage = "frolvlad/alpine-glibc:alpine-3.12";
                 }
                 from(baseImage);
                 if (baseImage.contains("alpine-glibc")) {


### PR DESCRIPTION
The `latest` version of `frolvlad/alpine-glibc` (3.13) is not compatible with GraalVM and application fail with a segmentation fault. This PR sets the version to the previous one that works (3.12)

More info: https://github.com/oracle/graal/issues/3159