### PR TITLE
Make sure `run` tasks are always executed

### DIFF
--- a/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
+++ b/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
@@ -85,6 +85,8 @@ public class MicronautMinimalApplicationPlugin implements Plugin<Project> {
                     // graal doesn't support this
                     javaExec.jvmArgs("-XX:TieredStopAtLevel=1");
                 }
+                // https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/385
+                javaExec.getOutputs().upToDateWhen(t -> false);
             }
             javaExec.classpath(developmentOnly);
 

--- a/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -307,6 +307,8 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
                 task.setGroup(runTask.getGroup());
                 task.setDescription("Executes the Micronaut application with AOT optimizations");
                 task.getMainClass().convention(javaApplication.getMainClass());
+                // https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/385
+                task.getOutputs().upToDateWhen(t -> false);
                 Set<File> mainSourceSetOutput = mainSourceSet.getOutput().getFiles();
                 task.setClasspath(
                         project.files(jarTask, mainSourceSet.getRuntimeClasspath().filter(f -> !mainJar.get().getArchiveFile().get().getAsFile().equals(f)


### PR DESCRIPTION
Gradle is a bit too smart with regards to up-to-date checks, and
wouldn't run the same app twice in a row if nothing changed.

Fixes #385