### PR TITLE
Set java.library path for the native image.

### DIFF
--- a/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -241,6 +241,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
                     List<String> newList = new ArrayList<>(strings.size() + 1);
                     newList.add("./func");
                     newList.addAll(strings);
+                    newList.add("-Djava.library.path=/function");
                     return newList;
                 }));
                 String cmd = this.defaultCommand.get();


### PR DESCRIPTION
A change occurred in GraalVM 21.1 whereby native libraries are no longer loaded from the current directly and explicitly setting java.library.path for any JNI libraries is now required.