### PR TITLE
Create Micronaut GraalVM plugin and generate GraalVM resources file

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,21 @@ dependencies {
 }
 ```
 
+
+## Micronaut GraalVM Plugin
+
+```groovy
+plugins {
+  id "io.micronaut.graalvm" version "{version}"
+}
+```
+
+The [Micronaut graalvm plugin](https://plugins.gradle.org/plugin/io.micronaut.graalvm) is applied automatically by the
+[Micronaut application plugin](https://github.com/micronaut-projects/micronaut-gradle-plugin#micronaut-application-plugin) (see below)
+and it provides tasks to generate a GraalVM native image and also creates the GraalVM `resource-config.json` automatically
+with all the resources from the application.
+
+
 ## Micronaut Application Plugin
 
 ```groovy
@@ -438,7 +453,7 @@ You can add Gradle Shadow plugin so when running `./gradlew assemble` a runnable
 ```groovy
 plugins {
     ...
-    id "com.github.johnrengelman.shadow" version "6.0.0"
+    id "com.github.johnrengelman.shadow" version "7.0.0"
     ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ plugins {
 }
 ```
 
-The [Micronaut graalvm plugin](https://plugins.gradle.org/plugin/io.micronaut.graalvm) is applied automatically by the
+The [Micronaut GraalVM plugin](https://plugins.gradle.org/plugin/io.micronaut.graalvm) is applied automatically by the
 [Micronaut application plugin](https://github.com/micronaut-projects/micronaut-gradle-plugin#micronaut-application-plugin) (see below)
 and it provides tasks to generate a GraalVM native image and also creates the GraalVM `resource-config.json` automatically
 with all the resources from the application.

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ gradlePlugin {
       id = 'io.micronaut.application'
       implementationClass = 'io.micronaut.gradle.MicronautApplicationPlugin'
     }
+    graalPlugin {
+      id = 'io.micronaut.graalvm'
+      implementationClass = 'io.micronaut.gradle.graalvm.MicronautGraalPlugin'
+    }
   }
 }
 configurations {
@@ -81,6 +85,9 @@ pluginBundle {
     }
     applicationPlugin {
       displayName = 'Micronaut Application Plugin'
+    }
+    graalPlugin {
+      displayName = 'Micronaut GraalVM Plugin'
     }
   }
 }

--- a/src/main/java/io/micronaut/gradle/graalvm/GenerateResourceConfigFile.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/GenerateResourceConfigFile.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2003-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle.graalvm;
+
+import com.bmuschko.gradle.docker.shaded.com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.bmuschko.gradle.docker.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import com.bmuschko.gradle.docker.shaded.com.fasterxml.jackson.databind.ObjectWriter;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@CacheableTask
+public abstract class GenerateResourceConfigFile extends DefaultTask {
+
+    private static final String META_INF = "META-INF";
+    private static final String RESOURCES = "resources";
+    private static final String PATTERN = "pattern";
+    private static final String RESOURCE_CONFIG_JSON = "resource-config.json";
+    private static final List<String> EXCLUDED_META_INF_DIRECTORIES = Arrays.asList("native-image", "services");
+
+    public GenerateResourceConfigFile() {
+        getOutputDirectory().convention(
+                getProject().getLayout().getBuildDirectory().dir("generated/resources/graalvm")
+        );
+    }
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getResourceDirectories();
+
+    /**
+     * Configures the list of directories to search for resources, but are typically
+     * unmanaged (because generated) so require more filtering than the application
+     * resources.
+     */
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getMixedContentsDirectories();
+
+    @OutputDirectory
+    public abstract DirectoryProperty getOutputDirectory();
+
+    @TaskAction
+    public void executeTask() {
+        Set<String> resourcesToAdd = new HashSet<>();
+
+        getResourceDirectories()
+                .getFiles()
+                .forEach(resourceDirectory -> resourcesToAdd.addAll(findResourceFiles(resourceDirectory)));
+
+        getMixedContentsDirectories()
+                .getFiles()
+                .forEach(dirtyResourcesDir -> {
+                    Path metaInfPath = Paths.get(dirtyResourcesDir.getAbsolutePath(), META_INF);
+
+                    // Generated resources (like openapi)
+                    resourcesToAdd.addAll(findResourceFiles(metaInfPath.toFile(), Collections.singletonList(META_INF)));
+                });
+
+        List<Map<String, String>> resourceList = resourcesToAdd.stream()
+                .map(GenerateResourceConfigFile::mapToGraalResource)
+                .collect(Collectors.toList());
+
+        generateJsonFile(resourceList);
+    }
+
+    private void generateJsonFile(List<Map<String, String>> resourceList) {
+        try {
+            Path outputDirectory = getOutputDirectory().get().getAsFile().toPath();
+            Files.createDirectories(outputDirectory);
+            File resourceConfigFile = outputDirectory.resolve(RESOURCE_CONFIG_JSON).toFile();
+            System.out.println("Generating " + resourceConfigFile.getAbsolutePath());
+            ObjectWriter writer = new ObjectMapper().writer(new DefaultPrettyPrinter());
+            writer.writeValue(resourceConfigFile, Collections.singletonMap(RESOURCES, resourceList));
+
+        } catch (IOException e) {
+            throw new GradleException("There was an error generating GraalVM resource-config.json file", e);
+        }
+    }
+
+    private static Set<String> findResourceFiles(File folder) {
+        return findResourceFiles(folder, null);
+    }
+
+    private static Set<String> findResourceFiles(File folder, List<String> filePath) {
+        Set<String> resourceFiles = new HashSet<>();
+
+        if (filePath == null) {
+            filePath = new ArrayList<>();
+        }
+
+        if (folder.exists()) {
+            File[] files = folder.listFiles();
+
+            if (files != null) {
+                boolean isMetaInfDirectory = META_INF.equals(folder.getName());
+
+                for (File element : files) {
+                    boolean isExcludedDirectory = EXCLUDED_META_INF_DIRECTORIES.contains(element.getName());
+                    // Exclude some directories in 'META-INF' like 'native-image' and 'services' but process other
+                    // 'META-INF' files and directories, for example, to include swagger-ui.
+                    if (!isMetaInfDirectory || !isExcludedDirectory) {
+                        if (element.isDirectory()) {
+                            List<String> paths = new ArrayList<>(filePath);
+                            paths.add(element.getName());
+
+                            resourceFiles.addAll(findResourceFiles(element, paths));
+                        } else {
+                            String joinedDirectories = String.join("/", filePath);
+                            String elementName = joinedDirectories.isEmpty() ? element.getName() : joinedDirectories + "/" + element.getName();
+
+                            resourceFiles.add(elementName);
+                        }
+                    }
+                }
+            }
+        }
+
+        return resourceFiles;
+    }
+
+    private static Map<String, String> mapToGraalResource(String resourceName) {
+        Map<String, String> result = new HashMap<>();
+
+        if (resourceName.contains("*")) {
+            result.put(PATTERN, resourceName);
+        } else {
+            result.put(PATTERN, "\\Q" + resourceName + "\\E");
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -1,12 +1,19 @@
 package io.micronaut.gradle.graalvm;
 
+import com.bmuschko.gradle.docker.shaded.com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.bmuschko.gradle.docker.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import com.bmuschko.gradle.docker.shaded.com.fasterxml.jackson.databind.ObjectWriter;
+import io.micronaut.gradle.AnnotationProcessing;
 import io.micronaut.gradle.MicronautApplicationPlugin;
 import io.micronaut.gradle.MicronautExtension;
 import io.micronaut.gradle.MicronautRuntime;
+import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.artifacts.*;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencySet;
+import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaApplication;
@@ -17,23 +24,44 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.jvm.tasks.Jar;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Support for building GraalVM native images.
  *
  * @author graemerocher
+ * @author Iván López
  * @since 1.0.0
  */
 public class MicronautGraalPlugin implements Plugin<Project> {
 
     private static final List<String> DEPENDENT_CONFIGURATIONS = Arrays.asList(JavaPlugin.API_CONFIGURATION_NAME, JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME);
+
+    private static final String META_INF = "META-INF";
+    private static final String RESOURCES = "resources";
+    private static final String PATTERN = "pattern";
+    private static final String RESOURCE_CONFIG_JSON = "resource-config.json";
+    private static final List<String> EXCLUDED_META_INF_DIRECTORIES = Arrays.asList("native-image", "services");
+
+    private final ObjectWriter writer = new ObjectMapper().writer(new DefaultPrettyPrinter());
 
     @Override
     public void apply(Project project) {
@@ -90,8 +118,6 @@ public class MicronautGraalPlugin implements Plugin<Project> {
                 nativeImageTask.dependsOn(tasks.findByName("classes"));
                 nativeImageTask.setGroup(BasePlugin.BUILD_GROUP);
                 nativeImageTask.setDescription("Builds a GraalVM Native Image");
-
-
             });
 
             project.afterEvaluate(p -> p
@@ -135,6 +161,58 @@ public class MicronautGraalPlugin implements Plugin<Project> {
                     nativeImageTestTask.setDescription("Runs tests against a native image build of the server. Requires the server to allow the port to configurable with 'micronaut.server.port'.");
             })));
 
+            tasks.withType(AbstractCompile.class, compileTask -> {
+                compileTask.doLast(task -> {
+                    Map<String, Object> json = new HashMap<>();
+
+                    SourceSetContainer sourceSets = project.getConvention()
+                            .getPlugin(JavaPluginConvention.class)
+                            .getSourceSets();
+
+                    SourceSet sourceSet = sourceSets.findByName("main");
+
+                    Set<String> resourcesToAdd = new HashSet<>();
+                    if (sourceSet != null) {
+                        List<Path> resourceDirectories = sourceSet
+                                .getResources()
+                                .getSrcDirs()
+                                .stream()
+                                .map(File::toPath)
+                                .collect(Collectors.toList());
+
+                        // Application resources (src/main/resources)
+                        for (Path resourceDirectory : resourceDirectories) {
+                            resourcesToAdd.addAll(findResourceFiles(resourceDirectory.toFile()));
+                        }
+
+                        for (File classesDir : sourceSet.getOutput().getClassesDirs()) {
+                            Path metaInfPath = Paths.get(classesDir.getAbsolutePath(), META_INF);
+
+                            // Generated resources (like openapi)
+                            resourcesToAdd.addAll(findResourceFiles(metaInfPath.toFile(), Collections.singletonList(META_INF)));
+
+                            Path nativeImagePath = buildNativeImagePath(project);
+                            Path graalVMResourcesPath = metaInfPath.resolve(nativeImagePath).toAbsolutePath();
+
+                            List<Map> resourceList = resourcesToAdd.stream()
+                                    .map(this::mapToGraalResource)
+                                    .collect(Collectors.toList());
+
+                            json.put(RESOURCES, resourceList);
+
+                            try {
+                                Files.createDirectories(graalVMResourcesPath);
+                                File resourceConfigFile = graalVMResourcesPath.resolve(RESOURCE_CONFIG_JSON).toFile();
+                                System.out.println("Generating " + resourceConfigFile.getAbsolutePath());
+                                writer.writeValue(resourceConfigFile, json);
+
+                            } catch (IOException e) {
+                                throw new GradleException("There was an error generating GraalVM resource-config.json file", e);
+                            }
+                        }
+                    }
+                });
+            });
 
             project.afterEvaluate(p -> p.getTasks().withType(NativeImageTask.class, nativeImageTask -> {
                 if (!nativeImageTask.getName().equals("internalDockerNativeImageTask")) {
@@ -152,5 +230,68 @@ public class MicronautGraalPlugin implements Plugin<Project> {
                 }
             }));
         }
+    }
+
+    private Set<String> findResourceFiles(File folder) {
+        return this.findResourceFiles(folder, null);
+    }
+
+    private Set<String> findResourceFiles(File folder, List<String> filePath) {
+        Set<String> resourceFiles = new HashSet<>();
+
+        if (filePath == null) {
+            filePath = new ArrayList<>();
+        }
+
+        if (folder.exists()) {
+            File[] files = folder.listFiles();
+
+            if (files != null) {
+                boolean isMetaInfDirectory = folder.getName().equals(META_INF);
+
+                for (File element : files) {
+                    boolean isExcludedDirectory = EXCLUDED_META_INF_DIRECTORIES.contains(element.getName());
+                    // Exclude some directories in 'META-INF' like 'native-image' and 'services' but process other
+                    // 'META-INF' files and directories, for example, to include swagger-ui.
+                    if (!isMetaInfDirectory || !isExcludedDirectory) {
+                        if (element.isDirectory()) {
+                            List<String> paths = new ArrayList<>(filePath);
+                            paths.add(element.getName());
+
+                            resourceFiles.addAll(findResourceFiles(element, paths));
+                        } else {
+                            String joinedDirectories = String.join("/", filePath);
+                            String elementName = joinedDirectories.isEmpty() ? element.getName() : joinedDirectories + "/" + element.getName();
+
+                            resourceFiles.add(elementName);
+                        }
+                    }
+                }
+            }
+        }
+
+        return resourceFiles;
+    }
+
+    private Path buildNativeImagePath(Project project) {
+        MicronautExtension micronautExtension = project.getExtensions().getByType(MicronautExtension.class);
+        AnnotationProcessing processing = micronautExtension.getProcessing();
+
+        String group = processing.getGroup().getOrElse(project.getGroup().toString());
+        String module = processing.getModule().getOrElse(project.getName());
+
+        return Paths.get("native-image", group, module);
+    }
+
+    private Map mapToGraalResource(String resourceName) {
+        Map<String, String> result = new HashMap<>();
+
+        if (resourceName.contains("*")) {
+            result.put(PATTERN, resourceName);
+        } else {
+            result.put(PATTERN, "\\Q" + resourceName + "\\E");
+        }
+
+        return result;
     }
 }

--- a/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -9,7 +9,6 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaApplication;
@@ -138,13 +137,9 @@ public class MicronautGraalPlugin implements Plugin<Project> {
             })));
 
             TaskProvider<GenerateResourceConfigFile> generateResourceConfig = configureResourcesFileGeneration(project, tasks);
-            tasks.withType(NativeImageTask.class).configureEach(nativeImage -> {
-                // This isn't great. Ideally the configuration file directories should be an input
-                // of the native image task directly, not something we patch
-                DirectoryProperty outputDirectory = generateResourceConfig.get().getOutputDirectory();
-                nativeImage.getInputs().files(generateResourceConfig);
-                nativeImage.args("-H:ConfigurationFileDirectories="+outputDirectory.get().getAsFile().getAbsolutePath());
-            });
+            tasks.withType(NativeImageTask.class).configureEach(nativeImage ->
+                    nativeImage.getConfigDirectories().from(generateResourceConfig)
+            );
 
             project.afterEvaluate(p -> p.getTasks().withType(NativeImageTask.class, nativeImageTask -> {
                 if (!nativeImageTask.getName().equals("internalDockerNativeImageTask")) {

--- a/src/main/java/io/micronaut/gradle/graalvm/internal/ResourceConfigJsonWriter.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/internal/ResourceConfigJsonWriter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2003-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle.graalvm.internal;
+
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A simple, handcrafted "pretty" JSON writer which is <b>only</b> intended
+ * to be used for the resource config file generation. Do not try to use it
+ * for generic JSON writing as it's not designed for this.
+ */
+public class ResourceConfigJsonWriter {
+    public static void generateJsonFile(List<Map<String, String>> resourceList, OutputStream out) {
+        try (PrintWriter prn = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8))) {
+            prn.println("{");
+            prn.println("   \"resources\": [");
+            boolean comma = false;
+            for (Map<String, String> entries : resourceList) {
+                if (comma) {
+                    prn.println(", ");
+                }
+                comma = true;
+                prn.print("        { ");
+                writeKeyValuePairs(prn, entries);
+                prn.print(" }");
+            }
+            prn.println();
+            prn.println("   ]");
+            prn.println("}");
+        }
+    }
+
+    private static void writeKeyValuePairs(PrintWriter prn, Map<String, String> entries) {
+        boolean comma = false;
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            if (comma) {
+                prn.print(", ");
+            }
+            String key = escape(entry.getKey());
+            String value = escape(entry.getValue());
+            prn.print("\"" + key + "\": \"" + value + "\"");
+            comma = true;
+        }
+    }
+
+    private static String escape(String value) {
+        return value.replace("\\", "\\\\")
+                .replaceAll("\"", "\\\\\"");
+    }
+}

--- a/src/test/groovy/io/micronaut/gradle/MicronautGraalPluginSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/MicronautGraalPluginSpec.groovy
@@ -63,16 +63,16 @@ class Application {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir.root)
-            .withArguments('classes', '-i', '--stacktrace')
+            .withArguments('generateResourceConfigFile', '-i', '--stacktrace')
             .withPluginClasspath()
             .build()
 
         then:
-        def task = result.task(":classes")
-        task.outcome == TaskOutcome.SUCCESS
+        result.task(":classes").outcome == TaskOutcome.SUCCESS
+        result.task(":generateResourceConfigFile").outcome == TaskOutcome.SUCCESS
 
         and:
-        def resourceConfigFile = new File(testProjectDir.root, 'build/classes/java/main/META-INF/native-image/example.micronaut/hello-world/resource-config.json')
+        def resourceConfigFile = new File(testProjectDir.root, 'build/generated/resources/graalvm/resource-config.json')
         def resourceConfigJson = new JsonSlurper().parse(resourceConfigFile)
 
         resourceConfigJson.resources.pattern.any { it == "\\Qapplication.yml\\E" }

--- a/src/test/groovy/io/micronaut/gradle/MicronautGraalPluginSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/MicronautGraalPluginSpec.groovy
@@ -1,0 +1,82 @@
+package io.micronaut.gradle
+
+import groovy.json.JsonSlurper
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class MicronautGraalPluginSpec extends Specification {
+
+    @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+
+    File settingsFile
+    File buildFile
+
+    def setup() {
+        settingsFile = testProjectDir.newFile('settings.gradle')
+        buildFile = testProjectDir.newFile('build.gradle')
+    }
+
+    void 'generate GraalVM resource-config.json with OpenAPI and resources included'() {
+        given:
+        testProjectDir.newFile('openapi.properties') << 'swagger-ui.enabled=true'
+        testProjectDir.newFolder('src', 'main', 'resources')
+        testProjectDir.newFile('src/main/resources/application.yml') << 'micronaut.application.name: hello-world'
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.application"
+                id "io.micronaut.graalvm"
+            }
+            dependencies {
+                annotationProcessor("io.micronaut.openapi:micronaut-openapi")
+                implementation("io.swagger.core.v3:swagger-annotations")
+            }
+            micronaut {
+                version "2.5.4"
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = "example.micronaut"
+            mainClassName="example.Application"
+        """
+        testProjectDir.newFolder("src", "main", "java", "example")
+        def javaFile = testProjectDir.newFile("src/main/java/example/Application.java")
+        javaFile.parentFile.mkdirs()
+        javaFile << """
+package example;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+
+@OpenAPIDefinition(info = @Info(title = "app", version = "0.0"))
+@io.micronaut.core.annotation.Introspected
+class Application {
+    public static void main(String... args) {
+    }
+}
+"""
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments('classes', '-i', '--stacktrace')
+            .withPluginClasspath()
+            .build()
+
+        then:
+        def task = result.task(":classes")
+        task.outcome == TaskOutcome.SUCCESS
+
+        and:
+        def resourceConfigFile = new File(testProjectDir.root, 'build/classes/java/main/META-INF/native-image/example.micronaut/hello-world/resource-config.json')
+        def resourceConfigJson = new JsonSlurper().parse(resourceConfigFile)
+
+        resourceConfigJson.resources.pattern.any { it == "\\Qapplication.yml\\E" }
+        resourceConfigJson.resources.pattern.any { it == "\\QMETA-INF/swagger/app-0.0.yml\\E" }
+        resourceConfigJson.resources.pattern.any { it == "\\QMETA-INF/swagger/views/swagger-ui/index.html\\E" }
+    }
+}

--- a/src/test/groovy/io/micronaut/gradle/MicronautGraalPluginSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/MicronautGraalPluginSpec.groovy
@@ -1,10 +1,12 @@
 package io.micronaut.gradle
 
 import groovy.json.JsonSlurper
+import io.micronaut.gradle.graalvm.GraalUtil
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import spock.lang.Requires
 import spock.lang.Specification
 
 class MicronautGraalPluginSpec extends Specification {
@@ -21,6 +23,50 @@ class MicronautGraalPluginSpec extends Specification {
 
     void 'generate GraalVM resource-config.json with OpenAPI and resources included'() {
         given:
+        withSwaggerApplication()
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments('generateResourceConfigFile', '-i', '--stacktrace')
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":classes").outcome == TaskOutcome.SUCCESS
+        result.task(":generateResourceConfigFile").outcome == TaskOutcome.SUCCESS
+
+        and:
+        def resourceConfigFile = new File(testProjectDir.root, 'build/generated/resources/graalvm/resource-config.json')
+        def resourceConfigJson = new JsonSlurper().parse(resourceConfigFile)
+
+        resourceConfigJson.resources.pattern.any { it == "\\Qapplication.yml\\E" }
+        resourceConfigJson.resources.pattern.any { it == "\\QMETA-INF/swagger/app-0.0.yml\\E" }
+        resourceConfigJson.resources.pattern.any { it == "\\QMETA-INF/swagger/views/swagger-ui/index.html\\E" }
+    }
+
+    @Requires({ GraalUtil.isGraalJVM() && !os.windows })
+    void 'native-image is called with the generated JSON file directory'() {
+        given:
+        withSwaggerApplication()
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('nativeImage', '-i', '--stacktrace')
+                .withPluginClasspath()
+                .build()
+
+        then:
+        result.task(":classes").outcome == TaskOutcome.SUCCESS
+        result.task(":generateResourceConfigFile").outcome == TaskOutcome.SUCCESS
+        result.task(":nativeImage").outcome == TaskOutcome.SUCCESS
+
+        and:
+        result.output.contains("-H:ConfigurationFileDirectories=${new File(testProjectDir.root, 'build/generated/resources/graalvm').absolutePath}")
+    }
+
+    private void withSwaggerApplication() {
         testProjectDir.newFile('openapi.properties') << 'swagger-ui.enabled=true'
         testProjectDir.newFolder('src', 'main', 'resources')
         testProjectDir.newFile('src/main/resources/application.yml') << 'micronaut.application.name: hello-world'
@@ -59,24 +105,5 @@ class Application {
     }
 }
 """
-
-        when:
-        def result = GradleRunner.create()
-            .withProjectDir(testProjectDir.root)
-            .withArguments('generateResourceConfigFile', '-i', '--stacktrace')
-            .withPluginClasspath()
-            .build()
-
-        then:
-        result.task(":classes").outcome == TaskOutcome.SUCCESS
-        result.task(":generateResourceConfigFile").outcome == TaskOutcome.SUCCESS
-
-        and:
-        def resourceConfigFile = new File(testProjectDir.root, 'build/generated/resources/graalvm/resource-config.json')
-        def resourceConfigJson = new JsonSlurper().parse(resourceConfigFile)
-
-        resourceConfigJson.resources.pattern.any { it == "\\Qapplication.yml\\E" }
-        resourceConfigJson.resources.pattern.any { it == "\\QMETA-INF/swagger/app-0.0.yml\\E" }
-        resourceConfigJson.resources.pattern.any { it == "\\QMETA-INF/swagger/views/swagger-ui/index.html\\E" }
     }
 }

--- a/src/test/groovy/io/micronaut/gradle/graalvm/internal/ResourceConfigJsonWriterTest.groovy
+++ b/src/test/groovy/io/micronaut/gradle/graalvm/internal/ResourceConfigJsonWriterTest.groovy
@@ -1,0 +1,107 @@
+package io.micronaut.gradle.graalvm.internal
+
+
+import spock.lang.Specification
+
+class ResourceConfigJsonWriterTest extends Specification {
+    private String actual
+
+    def "can generates resource file with a single value"() {
+        when:
+        generate 'hello'
+
+        then:
+        hasOutput """{
+   "resources": [
+        { "resource": "hello" }
+   ]
+}"""
+    }
+
+    def "escapes double quotes"() {
+        when:
+        generate 'value "under quotes" is supported'
+
+        then:
+        hasOutput '''{
+   "resources": [
+        { "resource": "value \\"under quotes\\" is supported" }
+   ]
+}'''
+    }
+
+    def "escapes backslash"() {
+        when:
+        generate 'value with \\ backslash'
+
+        then:
+        hasOutput """{
+   "resources": [
+        { "resource": "value with \\\\ backslash" }
+   ]
+}"""
+    }
+
+    def "can generate multiple entries in map"() {
+        when:
+        generateListOfKeyValuePairs([
+                [one: 'first'],
+                [two: 'second', more: 'extra']
+        ])
+
+        then:
+        hasOutput """{
+   "resources": [
+        { "one": "first" }, 
+        { "two": "second", "more": "extra" }
+   ]
+}"""
+    }
+
+    def "supports same keys in maps"() {
+        when:
+        generateListOfKeyValuePairs([
+                [pattern: '*'],
+                [pattern: 'hello'],
+                [pattern: '\\Qworld\\E']
+        ])
+
+        then:
+        hasOutput """{
+   "resources": [
+        { "pattern": "*" }, 
+        { "pattern": "hello" }, 
+        { "pattern": "\\\\Qworld\\\\E" }
+   ]
+}"""
+    }
+
+    private void generate(String value) {
+        generateKeyValue('resource', value)
+    }
+
+    private void generateKeyValue(String key, String value) {
+        generateKeyValuePairs([(key): (value)])
+    }
+
+    private void generateKeyValuePairs(Map<String, String> pairs) {
+        generateListOfKeyValuePairs([pairs])
+    }
+
+    private void generateListOfKeyValuePairs(List<Map<String, String>> list) {
+        def baos = new ByteArrayOutputStream()
+        ResourceConfigJsonWriter.generateJsonFile(
+                list, baos
+        )
+        actual = normalizeForComparison(baos.toString("UTF-8"))
+    }
+
+    private static String normalizeForComparison(String src) {
+        src.replaceAll('\r', '').trim()
+    }
+
+    private void hasOutput(String expected) {
+        def normalizedExpected = normalizeForComparison(expected)
+        assert actual == normalizedExpected
+    }
+}


### PR DESCRIPTION
This PR creates a new MicronautGraalVM plugin (that is automatically applied by Micronaut Application plugin) that generates GraalVM `resource-config.json` automatically.

After this and the same [PR for the Maven plugin](https://github.com/micronaut-projects/micronaut-maven-plugin/pull/184) are merged, we can remove the code that does this from GraalvmTypeElementVisitor in core (for Micronaut 3.0.x)