### PR TITLE
Fix invalid COPY instructions

### DIFF
--- a/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
+++ b/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
@@ -72,8 +72,8 @@ public class MicronautDockerfile extends Dockerfile implements DockerBuildOption
                 workingDir("/function");
                 runCommand("mkdir -p /function/app/resources");
                 copyFile("layers/libs/*.jar", "/function/app/");
-                copyFile("layers/classes/*", "/function/app/classes/");
-                copyFile("layers/resources/*", "/function/app/resources/");
+                copyFile("layers/classes", "/function/app/classes");
+                copyFile("layers/resources", "/function/app/resources");
                 copyFile("layers/application.jar", "/function/app/");
                 String cmd = this.defaultCommand.get();
                 if ("none".equals(cmd)) {


### PR DESCRIPTION
The copy instructions were incorrect if the source directory was empty.
Instead of using `/*`, it should simply copy the directory. This fixes
a build problem with Oracle functions, where the source `classes` or
`resources` directories may be empty.

@pgressa as our Docker expert, I assigned you for review. It seems to work locally but I'd like to make sure you agree :)