### PR TITLE
Upgrade dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
 kotlin = "1.4.32"
 docker = "6.7.0"
-diffplug = "3.29.1"
-shadow = "6.1.0"
-groovy = "3.0.8"
+diffplug = "3.33.2"
+shadow = "7.1.0"
+groovy = "3.0.9"
 spock = "2.0-groovy-3.0"
-graalvmPlug = "0.9.5"
+graalvmPlug = "0.9.7.1"
 
 [libraries]
 dockerPlug = { module = "com.bmuschko:gradle-docker-plugin", version.ref = "docker" }
 diffplugPlug = { module = "com.diffplug.gradle:goomph", version.ref = "diffplug" }
-shadowPlug = { module = "com.github.jengelman.gradle.plugins:shadow", version.ref = "shadow" }
+shadowPlug = { module = "gradle.plugin.com.github.johnrengelman:shadow", version.ref = "shadow" }
 graalvmPlug = { module = "org.graalvm.buildtools:native-gradle-plugin", version.ref = "graalvmPlug" }
 
 kotlin-allopen = { module = "org.jetbrains.kotlin:kotlin-allopen", version.ref = "kotlin" }

--- a/src/main/java/io/micronaut/gradle/MicronautApplicationPlugin.java
+++ b/src/main/java/io/micronaut/gradle/MicronautApplicationPlugin.java
@@ -137,17 +137,18 @@ public class MicronautApplicationPlugin extends MicronautLibraryPlugin {
                         .getSourceSets();
                 SourceSet sourceSet = sourceSets.findByName("main");
                 if (sourceSet != null) {
-                    String watchPaths = sourceSet
-                            .getAllSource()
-                            .getSrcDirs()
-                            .stream()
-                            .map(File::getPath)
-                            .collect(Collectors.joining(","));
-
                     Map<String, Object> sysProps = new LinkedHashMap<>();
                     sysProps.put("micronaut.io.watch.restart", true);
                     sysProps.put("micronaut.io.watch.enabled", true);
-                    sysProps.put("micronaut.io.watch.paths", watchPaths);
+                    javaExec.doFirst(workaroundEagerSystemProps -> {
+                        String watchPaths = sourceSet
+                                .getAllSource()
+                                .getSrcDirs()
+                                .stream()
+                                .map(File::getPath)
+                                .collect(Collectors.joining(","));
+                        javaExec.systemProperty("micronaut.io.watch.paths", watchPaths);
+                    });
                     javaExec.systemProperties(
                             sysProps
                     );


### PR DESCRIPTION
This also reworks the fix for watch paths as one of the plugins we're using triggers early realization of the `run` task.

We _cannot_ upgrade to the latest Docker plugin because it requires Java 11 and Micronaut still supports Java 8.