### PR TITLE
gh-pages: redirect from latest/guide to latest

### DIFF
--- a/latest/guide/index.html
+++ b/latest/guide/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Micronaut Gradle Plugin | Micronaut Framework</title>
+    <meta http-equiv="refresh" content="0; url=https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/" />
+    <meta name="robots" content="noindex"/>
+    <meta charset='utf-8'/>
+</head>
+<body>
+  <p>This page has moved to <a href="https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/">https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/</a></p>
+</body>
+</html>

--- a/snapshot/guide/index.html
+++ b/snapshot/guide/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Micronaut Gradle Plugin | Micronaut Framework</title>
+    <meta http-equiv="refresh" content="0; url=https://micronaut-projects.github.io/micronaut-gradle-plugin/snapshot/" />
+    <meta name="robots" content="noindex"/>
+    <meta charset='utf-8'/>
+</head>
+<body>
+  <p>This page has moved to <a href="https://micronaut-projects.github.io/micronaut-gradle-plugin/snapshot/">https://micronaut-projects.github.io/micronaut-gradle-plugin/snapshot/</a></p>
+</body>
+</html>


### PR DESCRIPTION
and from snapshot/guide to snapshot

Micronaut.io website expects the documentation to be in a subfolder named guides