### PR TITLE
build: bump up log4j to 2.17.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ spock = "2.0-groovy-3.0"
 graalvmPlug = "0.9.9"
 micronaut = "3.2.0"
 micronaut-aot = "1.0.0-M5"
-log4j2 = { require = "2.17.0", reject = ["]0, 2.17["] }
+log4j2 = { require = "2.17.1", reject = ["]0, 2.17["] }
 
 [libraries]
 dockerPlug = { module = "com.bmuschko:gradle-docker-plugin", version.ref = "docker" }


### PR DESCRIPTION
https://logging.apache.org/log4j/2.x/

> Log4j 2.17.1 has been released to:
> Address CVE-2021-44832.