### PR TITLE
Make documentation discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 A Gradle Plugin which makes development of Micronaut application and libraries a breeze.
 
-Please refer to the [documentation](https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/guide) for help.
+Please refer to the [documentation](https://micronaut-projects.github.io/micronaut-gradle-plugin/snapshot/) for help.
+
+Documentation for the 2.x version of the plugin can be found [here](https://github.com/micronaut-projects/micronaut-gradle-plugin/tree/2.0.x#readme).

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -15,6 +15,8 @@ Version {gradle-project-version}
 
 == What's new
 
+NOTE: Documentation for the 2.x branch can be found https://github.com/micronaut-projects/micronaut-gradle-plugin/tree/2.0.x#readme[here].
+
 The 3.0.0 version of the plugin integrates with the {native-gradle-plugin}[official GraalVM plugin] which introduces some breaking changes:
 
     - the `nativeImage` task is now replaced with `nativeCompile`


### PR DESCRIPTION
- Add link to the 2.x version from the Asciidoc page
- Add link to the 2.x version to the main README
- Update link to the main README to the snapshot version until
we have a release verson available