### PR TITLE
Upgrade log4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,11 @@ tasks.withType(PluginUnderTestMetadata) {
 }
 
 dependencies {
+    constraints {
+        implementation(libs.log4j2.core) {
+            because("Log4j2 <2.15 is vulnerable to RCE (CVE-2021-44228)")
+        }
+    }
     implementation libs.dockerPlug
     implementation libs.diffplugPlug
     implementation libs.shadowPlug

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ shadow = "7.1.0"
 groovy = "3.0.9"
 spock = "2.0-groovy-3.0"
 graalvmPlug = "0.9.8"
+log4j2 = { require = "2.15.0", reject = ["]0, 2.15["] }
 
 [libraries]
 dockerPlug = { module = "com.bmuschko:gradle-docker-plugin", version.ref = "docker" }
@@ -19,6 +20,7 @@ kotlin-gradlePlug = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", vers
 groovy-core = { module = "org.codehaus.groovy:groovy", version.ref = "groovy" }
 spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }
 spock-junit4 = { module = "org.spockframework:spock-junit4", version.ref = "spock" }
+log4j2-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j2" }
 
 [bundles]
 optionalPlugins = [ "kotlin-allopen", "kotlin-gradlePlug", "graalvmPlug" ]


### PR DESCRIPTION
Log4j is a transitive dependency brought by the shadow plugin that
is used internally. While this isn't a direct threat (because a
build tool is by design an arbitrary code execution engine), security
scanners may warn about this vulnerability.

Fixes #340