### PR TITLE
Upgrade to build tools 5.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ plugins {
     id "groovy"
     id "com.adarshr.test-logger"
     id "io.micronaut.internal.build.documented"
-    id "org.gradle.test-retry" version "1.3.1"
 }
 
 // If your plugin has any external java dependencies, Gradle will attempt to
@@ -72,11 +71,6 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-    retry {
-        maxRetries = 2
-        maxFailures = 20
-        failOnPassedAfterRetry = true
-    }
     useJUnitPlatform()
 }
 // The configuration example below shows the minimum required properties

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '4.2.6'
+    id 'io.micronaut.build.shared.settings' version '5.0.2'
 }
 
 rootProject.name = 'micronaut-gradle-plugin'


### PR DESCRIPTION
This removes the need to configure the test retry plugin as it's
already done by the build plugins.