### PR TITLE
Fix building native images on Java 8

### DIFF
--- a/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -72,12 +72,13 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
         } else if (javaVersion.isJava11Compatible()) {
             jdkVersion.convention("java11");
         } else {
-            jdkVersion.convention("java8");
+            getLogger().warn("Current Java version is Java 8 but it's unsupported by native-image. Falling back to Java 11 to build a native image.");
+            jdkVersion.convention("java11");
         }
         this.graalVersion = objects.property(String.class)
                 .convention("21.3.0");
         this.graalImage = objects.property(String.class)
-                .convention(graalVersion.map(version -> "ghcr.io/graalvm/graalvm-ce:" + jdkVersion.get() + '-' + version));
+                .convention(graalVersion.map(version -> "ghcr.io/graalvm/native-image:" + jdkVersion.get() + '-' + version));
         this.baseImage = objects.property(String.class)
                 .convention("null");
         this.args = objects.listProperty(String.class);
@@ -196,7 +197,6 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
             from(new From("graalvm").withStage("builder"));
         } else {
             from(new From(graalImage.get()).withStage("graalvm"));
-            runCommand("gu install native-image");
         }
         MicronautDockerfile.setupResources(this);
         // use native-image from docker image

--- a/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
@@ -156,9 +156,9 @@ micronaut:
 
         where:
         runtime  | nativeImage
-        "netty"  | 'FROM ghcr.io/graalvm/graalvm-ce:java'
+        "netty"  | 'FROM ghcr.io/graalvm/native-image:java'
         "lambda" | 'FROM amazonlinux:latest AS graalvm'
-        "jetty"  | 'FROM ghcr.io/graalvm/graalvm-ce:java'
+        "jetty"  | 'FROM ghcr.io/graalvm/native-image:java'
     }
 
     def "test build docker native image for lambda with custom main"() {
@@ -297,9 +297,9 @@ class Application {
 
         where:
         runtime  | nativeImage
-        "netty"  | 'FROM ghcr.io/graalvm/graalvm-ce:java'
+        "netty"  | 'FROM ghcr.io/graalvm/native-image:java'
         "lambda" | 'FROM amazonlinux:latest AS graalvm'
-        "jetty"  | 'FROM ghcr.io/graalvm/graalvm-ce:java'
+        "jetty"  | 'FROM ghcr.io/graalvm/native-image:java'
     }
 
     def "test construct dockerfile and dockerfileNative custom entrypoint"() {


### PR DESCRIPTION
This is a hotfix which makes sure that the application is built
minimally with Java 11 when building a native image in docker,
since the native image doesn't support Java 8 anymore.

Fixes #275