### PR TITLE
refactor: delete print statement

### DIFF
--- a/src/main/java/io/micronaut/gradle/graalvm/NativeImageTask.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/NativeImageTask.java
@@ -42,9 +42,6 @@ public class NativeImageTask extends AbstractExecTask<NativeImageTask>
     public NativeImageTask() {
         super(NativeImageTask.class);
         String nativeImageExecutable = findNativeImage("GRAALVM_HOME", "JAVA_HOME");
-        if (!new File(nativeImageExecutable).exists()) {
-            System.out.println("DOESN'T EXIST!! = " + nativeImageExecutable);
-        }
         setExecutable(nativeImageExecutable);
         setWorkingDir(new File(getProject().getBuildDir(), "native-image"));
         ObjectFactory objectFactory = getObjectFactory();


### PR DESCRIPTION
When you execute a gradle task, this is output:

```
 ./gradlew buildNativeLambda

> Configure project :
DOESN'T EXIST!! = native-image
DOESN'T EXIST!! = native-image
```

I don't think we should have this print statement. Or if we want it it should use [Gradle logger](https://docs.gradle.org/current/userguide/logging.html) and it should not appear by default. 
