### PR TITLE
Margin bottom copy to clipboard

### DIFF
--- a/src/docs/asciidoc/css/guide.css
+++ b/src/docs/asciidoc/css/guide.css
@@ -6,7 +6,9 @@
     padding: 10px 15px;
     font-size: 10px;
     margin-right: 20px;
+    margin-top: -16px;
     display: block;
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;
 }
+

--- a/src/docs/asciidoc/css/multi-lang-sample.css
+++ b/src/docs/asciidoc/css/multi-lang-sample.css
@@ -147,17 +147,3 @@
     border-radius: 0 0 4px 4px;
     margin-bottom: 30px;
 }
-
-.copytoclipboard {
-    font-family: "Open Sans";
-    cursor: pointer;
-    background-color: lightgray;
-    color: #000000;
-    float: right;
-    padding: 10px 15px;
-    font-size: 10px;
-    margin-right: 0px;
-    display: block;
-    border-bottom-left-radius: 5px;
-    border-bottom-right-radius: 5px;
-}


### PR DESCRIPTION
Removes the gap between code sample and `Copy to Clipboard` button.

<img width="896" alt="Screenshot 2021-11-01 at 07 56 20" src="https://user-images.githubusercontent.com/864788/139633733-4f51f84f-5471-4341-b381-77e0ed2c3288.png">

<img width="880" alt="Screenshot 2021-11-01 at 07 56 45" src="https://user-images.githubusercontent.com/864788/139633749-733d3926-2516-40bf-92da-e41e4b2131d3.png">

It also removes duplicated CSS snippet.

