### PR TITLE
Fix incremental builds with dockerBuild

### DIFF
--- a/src/main/java/io/micronaut/gradle/docker/tasks/BuildLayersTask.java
+++ b/src/main/java/io/micronaut/gradle/docker/tasks/BuildLayersTask.java
@@ -30,6 +30,7 @@ public class BuildLayersTask extends DefaultTask {
 
     @TaskAction
     public void action() {
+        getProject().delete(getProject().files(outputDir));
         // Create folders if case there are no resources/libs in project
         Provider<RegularFile> libsDir = outputDir.file("libs");
         getProject().mkdir(libsDir);


### PR DESCRIPTION
At the moment outputs of the `BuildLayersTask` are not cleared, what can lead to an incorrect build in the following scenario:

- Invoke `dockerBuild` on branch `main` with files `src/main/resources/res1.xml` and `src/main/resources/res2.xml`. The following files will be created by `BuildLayersTask` and will be present in the resulting image:  `build/docker/layers/resources/res1.xml `and `build/docker/layers/resources/res2.xml` 
- Switch to branch with only `src/main/resources/res1.xml` present 
- Invoke `dockerBuild` again

Resulting image will contain both `res1.xml` and `res2.xml`, since the outputs weren't cleared up.
Gradle's `org.gradle.language.jvm.tasks.ProcessResources` follows the similar clean up logic.

@graemerocher @melix, could it be reviewed and merged ASAP, as it hinders incremental builds?