### PR TITLE
ARM Lambda native images can be built on M1 machines

### DIFF
--- a/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -356,7 +356,9 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
             runCommand("yum install -y gcc gcc-c++ libc6-dev zlib1g-dev curl bash zlib zlib-devel zlib-static zip tar gzip");
             String jdkVersion = getJdkVersion().get();
             String graalVersion = getGraalVersion().get();
-            String fileName = "graalvm-ce-" + jdkVersion + "-linux-amd64-" + graalVersion + ".tar.gz";
+            String archMappingBash = "$([[ \"$(arch)\" =~ arm.* || \"$(arch)\" =~ aarch.* ]] && echo aarch64 || echo amd64)";
+            String fileName = "graalvm-ce-" + jdkVersion + "-linux-" + archMappingBash + "-" + graalVersion + ".tar.gz";
+            runCommand("echo \"==== Fetching GraalVM for " + archMappingBash + '\"');
             runCommand("curl -4 -L https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-" + graalVersion + "/" + fileName + " -o /tmp/" + fileName);
             runCommand("tar -zxf /tmp/" + fileName + " -C /tmp && mv /tmp/graalvm-ce-" + jdkVersion + "-" + graalVersion + " /usr/lib/graalvm");
             runCommand("rm -rf /tmp/*");
@@ -417,7 +419,8 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
                 runCommand("echo \"#!/bin/sh\" >> bootstrap && echo \"set -euo pipefail\" >> bootstrap && echo \"" + funcCmd + "\" >> bootstrap");
                 runCommand("chmod 777 bootstrap");
                 runCommand("chmod 777 func");
-                runCommand("zip -j function.zip bootstrap func");
+                runCommand("echo \"$(arch)\" > architecture");
+                runCommand("zip -j function.zip bootstrap func architecture");
                 getInstructions().addAll(additionalInstructions);
                 entryPoint("/function/func");
                 break;


### PR DESCRIPTION
Prior to this, when `buildNativeLambda` is executed on an M1 Apple machine, it pulls the
ARM version of amazonlinux:latest, and then installs the x86 version of GraalVM.

This obviously fails.

This change detects if the amazonlinux docker image is running on an ARM architecture,
and the fetches the correct GraalVM JDK from GitHub.

It does not allow cross-compilation of x86 Lambda images on M1 hardware.  Currently the
docker plugin we use does not allow buildx, nor setting the platform when executing docker

I'm not 100% it will be possible even with a later image.

I have tested the resulting ARM lambda on AWS when build on an M1 mac.

I am going to test the native image from an x86 Mac as well. I'm relying on GitHub to test
Linux and Windows