### PR TITLE
Improve Micronaut AOT configuration

### DIFF
--- a/src/main/java/io/micronaut/gradle/aot/AOTOptimizations.java
+++ b/src/main/java/io/micronaut/gradle/aot/AOTOptimizations.java
@@ -95,6 +95,18 @@ public interface AOTOptimizations {
     ListProperty<String> getPossibleEnvironments();
 
     /**
+     * Sets the list of target environment names. If set, then the list of environments
+     * is automatically configured before the AOT analysis starts. Note that it differs
+     * from {@link #getPossibleEnvironments()} that this call will override whatever
+     * the application context is configured to use.
+     *
+     * @return the list of target environments
+     */
+    @Input
+    @Optional
+    ListProperty<String> getTargetEnvironments();
+
+    /**
      * An optional map of properties which will be merged with the configuration
      * to generate the final configuration file of Micronaut AOT.
      * @return the configuration properties
@@ -110,4 +122,17 @@ public interface AOTOptimizations {
      */
     @Input
     Property<String> getTargetPackage();
+
+    /**
+     * Configures environment variables which will be injected
+     * during AOT analysis. This can be useful whenever some
+     * beans require environment variables to be present, but
+     * that those are not available when the AOT analysis is
+     * performed.
+     *
+     * @return the map of environment variables
+     */
+    @Input
+    @Optional
+    MapProperty<String, String> getEnvironmentVariables();
 }

--- a/src/main/java/io/micronaut/gradle/aot/AbstractMicronautAotCliTask.java
+++ b/src/main/java/io/micronaut/gradle/aot/AbstractMicronautAotCliTask.java
@@ -20,9 +20,11 @@ import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileOperations;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
@@ -49,6 +51,10 @@ abstract class AbstractMicronautAotCliTask extends DefaultTask implements Optimi
 
     @Input
     protected abstract Property<String> getAotVersion();
+
+    @Input
+    @Optional
+    protected abstract MapProperty<String, String> getEnvironmentVariables();
 
     protected AbstractMicronautAotCliTask() {
         getDebug().convention(false);
@@ -82,6 +88,9 @@ abstract class AbstractMicronautAotCliTask extends DefaultTask implements Optimi
             if (getDebug().get()) {
                 getLogger().info("Running with debug enabled");
                 spec.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
+            }
+            if (getEnvironmentVariables().isPresent()) {
+                spec.environment(getEnvironmentVariables().get());
             }
         });
         if (javaexec.getExitValue() != 0) {

--- a/src/main/java/io/micronaut/gradle/aot/MicronautAOTConfigWriterTask.java
+++ b/src/main/java/io/micronaut/gradle/aot/MicronautAOTConfigWriterTask.java
@@ -128,6 +128,7 @@ public abstract class MicronautAOTConfigWriterTask extends DefaultTask {
         booleanOptimization(props, EnvironmentPropertiesSourceGenerator.ID, optimizations.getPrecomputeOperations());
         booleanOptimization(props, DeduceEnvironmentSourceGenerator.ID, optimizations.getDeduceEnvironment());
         stringListParameter(props, Environments.POSSIBLE_ENVIRONMENTS_NAMES, optimizations.getPossibleEnvironments());
+        stringListParameter(props, Environments.TARGET_ENVIRONMENTS_NAMES, optimizations.getTargetEnvironments());
         File outputFile = getOutputFile().getAsFile().get();
         if (outputFile.getParentFile().isDirectory() || outputFile.getParentFile().mkdirs()) {
             try (OutputStream out = new FileOutputStream(outputFile)) {

--- a/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -171,7 +171,8 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
                 task.getOptimizerClasspath().from(optimizerRuntimeClasspath);
                 task.getClasspath().from(applicationClasspath);
                 task.getOutputDirectory().convention(project.getLayout().getBuildDirectory().dir("generated/aot/samples/" + targetRuntime.getSimpleName()));
-                task.getAotVersion().set(aotExtension.getVersion());
+                task.getAotVersion().convention(aotExtension.getVersion());
+                task.getEnvironmentVariables().convention(aotExtension.getEnvironmentVariables());
             });
             createAotSampleConfigurationFiles.configure(c -> c.dependsOn(createSample));
         }
@@ -377,7 +378,8 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
             task.getTargetRuntime().value(runtime).finalizeValue();
             task.getTargetPackage().convention(aotExtension.getTargetPackage());
             task.getClasspath().from(applicationClasspath);
-            task.getAotVersion().set(aotExtension.getVersion());
+            task.getAotVersion().convention(aotExtension.getVersion());
+            task.getEnvironmentVariables().convention(aotExtension.getEnvironmentVariables());
         });
     }
 


### PR DESCRIPTION
This commit improves integration with Micronaut AOT by exposing 2
new configuration options:

- the "target environments", which let the user explain what
deployment environments will be, letting the analyser run with
those environments set, instead of inferring from the local one
- environment variables: this lets the user declare environment
variables which should be visible when the analysis is performed.

Those changes are required to support deployments to environments
like Oracle Cloud, for which the bean requirements are vastly
different from what you get in a local mode.