### PR TITLE
Fix graal processor only added with the library plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id "groovy"
     id "com.adarshr.test-logger"
     id "io.micronaut.internal.build.documented"
+    id "org.gradle.test-retry" version "1.3.1"
 }
 
 // If your plugin has any external java dependencies, Gradle will attempt to
@@ -62,7 +63,12 @@ dependencies {
     testImplementation libs.spock.junit4
 }
 
-test {
+tasks.withType(Test).configureEach {
+    retry {
+        maxRetries = 2
+        maxFailures = 20
+        failOnPassedAfterRetry = true
+    }
     useJUnitPlatform()
 }
 // The configuration example below shows the minimum required properties

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ diffplug = "3.33.2"
 shadow = "7.1.0"
 groovy = "3.0.9"
 spock = "2.0-groovy-3.0"
-graalvmPlug = "0.9.7.1"
+graalvmPlug = "0.9.8"
 
 [libraries]
 dockerPlug = { module = "com.bmuschko:gradle-docker-plugin", version.ref = "docker" }

--- a/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -2,6 +2,7 @@ package io.micronaut.gradle.docker;
 
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
 import org.graalvm.buildtools.gradle.NativeImagePlugin;
+import org.graalvm.buildtools.gradle.dsl.AgentConfiguration;
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
 import org.graalvm.buildtools.gradle.dsl.NativeResourcesOptions;
 import org.graalvm.buildtools.gradle.internal.BaseNativeImageOptions;
@@ -202,8 +203,23 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
                             return delegate.getVerbose();
                         }
 
+                        /**
+                         * Configures the GraalVM agent options.
+                         *
+                         * @param spec the agent configuration.
+                         */
                         @Override
-                        public Property<Boolean> getAgent() {
+                        public void agent(Action<? super AgentConfiguration> spec) {
+                            delegate.agent(spec);
+                        }
+
+                        /**
+                         * Returns the GraalVM agent configuration.
+                         *
+                         * @return the configuration.
+                         */
+                        @Override
+                        public AgentConfiguration getAgent() {
                             return delegate.getAgent();
                         }
 

--- a/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -53,7 +53,11 @@ public class MicronautGraalPlugin implements Plugin<Project> {
         });
         GraalVMExtension graal = project.getExtensions().findByType(GraalVMExtension.class);
         graal.getBinaries().configureEach(options ->
-                options.resources(rsrc -> rsrc.autodetection(inf -> inf.getEnabled().convention(true)))
+                options.resources(rsrc -> rsrc.autodetection(inf -> {
+                    inf.getEnabled().convention(true);
+                    inf.getIgnoreExistingResourcesConfigFile().convention(true);
+                    inf.getRestrictToProjectDependencies().convention(true);
+                }))
         );
         project.getPluginManager().withPlugin("application", plugin -> {
             TaskContainer tasks = project.getTasks();

--- a/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -45,7 +45,11 @@ public class MicronautGraalPlugin implements Plugin<Project> {
         project.getPluginManager().apply(NativeImagePlugin.class);
         project.getPluginManager().withPlugin("io.micronaut.library", plugin -> {
             MicronautExtension extension = project.getExtensions().findByType(MicronautExtension.class);
-            configureMicronautLibrary(project, extension);
+            configureAnnotationProcessing(project, extension);
+        });
+        project.getPluginManager().withPlugin("io.micronaut.application", plugin -> {
+            MicronautExtension extension = project.getExtensions().findByType(MicronautExtension.class);
+            configureAnnotationProcessing(project, extension);
         });
         GraalVMExtension graal = project.getExtensions().findByType(GraalVMExtension.class);
         graal.getBinaries().configureEach(options ->
@@ -109,7 +113,7 @@ public class MicronautGraalPlugin implements Plugin<Project> {
         }
     }
 
-    private static void configureMicronautLibrary(Project project, MicronautExtension extension) {
+    private static void configureAnnotationProcessing(Project project, MicronautExtension extension) {
         SourceSetContainer sourceSets = project
                 .getConvention()
                 .getPlugin(JavaPluginConvention.class)

--- a/src/test/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
@@ -65,6 +65,7 @@ abstract class AbstractGradleBuildSpec extends Specification {
                 .forwardStdOutput(System.out.newWriter())
                 .forwardStdError(System.err.newWriter())
                 .withPluginClasspath()
+                .withDebug(true)
                 .build()
     }
 

--- a/src/test/groovy/io/micronaut/gradle/MicronautGraalWellBehavePluginSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/MicronautGraalWellBehavePluginSpec.groovy
@@ -1,0 +1,22 @@
+package io.micronaut.gradle
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class MicronautGraalWellBehavePluginSpec extends Specification {
+    def "graal processor is added with plugin #plugin"() {
+        def project = ProjectBuilder.builder().build()
+
+        when:
+        project.plugins.apply (plugin)
+
+        then:
+        project.configurations.annotationProcessor.dependencies.find { it.name == 'micronaut-graal' }
+
+        where:
+        plugin << [
+                "io.micronaut.library",
+                "io.micronaut.application",
+        ]
+    }
+}


### PR DESCRIPTION
This commit fixes the addition of the Micronaut Graal processor,
which was only done with the `library` plugin, not with the `application`.

Fixes #324