### PR TITLE
2 variants of adding dedicated group and user

### DIFF
--- a/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
@@ -88,7 +88,8 @@ public class MicronautDockerfile extends Dockerfile implements DockerBuildOption
             default:
                 from(new Dockerfile.From(from != null ? from : "openjdk:16-alpine"));
                 setupResources(this);
-                runCommand("addgroup app && adduser -G app app -D && chown -R app:app /home/app");
+                runCommand("test -e /usr/sbin/groupadd && groupadd -r app && adduser -g app app && chown -R app:app /home/app || true");
+                runCommand("test -e /usr/sbin/addgroup && addgroup app && adduser -G app app -D && chown -R app:app /home/app || true");
                 exposePort(exposedPorts);
                 entryPoint(getArgs().map(strings -> {
                     List<String> newList = new ArrayList<>(strings.size() + 3);

--- a/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
@@ -488,6 +488,7 @@ class Application {
 
         and:
         def dockerfile = new File(testProjectDir.root, 'build/docker/Dockerfile').readLines('UTF-8')
-        dockerfile.find { it.contains('addgroup app && adduser -G app app -D && chown -R app:app /home/app') }
+        dockerfile.find { it.contains('test -e /usr/sbin/groupadd && groupadd -r app && adduser -g app app && chown -R app:app /home/app || true') }
+        dockerfile.find { it.contains('test -e /usr/sbin/addgroup && addgroup app && adduser -G app app -D && chown -R app:app /home/app || true') }
     }
 }


### PR DESCRIPTION
Referenced issue: #161

This PR adds support for base images that have either groupadd or addgroup. It check which one is available and based on that triggers command. Also, when specific group manipulation command is available, useradd has different syntax, so this is also reflected.

Tested with openjdk:16-alpine and oraclelinux:7
