### PR TITLE
Make it more convenient to declare AOT plugins

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -894,6 +894,22 @@ micronaut {
 }
 ----
 
+In addition, you can use the `aotPlugins` configuration to declare additional AOT modules to be used:
+
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+dependencies {
+    aotPlugins 'io.micronaut.security:micronaut-security-aot:1.0.0'
+}
+----
+
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+dependencies {
+    aotPlugins("io.micronaut.security:micronaut-security-aot:1.0.0")
+}
+----
+
 Because Micronaut AOT is an extensible optimization engine, not all optimizations are known beforehand by the plugin, which means that not all of them may be accessible via the DSL.
 For this reason, it is possible to provide a _Micronaut AOT configuration file_ instead:
 

--- a/src/main/java/io/micronaut/gradle/aot/AOTOptimizations.java
+++ b/src/main/java/io/micronaut/gradle/aot/AOTOptimizations.java
@@ -16,6 +16,7 @@
 package io.micronaut.gradle.aot;
 
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
@@ -92,4 +93,13 @@ public interface AOTOptimizations {
     @Input
     @Optional
     ListProperty<String> getPossibleEnvironments();
+
+    /**
+     * An optional map of properties which will be merged with the configuration
+     * to generate the final configuration file of Micronaut AOT.
+     * @return the configuration properties
+     */
+    @Input
+    @Optional
+    MapProperty<String, String> getConfigurationProperties();
 }

--- a/src/main/java/io/micronaut/gradle/aot/MicronautAOTConfigWriterTask.java
+++ b/src/main/java/io/micronaut/gradle/aot/MicronautAOTConfigWriterTask.java
@@ -101,13 +101,16 @@ public abstract class MicronautAOTConfigWriterTask extends DefaultTask {
                 throw new GradleException("Unable to parse configuration file", e);
             }
         }
+        AOTOptimizations optimizations = getAOTOptimizations().get();
+        if (optimizations.getConfigurationProperties().isPresent()) {
+            props.putAll(optimizations.getConfigurationProperties().get());
+        }
         if (!props.containsKey(KnownMissingTypesSourceGenerator.OPTION.key())) {
             props.put(KnownMissingTypesSourceGenerator.OPTION.key(), String.join(",", MicronautAotPlugin.TYPES_TO_CHECK));
         }
         if (!props.containsKey(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES)) {
             props.put(AbstractStaticServiceLoaderSourceGenerator.SERVICE_TYPES, String.join(",", MicronautAotPlugin.SERVICE_TYPES));
         }
-        AOTOptimizations optimizations = getAOTOptimizations().get();
         booleanOptimization(props, GraalVMOptimizationFeatureSourceGenerator.ID, getForNative());
         booleanOptimization(props, LogbackConfigurationSourceGenerator.ID, optimizations.getReplaceLogbackXml());
         booleanOptimization(props, CachedEnvironmentSourceGenerator.ID, optimizations.getCacheEnvironment());

--- a/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -374,6 +374,11 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
             c.getDependencies().addLater(aotExtension.getVersion().map(v -> project.getDependencies().create("io.micronaut.aot:micronaut-aot-cli:" + v)));
         });
         // User configurations
+        Configuration aotPlugins = configurations.create("aotPlugins", c -> {
+            c.setCanBeResolved(false);
+            c.setCanBeConsumed(false);
+        });
+        aotOptimizerRuntimeClasspath.extendsFrom(aotPlugins);
         Configuration aotApplication = configurations.create("aotApplication", c -> {
             c.setCanBeResolved(false);
             c.setCanBeConsumed(false);

--- a/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
+++ b/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
@@ -46,4 +46,61 @@ class BasicMicronautAOTSpec extends AbstractAOTPluginSpec {
         runtime << ['jit', 'native']
 
     }
+
+    def "can configure properties via the DSL #runtime"() {
+        withSample("aot/basic-app")
+        buildFile << """
+            micronaut {
+                aot {
+                    configurationProperties.putAll([
+                        'known.missing.types.enabled': 'false',
+                        'some.plugin.enabled': 'true'
+                    ])
+                }
+            }
+
+        """
+
+        when:
+        def result = build "prepare${runtime.capitalize()}Optimizations", "-i"
+
+        and: "configuration file is generated"
+        hasAOTConfiguration(runtime) {
+            withProperty('graalvm.config.enabled', 'native' == runtime ? 'true' : 'false')
+            withProperty('logback.xml.to.java.enabled', 'false')
+            withProperty('cached.environment.enabled', 'true')
+            withProperty('serviceloading.jit.enabled', 'true')
+            withProperty('serviceloading.native.enabled', 'true')
+            withProperty('yaml.to.java.config.enabled', 'true')
+            withProperty('scan.reactive.types.enabled', 'true')
+            withProperty('known.missing.types.enabled', 'false')
+            withProperty('sealed.property.source.enabled', 'true')
+            withProperty('precompute.environment.properties.enabled', 'true')
+            withProperty('deduce.environment.enabled', 'true')
+            withProperty('some.plugin.enabled', 'true')
+            withExtraPropertyKeys 'service.types', 'known.missing.types.list'
+        }
+
+        then: "Context configurer is loaded"
+        result.output.contains 'Java configurer loaded'
+
+        when:
+        interruptApplicationStartup()
+        result = build("optimizedRun")
+
+        then:
+        [
+                'io.micronaut.core.util.EnvironmentProperties',
+                'io.micronaut.core.async.publisher.PublishersOptimizations',
+                'io.micronaut.core.io.service.SoftServiceLoader$Optimizations',
+                'io.micronaut.context.env.ConstantPropertySources'
+        ].each {
+            assert result.output.contains("Setting optimizations for class $it")
+        }
+
+        where:
+        runtime << ['jit', 'native']
+
+    }
+
 }


### PR DESCRIPTION
A project like Micronaut Security can contribute new AOT modules.
We need a user-friendly way to declare such extensions, and a way
to configure them.

This commit introduces an `aotPlugins` configuration which makes
it more obvious where to declare the AOT extensions. It also adds
a properties block to the AOT configuration, so that configuration
keys from plugins can be used without resorting to a properties
file.