### PR TITLE
Fix of up-to-date check for dockerBuild task and general improvements 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 // First, apply the publishing plugin
 plugins {
+  id "idea"
   id "com.gradle.plugin-publish" version "0.12.0"
   id "java-gradle-plugin"
   id "maven-publish"
@@ -79,4 +80,9 @@ pluginBundle {
 java {
     sourceCompatibility = JavaVersion.toVersion('1.8')
     targetCompatibility = JavaVersion.toVersion('1.8')
+}
+
+idea.module {
+  downloadJavadoc = true
+  downloadSources = true
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
@@ -1,8 +1,10 @@
 package io.micronaut.gradle.docker;
 
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
+import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaApplication;
@@ -16,7 +18,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class MicronautDockerfile extends Dockerfile implements DockerBuildOptions  {
+public class MicronautDockerfile extends Dockerfile implements DockerBuildOptions {
 
     @Input
     private final Property<String> baseImage;
@@ -43,9 +45,13 @@ public class MicronautDockerfile extends Dockerfile implements DockerBuildOption
         this.exposedPorts = objects.listProperty(Integer.class)
                     .convention(Collections.singletonList(8080));
 
-        doLast(task -> {
-            java.io.File f = getDestFile().get().getAsFile();
-            System.out.println("Dockerfile written to: " + f.getAbsolutePath());
+        //noinspection Convert2Lambda
+        doLast(new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                java.io.File f = MicronautDockerfile.this.getDestFile().get().getAsFile();
+                System.out.println("Dockerfile written to: " + f.getAbsolutePath());
+            }
         });
     }
 

--- a/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -2,6 +2,7 @@ package io.micronaut.gradle.docker;
 
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
 import io.micronaut.gradle.graalvm.NativeImageTask;
+import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -19,7 +20,6 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Specialization of {@link Dockerfile} for building native images.
@@ -75,9 +75,14 @@ public class NativeImageDockerfile extends Dockerfile implements DockerBuildOpti
         this.args = objects.listProperty(String.class);
         this.exposedPorts = objects.listProperty(Integer.class);
         this.defaultCommand = objects.property(String.class).convention("none");
-        doLast(task -> {
-            java.io.File f = getDestFile().get().getAsFile();
-            System.out.println("Dockerfile written to: " + f.getAbsolutePath());
+
+        //noinspection Convert2Lambda
+        doLast(new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                java.io.File f = NativeImageDockerfile.this.getDestFile().get().getAsFile();
+                System.out.println("Dockerfile written to: " + f.getAbsolutePath());
+            }
         });
     }
 

--- a/src/main/java/io/micronaut/gradle/docker/tasks/BuildLayersTask.java
+++ b/src/main/java/io/micronaut/gradle/docker/tasks/BuildLayersTask.java
@@ -1,0 +1,63 @@
+package io.micronaut.gradle.docker.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+
+public class BuildLayersTask extends DefaultTask {
+    private final ConfigurableFileCollection libsLayer;
+    private final ConfigurableFileCollection resourcesLayer;
+    private final ConfigurableFileCollection appLayer;
+    private final DirectoryProperty outputDir;
+
+    @Inject
+    public BuildLayersTask(ObjectFactory objectFactory) {
+        this.libsLayer = objectFactory.fileCollection();
+        this.resourcesLayer = objectFactory.fileCollection();
+        this.appLayer = objectFactory.fileCollection();
+        this.outputDir = objectFactory.directoryProperty();
+        this.outputDir.set(getProject().getLayout().getBuildDirectory().dir("docker/layers"));
+    }
+
+
+    @TaskAction
+    public void action() {
+        // Create folders if case there are no resources/libs in project
+        Provider<RegularFile> libsDir = outputDir.file("libs");
+        getProject().mkdir(libsDir);
+        Provider<RegularFile> resourcesDir = outputDir.file("resources");
+        getProject().mkdir(resourcesDir);
+        getProject().copy(copy -> copy.from(libsLayer).into(libsDir));
+        getProject().copy(copy -> copy.from(appLayer).into(outputDir).rename(s -> "application.jar"));
+        getProject().copy(copy -> copy.from(resourcesLayer).into(resourcesDir));
+    }
+
+
+    @InputFiles
+    public ConfigurableFileCollection getLibsLayer() {
+        return libsLayer;
+    }
+
+    @InputFiles
+    public ConfigurableFileCollection getResourcesLayer() {
+        return resourcesLayer;
+    }
+
+    @InputFiles
+    public ConfigurableFileCollection getAppLayer() {
+        return appLayer;
+    }
+
+    @OutputDirectory
+    public DirectoryProperty getOutputDir() {
+        return outputDir;
+    }
+}

--- a/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
@@ -56,7 +56,7 @@ class BuildLayersSpec extends Specification {
 
         then:
         task.outcome == TaskOutcome.SUCCESS
-        new File(testProjectDir.root, "build-custom/layers").exists()
-        !new File(testProjectDir.root, "build/layers").exists()
+        new File(testProjectDir.root, "build-custom/docker/layers").exists()
+        !new File(testProjectDir.root, "build/docker/layers").exists()
     }
 }


### PR DESCRIPTION
This merge request fixes issue with up-to-date check, which is currently applied only for a third build, because `.docker` folder is created in build directory after the first one, thus changing input for the `dockerBuild`.

Example of log from the second build:
```
Task ':analytics:computation-service:dockerBuild' is not up-to-date because:
  Input property 'inputDir' file /home/ivan/IdeaProjects/computation-service/build/.docker has been added.
  Input property 'inputDir' file /home/ivan/IdeaProjects/computation-service/build/.docker/analytics_computation-service_dockerBuild-imageId.txt has been added.
```

Also, there is a refactoring for `buildLayers` task which clearly defines its' config and makes its' cache key consistent when the `--build-cache` enabled. Thus, with some (tricky) configuration of  `dockerBuild`, it is possible to employ gradle build cache mechanism to skip the `dockerBuild` entirely, which is a great improvement for multi-modules projects.
