### PR TITLE
Fix detection of GraalVM in IntelliJ IDEA

### DIFF
--- a/src/main/java/io/micronaut/gradle/graalvm/GraalUtil.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/GraalUtil.java
@@ -11,7 +11,7 @@ public final class GraalUtil {
      * @return Return whether the JVM in use a GraalVM JVM.
      */
     public static boolean isGraalJVM() {
-        return isGraal("jvmci.Compiler", "java.vendor.version");
+        return isGraal("jvmci.Compiler", "java.vendor.version", "java.vendor");
     }
 
     private static boolean isGraal(String... props) {


### PR DESCRIPTION
In IntelliJ IDEA, the `java.vendor.version` property is inherited from IDEA's JDK, so `nativeImage` task is reporting this error message:

```
A GraalVM SDK is required to build native images
```

The `java.vendor` property is working well with value: "GraalVM Community"

See related issues here:
- https://youtrack.jetbrains.com/issue/IDEA-271768
- https://youtrack.jetbrains.com/issue/IDEA-268520