### PR TITLE
Fix links to Gradle docs

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -6,7 +6,7 @@
 :shadow-version: 7.0.0
 :native-gradle-plugin: https://graalvm.github.io/native-build-tools/{native-build-tools-version}/gradle-plugin.html
 :gradle-docs: https://docs.gradle.org/{gradle-version}/userguide
-:gradle-toolchains: {gradle-docs}/{gradle-version}/userguide/toolchains.html
+:gradle-toolchains: {gradle-docs}/toolchains.html
 :default-docker-image: openjdk:17-alpine
 :docker-plugin: https://github.com/bmuschko/gradle-docker-plugin
 :aws-docs: https://micronaut-projects.github.io/micronaut-aws/latest/guide/index.html#customRuntimes


### PR DESCRIPTION
Before this PR, links to Gradle docs are wrong because they include duplicated `7.2/userguide`, like `https://docs.gradle.org/7.2/userguide/7.2/userguide/toolchains.html`.