### PR TITLE
Set the right mainClass for apps deployed to AWS

### DIFF
--- a/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -1,9 +1,10 @@
 package io.micronaut.gradle.graalvm;
 
+import io.micronaut.gradle.MicronautApplicationPlugin;
 import io.micronaut.gradle.MicronautExtension;
+import io.micronaut.gradle.MicronautRuntime;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.plugins.BasePlugin;
@@ -11,14 +12,16 @@ import org.gradle.api.plugins.JavaApplication;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.*;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.SourceSetOutput;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Support for building GraalVM native images.
@@ -67,6 +70,10 @@ public class MicronautGraalPlugin implements Plugin<Project> {
         if (project.getPlugins().hasPlugin("application")) {
             TaskContainer tasks = project.getTasks();
             TaskProvider<NativeImageTask> nit = tasks.register("nativeImage", NativeImageTask.class, nativeImageTask -> {
+                MicronautRuntime mr = MicronautApplicationPlugin.resolveRuntime(project);
+                if (mr == MicronautRuntime.LAMBDA) {
+                    nativeImageTask.setMain("io.micronaut.function.aws.runtime.MicronautLambdaRuntime");
+                }
                 nativeImageTask.dependsOn(tasks.findByName("classes"));
                 nativeImageTask.setGroup(BasePlugin.BUILD_GROUP);
                 nativeImageTask.setDescription("Builds a GraalVM Native Image");

--- a/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
@@ -1,11 +1,9 @@
 package io.micronaut.gradle
 
-
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
-import spock.lang.IgnoreIf
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -249,12 +247,12 @@ class Application {
             
             dockerfile {
                 args('-Xmx64m')
-                baseImage('test_base_image')
+                baseImage('test_base_image_jvm')
                 instruction \"\"\"HEALTHCHECK CMD curl -s localhost:8090/health | grep '"status":"UP"'\"\"\"
             }
             dockerfileNative {
                 args('-Xmx64m')
-                baseImage('test_base_image')
+                baseImage('test_base_image_docker')
                 instruction \"\"\"HEALTHCHECK CMD curl -s localhost:8090/health | grep '"status":"UP"'\"\"\"
             }
             
@@ -280,7 +278,7 @@ class Application {
                 .build()
 
         def dockerfileTask = result.task(":dockerfile")
-        def dockerfileNativeTask = result.task(":dockerfile")
+        def dockerfileNativeTask = result.task(":dockerfileNative")
         def dockerFileNative = new File(testProjectDir.root, 'build/docker/DockerfileNative').readLines('UTF-8')
         def dockerFile = new File(testProjectDir.root, 'build/docker/Dockerfile').readLines('UTF-8')
 
@@ -289,12 +287,12 @@ class Application {
         dockerfileNativeTask.outcome == TaskOutcome.SUCCESS
 
         and:
-        dockerFile.first() == ('FROM test_base_image')
+        dockerFile.first() == ('FROM test_base_image_jvm')
         dockerFile.last() == """HEALTHCHECK CMD curl -s localhost:8090/health | grep '"status":"UP"'"""
         dockerFile.find {s -> s.contains('-Xmx64m')}
 
         and:
-        dockerFileNative.find() { s -> s == 'FROM test_base_image' }
+        dockerFileNative.find() { s -> s == 'FROM test_base_image_docker' }
         dockerFileNative.last() == """HEALTHCHECK CMD curl -s localhost:8090/health | grep '"status":"UP"'"""
         dockerFileNative.find {s -> s.contains('-Xmx64m')}
 

--- a/src/test/groovy/io/micronaut/gradle/LambdaNativeImageSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/LambdaNativeImageSpec.groovy
@@ -1,0 +1,114 @@
+package io.micronaut.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class LambdaNativeImageSpec extends Specification {
+
+    @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+
+    File settingsFile
+    File buildFile
+
+    def setup() {
+        settingsFile = testProjectDir.newFile('settings.gradle')
+        buildFile = testProjectDir.newFile('build.gradle')
+    }
+
+    void 'mainclass is set correctly for an application deployed as GraalVM and Lambda'() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.application"
+            }
+            
+            micronaut {
+                version "2.3.0"
+                runtime "netty"
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            application {
+                mainClass.set("com.example.Application")
+            }
+            
+            java {
+                sourceCompatibility = JavaVersion.toVersion('8')
+                targetCompatibility = JavaVersion.toVersion('8')
+            }
+        """
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments('dockerfileNative', '-Pmicronaut.runtime=lambda')
+            .withPluginClasspath()
+            .build()
+
+        def dockerfileNativeTask = result.task(':dockerfileNative')
+        def dockerFileNative = new File(testProjectDir.root, 'build/docker/DockerfileNative').readLines('UTF-8')
+
+        then:
+        dockerfileNativeTask.outcome == TaskOutcome.SUCCESS
+
+        and:
+        dockerFileNative.find() { it.contains('-H:Class=io.micronaut.function.aws.runtime.MicronautLambdaRuntime')}
+        !dockerFileNative.find() { it.contains('com.example.Application')}
+    }
+
+    void 'it is possible to define the mainclass for a dockerfile native'() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.application"
+            }
+            
+            micronaut {
+                version "2.3.0"
+                runtime "netty"
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            application {
+                mainClass.set("com.example.Application")
+            }
+            
+            java {
+                sourceCompatibility = JavaVersion.toVersion('8')
+                targetCompatibility = JavaVersion.toVersion('8')
+            }
+            
+            nativeImage {
+                main("my.own.main.class")
+            }
+        """
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments('dockerfileNative')
+            .withPluginClasspath()
+            .build()
+
+        def dockerfileNativeTask = result.task(':dockerfileNative')
+        def dockerFileNative = new File(testProjectDir.root, 'build/docker/DockerfileNative').readLines('UTF-8')
+
+        then:
+        dockerfileNativeTask.outcome == TaskOutcome.SUCCESS
+
+        and:
+        dockerFileNative.find() { it.contains('my.own.main.class')}
+        !dockerFileNative.find() { it.contains('com.example.Application')}
+    }
+}


### PR DESCRIPTION
Fixes #132

This also fixes the discussion commented here https://github.com/orgs/micronaut-projects/teams/core-developers/discussions/103.

Basically:

`./gradlew nativeImage` sets the main class (`foo.Application`) as entry point for the native image
`./gradlew nativeImage -Pmicronaut.runtime=lambda` sets the main as to `io.micronaut.function.aws.runtime.MicronautLambdaRuntime` so the app can be deployed to AWS Lambda.