### PR TITLE
Bump version of Gradle Docker Plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.4.32"
-docker = "6.7.0"
+docker = "7.1.0"
 diffplug = "3.33.2"
 shadow = "7.1.0"
 groovy = "3.0.9"


### PR DESCRIPTION
This bumps the version of the Gradle Docker Plugin to `7.1.0` in order to accommodate compilation for Apple M1 processors. Some users have had trouble running `dockerBuild` on Apple M1 devices.

See:
* https://github.com/docker-java/docker-java/issues/1779
* https://github.com/bmuschko/gradle-docker-plugin/issues/1035

Following the [suggestion here](https://github.com/bmuschko/gradle-docker-plugin/issues/1035#issuecomment-1023275441), upgrading to the latest version of gradle-docker-plugin seems to resolve the docker issues with Apple M1 processors.