### PR TITLE
Fix configuration missing when merging user configuration with defaults

### DIFF
--- a/src/main/java/io/micronaut/gradle/aot/MicronautAOTConfigWriterTask.java
+++ b/src/main/java/io/micronaut/gradle/aot/MicronautAOTConfigWriterTask.java
@@ -88,8 +88,11 @@ public abstract class MicronautAOTConfigWriterTask extends DefaultTask {
             } catch (IOException e) {
                 throw new GradleException("Unable to parse configuration file", e);
             }
-        } else {
+        }
+        if (!props.containsKey(KnownMissingTypesSourceGenerator.OPTION.key())) {
             props.put(KnownMissingTypesSourceGenerator.OPTION.key(), String.join(",", MicronautAotPlugin.TYPES_TO_CHECK));
+        }
+        if (!props.containsKey(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES)) {
             props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES, String.join(",", MicronautAotPlugin.SERVICE_TYPES));
         }
         AOTOptimizations optimizations = getAOTOptimizations().get();


### PR DESCRIPTION
This commit fixes a bug with optimizations not being loaded because they
would miss the default service types to check/load if the user supplies
a custom configuration file.