### PR TITLE
Resolve #237 - Unable to use custom entrypoint in generated Dockerfile

### DIFF
--- a/src/main/java/io/micronaut/gradle/docker/DockerBuildOptions.java
+++ b/src/main/java/io/micronaut/gradle/docker/DockerBuildOptions.java
@@ -4,6 +4,8 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 
+import javax.annotation.Nullable;
+
 /**
  * Build options for Docker.
  *
@@ -36,12 +38,6 @@ public interface DockerBuildOptions {
     ListProperty<Integer> getExposedPorts();
 
     /**
-     * @return The entry point command to run
-     */
-    @Input
-    ListProperty<String> getCustomEntrypoint();
-
-    /**
      * Arguments for the entrypoint.
      * @param args The arguments
      * @return This
@@ -60,10 +56,4 @@ public interface DockerBuildOptions {
      * @return The ports
      */
     DockerBuildOptions exportPorts(Integer... ports);
-
-    /**
-     * @param customEntrypoint The entry point command to run
-     * @return This
-     */
-    DockerBuildOptions customEntrypoint(String... customEntrypoint);
 }

--- a/src/main/java/io/micronaut/gradle/docker/DockerBuildOptions.java
+++ b/src/main/java/io/micronaut/gradle/docker/DockerBuildOptions.java
@@ -4,8 +4,6 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 
-import javax.annotation.Nullable;
-
 /**
  * Build options for Docker.
  *
@@ -38,6 +36,12 @@ public interface DockerBuildOptions {
     ListProperty<Integer> getExposedPorts();
 
     /**
+     * @return The entry point command to run
+     */
+    @Input
+    ListProperty<String> getCustomEntrypoint();
+
+    /**
      * Arguments for the entrypoint.
      * @param args The arguments
      * @return This
@@ -56,4 +60,10 @@ public interface DockerBuildOptions {
      * @return The ports
      */
     DockerBuildOptions exportPorts(Integer... ports);
+
+    /**
+     * @param customEntrypoint The entry point command to run
+     * @return This
+     */
+    DockerBuildOptions customEntrypoint(String... customEntrypoint);
 }

--- a/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
@@ -30,8 +30,7 @@ public class MicronautDockerfile extends Dockerfile implements DockerBuildOption
     private final Property<DockerBuildStrategy> buildStrategy;
     @Input
     private final Property<String> defaultCommand;
-    @Input
-    private final ListProperty<String> customEntrypoint;
+
 
     public MicronautDockerfile() {
         Project project = getProject();
@@ -45,8 +44,6 @@ public class MicronautDockerfile extends Dockerfile implements DockerBuildOption
         this.args = objects.listProperty(String.class);
         this.exposedPorts = objects.listProperty(Integer.class)
                     .convention(Collections.singletonList(8080));
-        this.customEntrypoint = objects.listProperty(String.class)
-                    .convention(Collections.emptyList());
 
         //noinspection Convert2Lambda
         doLast(new Action<Task>() {
@@ -93,9 +90,7 @@ public class MicronautDockerfile extends Dockerfile implements DockerBuildOption
                 setupResources(this);
                 exposePort(exposedPorts);
                 getInstructions().addAll(additionalInstructions);
-                if (getCustomEntrypoint().get().size() > 0) {
-                    entryPoint(getCustomEntrypoint());
-                } else {
+                if (getInstructions().get().stream().noneMatch(instruction -> instruction.getKeyword().equals(EntryPointInstruction.KEYWORD))) {
                     entryPoint(getArgs().map(strings -> {
                         List<String> newList = new ArrayList<>(strings.size() + 3);
                         newList.add("java");
@@ -151,11 +146,6 @@ public class MicronautDockerfile extends Dockerfile implements DockerBuildOption
     }
 
     @Override
-    public ListProperty<String> getCustomEntrypoint() {
-        return customEntrypoint;
-    }
-
-    @Override
     public DockerBuildOptions args(String... args) {
         this.args.addAll(args);
         return this;
@@ -172,12 +162,6 @@ public class MicronautDockerfile extends Dockerfile implements DockerBuildOption
     @Override
     public DockerBuildOptions exportPorts(Integer... ports) {
         this.exposedPorts.set(Arrays.asList(ports));
-        return this;
-    }
-
-    @Override
-    public DockerBuildOptions customEntrypoint(String... customEntrypoint) {
-        this.customEntrypoint.addAll(Arrays.asList(customEntrypoint));
         return this;
     }
 

--- a/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
@@ -331,13 +331,13 @@ class Application {
                 args('-Xmx64m')
                 baseImage('test_base_image_jvm')
                 instruction \"\"\"HEALTHCHECK CMD curl -s localhost:8090/health | grep '"status":"UP"'\"\"\"
-                customEntrypoint = ["./entrypoint.sh"]
+                entryPoint('./entrypoint.sh')
             }
             dockerfileNative {
                 args('-Xmx64m')
                 baseImage('test_base_image_docker')
                 instruction \"\"\"HEALTHCHECK CMD curl -s localhost:8090/health | grep '"status":"UP"'\"\"\"
-                customEntrypoint = ["./entrypoint.sh"]
+                entryPoint('./entrypoint.sh')
             }
             
             mainClassName="example.Application"
@@ -373,12 +373,12 @@ class Application {
         and:
         dockerFile.first() == ('FROM test_base_image_jvm')
         dockerFile.find { s -> s == """HEALTHCHECK CMD curl -s localhost:8090/health | grep '"status":"UP"'""" }
-        dockerFile.last().contains('ENTRYPOINT ["./entrypoint.sh"]')
+        dockerFile.find { s -> s == 'ENTRYPOINT ["./entrypoint.sh"]'}
 
         and:
         dockerFileNative.find() { s -> s == 'FROM test_base_image_docker' }
         dockerFileNative.find { s -> s == """HEALTHCHECK CMD curl -s localhost:8090/health | grep '"status":"UP"'""" }
-        dockerFileNative.last().contains('ENTRYPOINT ["./entrypoint.sh"]')
+        dockerFileNative.find { s -> s == 'ENTRYPOINT ["./entrypoint.sh"]'}
     }
 
     @Unroll


### PR DESCRIPTION
This solves #237  - Unable to use custom entrypoint in generated Dockerfile.

By specifying a `customEntrypoint` parameter to dockerfile or nativedockerfile closures the generated entrypoint will be overwritten completely by what is passed in versus concatenating multiple lists.