### PR TITLE
Support spaces in paths in argfile

### DIFF
--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/AbstractMicronautAotCliTask.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/AbstractMicronautAotCliTask.java
@@ -90,7 +90,7 @@ abstract class AbstractMicronautAotCliTask extends DefaultTask implements Optimi
                 configureExtraArguments(args);
                 boolean useArgFile = true;
                 try (PrintWriter wrt = new PrintWriter(new FileWriter(argFile))) {
-                    args.forEach(wrt::println);
+                    args.forEach(arg -> wrt.println(escapeArg(arg)));
                 } catch (IOException e) {
                     useArgFile = false;
                 }
@@ -126,6 +126,14 @@ abstract class AbstractMicronautAotCliTask extends DefaultTask implements Optimi
                 args.add(classpath.getAsPath());
             }
         }
+    }
+
+    private static String escapeArg(String arg) {
+        arg = arg.replace("\\", "\\\\");
+        if (arg.contains(" ")) {
+            arg = "\"" + arg + "\"";
+        }
+        return arg;
     }
 
 }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.gradle.aot
 
-
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Issue
 import spock.lang.Requires
 
 @Requires({ jvm.isJava11Compatible() })
@@ -136,6 +137,20 @@ class BasicMicronautAOTSpec extends AbstractAOTPluginSpec {
             assert result.output.contains("Setting optimizations for class $it")
         }
 
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/401")
+    def "supports spaces in file names"() {
+        withSpacesInTestDir()
+        withSample("aot/basic-app")
+        withPlugins(Plugins.MINIMAL_APPLICATION)
+        println("Base directory: $baseDir")
+
+        when:
+        def result = build "prepareJitOptimizations"
+
+        then:
+        result.task(":prepareJitOptimizations").outcome == TaskOutcome.SUCCESS
     }
 
 }

--- a/minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
+++ b/minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
@@ -19,24 +19,35 @@ abstract class AbstractGradleBuildSpec extends Specification {
 
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
+    protected Path baseDir
 
-    File settingsFile
-    File buildFile
-    File kotlinBuildFile
+    File getSettingsFile() {
+        baseDir.resolve("settings.gradle").toFile()
+    }
+
+    File getBuildFile() {
+        baseDir.resolve("build.gradle").toFile()
+    }
+
+    File getKotlinBuildFile() {
+        baseDir.resolve("build.gradle.kts").toFile()
+    }
 
     // This can be used during development to add statements like includeBuild
     final List<String> postSettingsStatements = [
     ]
 
     def setup() {
-        settingsFile = testProjectDir.newFile('settings.gradle')
-        buildFile = testProjectDir.newFile('build.gradle')
-        kotlinBuildFile = testProjectDir.newFile('build.gradle.kts')
+        baseDir = testProjectDir.root.toPath()
+    }
+
+    void withSpacesInTestDir() {
+        baseDir = testProjectDir.newFolder("with spaces").toPath()
     }
 
     protected void withSample(String name) {
         File sampleDir = new File("../samples/$name").canonicalFile
-        copySample(sampleDir.toPath(), testProjectDir.root.toPath())
+        copySample(sampleDir.toPath(), baseDir)
     }
 
     private static void copySample(Path from, Path into) {
@@ -51,7 +62,7 @@ abstract class AbstractGradleBuildSpec extends Specification {
     }
 
     File file(String relativePath) {
-        testProjectDir.root.toPath().resolve(relativePath).toFile()
+        baseDir.resolve(relativePath).toFile()
     }
 
     def getRepositoriesBlock(String dsl = 'groovy') {
@@ -85,7 +96,7 @@ abstract class AbstractGradleBuildSpec extends Specification {
                 )
             }
         }
-        runner.withProjectDir(testProjectDir.root)
+        runner.withProjectDir(baseDir.toFile())
                 .withArguments(["--no-watch-fs",
                                 "-S",
                                 "-Porg.gradle.java.installations.auto-download=false",


### PR DESCRIPTION
This commit fixes the AOT tasks which use `@arfile` for calling
Micronaut AOT: they suffer the same bug as in native build tools,
which is that spaces in paths need to be escaped.

See #401