### PR TITLE
Build "mostly" static native image and use distroless docker image

### DIFF
--- a/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -157,7 +157,7 @@ public class NativeImageDockerfile extends Dockerfile implements DockerBuildOpti
         if (buildStrategy == DockerBuildStrategy.LAMBDA) {
             from(new From("amazonlinux:latest").withStage("graalvm"));
             environmentVariable("LANG", "en_US.UTF-8");
-            runCommand("yum install -y gcc gcc-c++ libc6-dev  zlib1g-dev curl bash zlib zlib-devel zip tar gzip");
+            runCommand("yum install -y gcc gcc-c++ libc6-dev zlib1g-dev curl bash zlib zlib-devel zlib-static zip tar gzip");
             String jdkVersion = this.jdkVersion.get();
             String graalVersion = this.graalVersion.get();
             String fileName = "graalvm-ce-" + jdkVersion + "-linux-amd64-" + graalVersion + ".tar.gz";
@@ -215,12 +215,9 @@ public class NativeImageDockerfile extends Dockerfile implements DockerBuildOpti
             break;
             default:
                 if (baseImage == null) {
-                    baseImage = "frolvlad/alpine-glibc:alpine-3.12";
+                    baseImage = "gcr.io/distroless/cc-debian10";
                 }
                 from(baseImage);
-                if (baseImage.contains("alpine-glibc")) {
-                    runCommand("apk update && apk add libstdc++");
-                }
                 exposePort(this.exposedPorts);
                 copyFile(new CopyFile("/home/app/application", "/app/application").withStage("graalvm"));
                 entryPoint(APPLICATION_ARGS_TO_REPLACE);

--- a/src/main/java/io/micronaut/gradle/graalvm/NativeImageTask.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/NativeImageTask.java
@@ -105,6 +105,9 @@ public class NativeImageTask extends AbstractExecTask<NativeImageTask>
         String imageName = getImageName().get();
         args("-H:Name=" + imageName);
 
+        // to build a "mostly" static native image
+        args("-H:+StaticExecutableWithDynamicLibC");
+
         // Adds boolean flags to the command line
         booleanCmds.forEach((property, cmd) -> {
             if (property.getAsBoolean()) {


### PR DESCRIPTION
This PR enables the generation of [mostly static native images](https://www.graalvm.org/reference-manual/native-image/StaticImages/#build-a-mostly-static-native-image) and switch from an alpine-glibc docker image to a distroless one.

I've tested in CI and everything is working. I've also tested this deploying to AWS Lambda and it also works.