### PR TITLE
Add the `deduceEnvironment` optimization

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ groovy = "3.0.9"
 spock = "2.0-groovy-3.0"
 graalvmPlug = "0.9.8"
 micronaut = "3.2.0"
-micronaut-aot = "1.0.0-M1"
+micronaut-aot = "1.0.0-M2"
 
 [libraries]
 dockerPlug = { module = "com.bmuschko:gradle-docker-plugin", version.ref = "docker" }

--- a/samples/aot/basic-app/build.gradle
+++ b/samples/aot/basic-app/build.gradle
@@ -8,6 +8,7 @@ group = "demo.app"
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 micronaut {
@@ -24,6 +25,7 @@ micronaut {
         optimizeClassLoading = true
         convertYamlToJava = true
         precomputeOperations = true
+        deduceEnvironment = true
     }
 }
 

--- a/samples/aot/with-shadow/build.gradle
+++ b/samples/aot/with-shadow/build.gradle
@@ -25,6 +25,7 @@ micronaut {
         optimizeClassLoading = true
         convertYamlToJava = true
         precomputeOperations = true
+        deduceEnvironment = true
     }
 }
 

--- a/src/main/java/io/micronaut/gradle/aot/AOTOptimizations.java
+++ b/src/main/java/io/micronaut/gradle/aot/AOTOptimizations.java
@@ -71,4 +71,13 @@ public interface AOTOptimizations {
     @Input
     Property<Boolean> getPrecomputeOperations();
 
+    /**
+     * If set to true and that the application context uses deduceEnvironment(true)
+     * then the deduction will be done at build time instead of run time.
+     *
+     * @return the deduce environment property
+     */
+    @Input
+    Property<Boolean> getDeduceEnvironment();
+
 }

--- a/src/main/java/io/micronaut/gradle/aot/MicronautAOTConfigWriterTask.java
+++ b/src/main/java/io/micronaut/gradle/aot/MicronautAOTConfigWriterTask.java
@@ -17,6 +17,7 @@ package io.micronaut.gradle.aot;
 
 import io.micronaut.aot.std.sourcegen.AbstractStaticServiceLoaderSourceGenerator;
 import io.micronaut.aot.std.sourcegen.ConstantPropertySourcesSourceGenerator;
+import io.micronaut.aot.std.sourcegen.DeduceEnvironmentSourceGenerator;
 import io.micronaut.aot.std.sourcegen.EnvironmentPropertiesSourceGenerator;
 import io.micronaut.aot.std.sourcegen.GraalVMOptimizationFeatureSourceGenerator;
 import io.micronaut.aot.std.sourcegen.JitStaticServiceLoaderSourceGenerator;
@@ -107,6 +108,7 @@ public abstract class MicronautAOTConfigWriterTask extends DefaultTask {
             booleanOptimization(props, ConstantPropertySourcesSourceGenerator.ID, optimizations.getConvertYamlToJava());
         }
         booleanOptimization(props, EnvironmentPropertiesSourceGenerator.ID, optimizations.getPrecomputeOperations());
+        booleanOptimization(props, DeduceEnvironmentSourceGenerator.ID, optimizations.getDeduceEnvironment());
         File outputFile = getOutputFile().getAsFile().get();
         if (outputFile.getParentFile().isDirectory() || outputFile.getParentFile().mkdirs()) {
             try (OutputStream out = new FileOutputStream(outputFile)) {

--- a/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -77,7 +77,7 @@ import static org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_
 @SuppressWarnings("Convert2Lambda")
 public abstract class MicronautAotPlugin implements Plugin<Project> {
 
-    public static final String DEFAULT_AOT_VERSION = "1.0.0-M1";
+    public static final String DEFAULT_AOT_VERSION = "1.0.0-M2";
     public static final String OPTIMIZED_BINARY_NAME = "optimized";
     public static final String OPTIMIZED_DIST_NAME = "optimized";
     public static final String MAIN_BINARY_NAME = "main";
@@ -130,6 +130,7 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
         aotExtension.getReplaceLogbackXml().convention(false);
         aotExtension.getOptimizeClassLoading().convention(false);
         aotExtension.getPrecomputeOperations().convention(false);
+        aotExtension.getDeduceEnvironment().convention(false);
     }
 
     private void registerPrepareOptimizationsTasks(Project project, Configurations configurations, AOTExtension aotExtension) {

--- a/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
@@ -20,6 +20,7 @@ class BasicMicronautAOTSpec extends AbstractAOTPluginSpec {
             withProperty('known.missing.types.enabled', 'true')
             withProperty('sealed.property.source.enabled', 'true')
             withProperty('precompute.environment.properties.enabled', 'true')
+            withProperty('deduce.environment.enabled', 'true')
             withExtraPropertyKeys 'service.types', 'known.missing.types.list'
         }
 


### PR DESCRIPTION
This commit upgrades the plugin to use Micronaut AOT 1.0.0-M2,
which gives us the opportunity to add support for the built-in
`deduceEnvironment` optimization.