### PR TITLE
Lazily configure the Java exec tasks

### DIFF
--- a/src/main/java/io/micronaut/gradle/MicronautApplicationPlugin.java
+++ b/src/main/java/io/micronaut/gradle/MicronautApplicationPlugin.java
@@ -36,6 +36,8 @@ import java.util.stream.Collectors;
 public class MicronautApplicationPlugin extends MicronautLibraryPlugin {
 
     public static final String CONFIGURATION_DEVELOPMENT_ONLY = "developmentOnly";
+    // This flag is used for testing purposes only
+    public static final String INTERNAL_CONTINUOUS_FLAG = "io.micronaut.internal.gradle.continuous";
 
     @Override
     public void apply(Project project) {
@@ -114,7 +116,7 @@ public class MicronautApplicationPlugin extends MicronautLibraryPlugin {
         
         new MicronautDockerPlugin().apply(project);
         final TaskContainer tasks = project.getTasks();
-        tasks.withType(JavaExec.class, javaExec -> {
+        tasks.withType(JavaExec.class).configureEach(javaExec -> {
             if (javaExec.getName().equals("run")) {
                 javaExec.jvmArgs(
                         "-Dcom.sun.management.jmxremote"
@@ -129,7 +131,7 @@ public class MicronautApplicationPlugin extends MicronautLibraryPlugin {
             // If -t (continuous mode) is enabled feed parameters to the JVM
             // that allows it to shutdown on resources changes so a rebuild
             // can apply a restart to the application
-            if (project.getGradle().getStartParameter().isContinuous()) {
+            if (project.getGradle().getStartParameter().isContinuous() || Boolean.getBoolean(INTERNAL_CONTINUOUS_FLAG)) {
                 SourceSetContainer sourceSets = project.getConvention()
                         .getPlugin(JavaPluginConvention.class)
                         .getSourceSets();

--- a/src/test/groovy/io/micronaut/gradle/MicronautApplicationPluginSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/MicronautApplicationPluginSpec.groovy
@@ -1,9 +1,11 @@
 package io.micronaut.gradle
 
+
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import spock.lang.Issue
 import spock.lang.Specification
 
 class MicronautApplicationPluginSpec extends Specification {
@@ -140,4 +142,53 @@ public class ExampleTest {
 //        task.outcome == TaskOutcome.SUCCESS
 //    }
 
+    @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/292")
+    def "Groovy sources are found when configuring watch paths"() {
+                given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.application"
+                id 'groovy'
+            }
+
+            micronaut {
+                version "3.0.1"
+                runtime "netty"
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation "org.codehaus.groovy:groovy:3.0.5"
+            }
+            mainClassName="example.Application"
+        """
+
+        testProjectDir.newFolder("src", "main", "groovy", "example")
+        def groovyApp = testProjectDir.newFile("src/main/groovy/example/Application.groovy")
+
+        groovyApp << """package example
+
+            println "Watch paths: \${System.getProperty('micronaut.io.watch.paths')}"
+        """
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('run', "-D${MicronautApplicationPlugin.INTERNAL_CONTINUOUS_FLAG}=true")
+                .withPluginClasspath()
+                .build()
+
+        def task = result.task(":run")
+        def output = result.output.readLines()
+        def watchLine = output.find { it.startsWith("Watch paths: ") }
+            .replace(File.separatorChar, (char) '/')
+
+        then:
+        task.outcome == TaskOutcome.SUCCESS
+        watchLine.contains 'src/main/groovy'
+    }
 }


### PR DESCRIPTION
This commit fixes the fact that Groovy sources (and probably Kotlin/Scala/...)
were not added to the watch paths. The problem was that the exec task was eagerly
configured. By moving to `configureEach` we're deferring the configuration to
when it's actually being requested by a user. As a consequence we are sure, when
his happens, that all plugins are applied, so the Groovy sources will be visible.

Fixes #292