### PR TITLE
update log4j2 to 2.17.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ spock = "2.0-groovy-3.0"
 graalvmPlug = "0.9.8"
 micronaut = "3.2.0"
 micronaut-aot = "1.0.0-M4"
-log4j2 = { require = "2.16.0", reject = ["]0, 2.16["] }
+log4j2 = { require = "2.17.0", reject = ["]0, 2.17["] }
 
 [libraries]
 dockerPlug = { module = "com.bmuschko:gradle-docker-plugin", version.ref = "docker" }


### PR DESCRIPTION
> The Log4j team has been made aware of a security vulnerability, CVE-2021-45105, that has been addressed in Log4j 2.17.0 for Java 8 and up.
> Summary: Apache Log4j2 does not always protect from infinite recursion in lookup evaluation.