### PR TITLE
Generate the GraalVM resource file even without the Micronaut application plugin

### DIFF
--- a/src/main/java/io/micronaut/gradle/MicronautApplicationPlugin.java
+++ b/src/main/java/io/micronaut/gradle/MicronautApplicationPlugin.java
@@ -1,7 +1,6 @@
 package io.micronaut.gradle;
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin;
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar;
 import io.micronaut.gradle.docker.MicronautDockerPlugin;
 import io.micronaut.gradle.graalvm.GraalUtil;
 import org.apache.tools.ant.taskdefs.condition.Os;
@@ -9,14 +8,23 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
-import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.file.SourceDirectorySet;
-import org.gradle.api.plugins.*;
+import org.gradle.api.plugins.JavaApplication;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.*;
+import org.gradle.api.tasks.JavaExec;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.SourceSetOutput;
+import org.gradle.api.tasks.TaskContainer;
 
 import java.io.File;
-import java.util.*;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -177,12 +185,14 @@ public class MicronautApplicationPlugin extends MicronautLibraryPlugin {
     }
 
     public static MicronautRuntime resolveRuntime(Project p) {
-        MicronautExtension ext = p.getExtensions().getByType(MicronautExtension.class);
+        MicronautExtension ext = p.getExtensions().findByType(MicronautExtension.class);
         Object o = p.findProperty("micronaut.runtime");
 
         MicronautRuntime micronautRuntime;
         if (o != null) {
             micronautRuntime = MicronautRuntime.valueOf(o.toString().toUpperCase(Locale.ENGLISH));
+        } else if (ext == null) {
+            micronautRuntime = MicronautRuntime.NONE;
         } else {
             micronautRuntime = ext.getRuntime().getOrElse(MicronautRuntime.NONE);
         }

--- a/src/test/groovy/io/micronaut/gradle/MicronautGraalPluginSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/MicronautGraalPluginSpec.groovy
@@ -23,6 +23,30 @@ class MicronautGraalPluginSpec extends Specification {
 
     void 'generate GraalVM resource-config.json with OpenAPI and resources included'() {
         given:
+        withSwaggerMicronautApplication()
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments('generateResourceConfigFile', '-i', '--stacktrace')
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":classes").outcome == TaskOutcome.SUCCESS
+        result.task(":generateResourceConfigFile").outcome == TaskOutcome.SUCCESS
+
+        and:
+        def resourceConfigFile = new File(testProjectDir.root, 'build/generated/resources/graalvm/resource-config.json')
+        def resourceConfigJson = new JsonSlurper().parse(resourceConfigFile)
+
+        resourceConfigJson.resources.pattern.any { it == "\\Qapplication.yml\\E" }
+        resourceConfigJson.resources.pattern.any { it == "\\QMETA-INF/swagger/app-0.0.yml\\E" }
+        resourceConfigJson.resources.pattern.any { it == "\\QMETA-INF/swagger/views/swagger-ui/index.html\\E" }
+    }
+
+    void 'generate GraalVM resource-config.json with OpenAPI and resources included without the Micronaut Application plugin'() {
+        given:
         withSwaggerApplication()
 
         when:
@@ -46,7 +70,28 @@ class MicronautGraalPluginSpec extends Specification {
     }
 
     @Requires({ GraalUtil.isGraalJVM() && !os.windows })
-    void 'native-image is called with the generated JSON file directory'() {
+    void 'native-image is called with the generated JSON file directory (Micronaut Application)'() {
+        given:
+        withSwaggerMicronautApplication()
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('nativeImage', '-i', '--stacktrace')
+                .withPluginClasspath()
+                .build()
+
+        then:
+        result.task(":classes").outcome == TaskOutcome.SUCCESS
+        result.task(":generateResourceConfigFile").outcome == TaskOutcome.SUCCESS
+        result.task(":nativeImage").outcome == TaskOutcome.SUCCESS
+
+        and:
+        result.output.contains("-H:ConfigurationFileDirectories=${new File(testProjectDir.root, 'build/generated/resources/graalvm').absolutePath}")
+    }
+
+    @Requires({ GraalUtil.isGraalJVM() && !os.windows })
+    void 'native-image is called with the generated JSON file directory (regular Application)'() {
         given:
         withSwaggerApplication()
 
@@ -66,7 +111,7 @@ class MicronautGraalPluginSpec extends Specification {
         result.output.contains("-H:ConfigurationFileDirectories=${new File(testProjectDir.root, 'build/generated/resources/graalvm').absolutePath}")
     }
 
-    private void withSwaggerApplication() {
+    private void withSwaggerMicronautApplication() {
         testProjectDir.newFile('openapi.properties') << 'swagger-ui.enabled=true'
         testProjectDir.newFolder('src', 'main', 'resources')
         testProjectDir.newFile('src/main/resources/application.yml') << 'micronaut.application.name: hello-world'
@@ -83,6 +128,51 @@ class MicronautGraalPluginSpec extends Specification {
             micronaut {
                 version "2.5.4"
             }
+            repositories {
+                mavenCentral()
+            }
+            group = "example.micronaut"
+            mainClassName="example.Application"
+        """
+        testProjectDir.newFolder("src", "main", "java", "example")
+        def javaFile = testProjectDir.newFile("src/main/java/example/Application.java")
+        javaFile.parentFile.mkdirs()
+        javaFile << """
+package example;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+
+@OpenAPIDefinition(info = @Info(title = "app", version = "0.0"))
+@io.micronaut.core.annotation.Introspected
+class Application {
+    public static void main(String... args) {
+    }
+}
+"""
+    }
+
+    private void withSwaggerApplication() {
+        testProjectDir.newFile('openapi.properties') << 'swagger-ui.enabled=true'
+        testProjectDir.newFolder('src', 'main', 'resources')
+        testProjectDir.newFile('src/main/resources/application.yml') << 'micronaut.application.name: hello-world'
+        settingsFile << "rootProject.name = 'hello-world'"
+        String micronautVersion = '2.5.0'
+        buildFile << """
+            plugins {
+                id "application"
+                id "io.micronaut.graalvm"
+            }
+            dependencies {
+                annotationProcessor(enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion"))
+                annotationProcessor("io.micronaut:micronaut-inject-java")
+                annotationProcessor("io.micronaut.openapi:micronaut-openapi")
+                
+                implementation(enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion"))
+                implementation("io.micronaut:micronaut-inject")
+                implementation("io.swagger.core.v3:swagger-annotations")
+            }
+            
             repositories {
                 mavenCentral()
             }


### PR DESCRIPTION
This commit adds support for generating the GraalVM resource-config.json file
even if the Micronaut Application plugin isn't applied (e.g if the application
plugin is).

This basically adds some null checks on extensions, but ideally the plugin should
react to different plugins being applied, and in particular the Micronaut
application plugin.

Fixes #223