### PR TITLE
remove links from navigation but api reference

### DIFF
--- a/src/docs/asciidoc/template/template.html
+++ b/src/docs/asciidoc/template/template.html
@@ -37,72 +37,10 @@
 
                 <ul class="navbar-nav ml-auto">
 
-                    <li id="menu-item-2865" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2865 nav-item">
-                        <a href="https://micronaut.io/download/" class="nav-link">Download</a>
-                    </li>
                     <li id="menu-item-2866" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2866 nav-item">
                         <a href="api/index.html" class="nav-link">API reference</a>
                     </li>
-                    <li id="menu-item-2868" class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-22 current_page_item current-menu-ancestor current-menu-parent current_page_parent current_page_ancestor menu-item-has-children menu-item-2872 active dropdown nav-item">
-                        <a href="https://micronaut.io/guides/" class="nav-link dropdown-toggle" data-toggle="dropdown">Learn</a>
-                        <ul class="dropdown-menu">
-                            <li id="menu-item-2869" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2869">
-                                <a href="https://micronaut.io/docs/" class="dropdown-item">User Documentation</a>
-                            </li>
-                            <li id="menu-item-2870" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2870">
-                                <a href="https://micronaut.io/guides/" class="dropdown-item">Guides</a>
-                            </li>
-                            <li id="menu-item-2896" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-2896">
-                                <a href="https://micronaut.io/category/microcast/" class="dropdown-item">Microcasts</a>
-                            </li>
-                            <li id="menu-item-2897" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-2897">
-                                <a href="https://micronaut.io/category/webinar/" class="dropdown-item">Webinars</a>
-                            </li>
-                            <li id="menu-item-2871" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2871">
-                                <a href="https://micronaut.io/professional-training/" class="dropdown-item">Professional Training</a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li id="menu-item-2878" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2878 dropdown nav-item">
-                        <a href="https://micronaut.io/blog/" class="nav-link dropdown-toggle" data-toggle="dropdown">Resources</a>
-                        <ul class="dropdown-menu">
-                            <li id="menu-item-2879" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2879">
-                                <a href="https://micronaut.io/blog/" class="dropdown-item">Blog</a>
-                            </li>
-                            <li id="menu-item-2881" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2881">
-                                <a href="https://micronaut.io/events/" class="dropdown-item">Upcoming Events</a>
-                            </li>
-                            <li id="menu-item-2880" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2880">
-                                <a href="https://micronaut.io/commercial-support/" class="dropdown-item">Commercial Support</a>
-                            </li>
-                            <li id="menu-item-2882" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2882">
-                                <a href="https://micronaut.io/faq/" class="dropdown-item">FAQ</a>
-                            </li>
-                            <li id="menu-item-2883" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2883">
-                                <a href="https://micronaut.io/contact/" class="dropdown-item">Contact</a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li id="menu-item-2872" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2878 dropdown nav-item">
-                        <a href="https://micronaut.io/foundation/" aria-current="page" class="nav-link dropdown-toggle" data-toggle="dropdown">Foundation</a>
-                        <ul class="dropdown-menu">
-                            <li id="menu-item-2877" class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-22 current_page_item menu-item-2877 active">
-                                <a href="https://micronaut.io/foundation/" aria-current="page" class="dropdown-item">Overview</a>
-                            </li>
-                            <li id="menu-item-2874" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2874">
-                                <a href="https://micronaut.io/foundation/corporate-sponsorship/" class="dropdown-item">Corporate Sponsorship</a>
-                            </li>
-                            <li id="menu-item-2873" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2873">
-                                <a href="https://micronaut.io/foundation/community-sponsorship/" class="dropdown-item">Community Sponsorship</a>
-                            </li>
-                            <li id="menu-item-2876" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2876">
-                                <a href="https://micronaut.io/foundation/sponsors/" class="dropdown-item">Sponsors</a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li id="menu-item-2884" class="action menu-item menu-item-type-custom menu-item-object-custom menu-item-2884 nav-item">
-                        <a target="_blank" rel="noopener" href="https://micronaut.io/launch/" class="nav-link">Launch</a>
-                    </li>
+                 
                 </ul>
             </div>
 


### PR DESCRIPTION
I don't think the changes done here are consistent with our navigation in other modules' documentation 

https://github.com/micronaut-projects/micronaut-gradle-plugin/pull/295

<img width="1060" alt="Screenshot 2021-11-10 at 07 16 17" src="https://user-images.githubusercontent.com/864788/141060794-e719a3cb-b95e-4c81-a9f9-9ff09ef9c4d2.png">

Example of other modules: 

<img width="1053" alt="Screenshot 2021-11-10 at 07 16 44" src="https://user-images.githubusercontent.com/864788/141060823-5c4fd2b7-7206-45fe-879c-38d9f5807dce.png">


