### PR TITLE
Fix for incorrect paths in docker image file

### DIFF
--- a/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
+++ b/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
@@ -10,6 +10,7 @@ import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
 import io.micronaut.gradle.MicronautApplicationPlugin;
 import io.micronaut.gradle.MicronautRuntime;
 import io.micronaut.gradle.docker.tasks.BuildLayersTask;
+import io.micronaut.gradle.graalvm.GenerateResourceConfigFile;
 import io.micronaut.gradle.graalvm.NativeImageTask;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
@@ -90,6 +91,8 @@ public class MicronautDockerPlugin implements Plugin<Project> {
                     .getByName(RUNTIME_CLASSPATH_CONFIGURATION_NAME));
             task.getResourcesLayer().from(project.getExtensions().getByType(SourceSetContainer.class)
                     .getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput().getResourcesDir());
+            // workaround for #246
+            task.getResourcesLayer().from(tasks.withType(GenerateResourceConfigFile.class));
             task.getAppLayer().from(runnerJar);
         });
 


### PR DESCRIPTION
The generate docker image file contained paths to files on the host
instead of paths in the image builder. The consequence is that
resources files, and in particular `application.yml` file were
totally ignored.

This is a hotfix for this issue, but this is NOT a final fix: this
is a very dirty hack, which is going to be removed once we migrate
to the official GraalVM plugin.

Fixes #246
Fixes #243