### PR TITLE
remove list style type from table of contents

### DIFF
--- a/src/docs/asciidoc/css/guide.css
+++ b/src/docs/asciidoc/css/guide.css
@@ -10,3 +10,17 @@
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;
 }
+
+.toc ul {
+    list-style-type: none;
+    padding-left: 0;
+}
+.toc ul li {
+    margin-top: 5px;
+    padding-left: 0;
+    margin-bottom: 5px;
+}
+
+.toc ul li li {
+    padding-left: 25px;
+}


### PR DESCRIPTION
Remove the list style type and margin from the table of contents 

Before: 

<img width="1204" alt="Screenshot 2021-11-01 at 08 34 51" src="https://user-images.githubusercontent.com/864788/139637720-b750edd1-87e7-40e6-a69c-fe43ed391126.png">

After:
 
<img width="1327" alt="Screenshot 2021-11-01 at 08 35 20" src="https://user-images.githubusercontent.com/864788/139637692-04fed703-682d-48fc-81ae-5fa0039bb3ee.png">
