### PR TITLE
Rework how the default runtime class is set for Lambda

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
@@ -47,6 +47,8 @@ import static io.micronaut.gradle.Strings.capitalize;
 import static org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME;
 
 public class MicronautDockerPlugin implements Plugin<Project> {
+    public static final String DEFAULT_LAMBDA_RUNTIME_CLASS = "io.micronaut.function.aws.runtime.MicronautLambdaRuntime";
+
     @Override
     public void apply(Project project) {
         project.getPluginManager().apply(MicronautBasePlugin.class);

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
@@ -18,6 +18,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static io.micronaut.gradle.docker.MicronautDockerPlugin.DEFAULT_LAMBDA_RUNTIME_CLASS;
+
 public class MicronautDockerfile extends Dockerfile implements DockerBuildOptions {
     public static final String DEFAULT_WORKING_DIR = "/home/app";
 
@@ -92,7 +94,7 @@ public class MicronautDockerfile extends Dockerfile implements DockerBuildOption
                 }
                 break;
             case LAMBDA:
-                javaApplication.getMainClass().set("io.micronaut.function.aws.runtime.MicronautLambdaRuntime");
+                javaApplication.getMainClass().set(DEFAULT_LAMBDA_RUNTIME_CLASS);
             default:
                 from(new Dockerfile.From(from != null ? from : "openjdk:17-alpine"));
                 setupResources(this);

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static io.micronaut.gradle.docker.MicronautDockerPlugin.DEFAULT_LAMBDA_RUNTIME_CLASS;
 import static io.micronaut.gradle.docker.MicronautDockerfile.DEFAULT_WORKING_DIR;
 
 /**
@@ -462,12 +463,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
             options.getBuildArgs().add("--report-unsupported-elements-at-runtime");
         } else if (buildStrategy == DockerBuildStrategy.LAMBDA) {
             JavaApplication javaApplication = getProject().getExtensions().getByType(JavaApplication.class);
-            if (!javaApplication.getMainClass().isPresent()) {
-                options.getMainClass().set("io.micronaut.function.aws.runtime.MicronautLambdaRuntime");
-            }
-            if (!options.getMainClass().isPresent()) {
-                options.getMainClass().set("io.micronaut.function.aws.runtime.MicronautLambdaRuntime");
-            }
+            options.getMainClass().set(javaApplication.getMainClass().orElse(DEFAULT_LAMBDA_RUNTIME_CLASS));
         }
         List<String> commandLine = new ArrayList<>();
         commandLine.add("native-image");

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -455,7 +455,9 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
         return new CopyFileInstruction(new CopyFile("config-dirs/" + resourceDirectory.getName(), getTargetWorkingDirectory().get() + "/config-dirs/" + resourceDirectory.getName()));
     }
 
-    protected List<String> buildActualCommandLine(Provider<String> executable, DockerBuildStrategy buildStrategy, BaseImageForBuildStrategyResolver imageResolver) {
+    protected List<String> buildActualCommandLine(Provider<String> executable,
+                                                  DockerBuildStrategy buildStrategy,
+                                                  BaseImageForBuildStrategyResolver imageResolver) {
         NativeImageOptions options = newNativeImageOptions("actualDockerOptions");
         prepareNativeImageOptions(options);
         if (buildStrategy == DockerBuildStrategy.ORACLE_FUNCTION) {
@@ -463,7 +465,9 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
             options.getBuildArgs().add("--report-unsupported-elements-at-runtime");
         } else if (buildStrategy == DockerBuildStrategy.LAMBDA) {
             JavaApplication javaApplication = getProject().getExtensions().getByType(JavaApplication.class);
-            options.getMainClass().set(javaApplication.getMainClass().orElse(DEFAULT_LAMBDA_RUNTIME_CLASS));
+            if (!options.getMainClass().isPresent()) {
+                options.getMainClass().set(javaApplication.getMainClass().orElse(DEFAULT_LAMBDA_RUNTIME_CLASS));
+            }
         }
         List<String> commandLine = new ArrayList<>();
         commandLine.add("native-image");

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
@@ -12,7 +12,7 @@ import spock.lang.Requires
 @Requires({ jvm.isJava11Compatible() })
 class LambdaNativeImageSpec extends AbstractFunctionalTest {
 
-    void 'mainclass is set correctly for an application deployed as GraalVM and Lambda'() {
+    void 'mainclass defaults to MicronautLambdaRuntime for an application deployed as GraalVM and Lambda'() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"
         buildFile << """
@@ -28,10 +28,6 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
             }
             
             $repositoriesBlock
-            
-            application {
-                mainClass.set("com.example.Application")
-            }
             
             java {
                 sourceCompatibility = JavaVersion.toVersion('11')
@@ -51,6 +47,47 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
         and:
         dockerFileNative.find() { it.contains('-H:Class=io.micronaut.function.aws.runtime.MicronautLambdaRuntime')}
         !dockerFileNative.find() { it.contains('com.example.Application')}
+    }
+
+    void 'explicitly configured main class takes precedence for an application deployed as GraalVM and Lambda'() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.docker"
+                id "io.micronaut.graalvm"
+            }
+            
+            micronaut {
+                version "2.3.4"
+                runtime "netty"
+            }
+            
+            $repositoriesBlock
+
+            application {
+                mainClass = 'com.example.Application'
+            }            
+
+            java {
+                sourceCompatibility = JavaVersion.toVersion('11')
+                targetCompatibility = JavaVersion.toVersion('11')
+            }
+        """
+
+        when:
+        def result = build('dockerfileNative', '-Pmicronaut.runtime=lambda')
+
+        def dockerfileNativeTask = result.task(':dockerfileNative')
+        def dockerFileNative = new File(testProjectDir.root, 'build/docker/native-main/DockerfileNative').readLines('UTF-8')
+
+        then:
+        dockerfileNativeTask.outcome == TaskOutcome.SUCCESS
+
+        and:
+        !dockerFileNative.find() { it.contains('-H:Class=io.micronaut.function.aws.runtime.MicronautLambdaRuntime')}
+        dockerFileNative.find() { it.contains('com.example.Application')}
     }
 
     void 'it is possible to define the mainclass for a dockerfile native'() {

--- a/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -1,14 +1,11 @@
 package io.micronaut.gradle.graalvm;
 
 import io.micronaut.gradle.MicronautExtension;
-import io.micronaut.gradle.MicronautRuntime;
-import io.micronaut.gradle.PluginsHelper;
 import org.graalvm.buildtools.gradle.NativeImagePlugin;
 import org.graalvm.buildtools.gradle.dsl.GraalVMExtension;
 import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.ListProperty;
@@ -27,7 +24,6 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -64,18 +60,6 @@ public class MicronautGraalPlugin implements Plugin<Project> {
         );
         project.getPluginManager().withPlugin("application", plugin -> {
             TaskContainer tasks = project.getTasks();
-            tasks.withType(BuildNativeImageTask.class).named("nativeCompile", nativeImageTask -> {
-                MicronautRuntime mr = PluginsHelper.resolveRuntime(project);
-                if (mr == MicronautRuntime.LAMBDA) {
-                    DependencySet implementation = project.getConfigurations().getByName("implementation").getDependencies();
-                    boolean isAwsApp = implementation.stream()
-                            .noneMatch(dependency -> Objects.equals(dependency.getGroup(), "io.micronaut.aws") && dependency.getName().equals("micronaut-function-aws"));
-
-                    if (isAwsApp) {
-                        nativeImageTask.getOptions().get().getMainClass().set("io.micronaut.function.aws.runtime.MicronautLambdaRuntime");
-                    }
-                }
-            });
 
             // We use `afterEvaluate` here in order to preserve laziness of task configuration
             // and because there is no API to allow reacting to registration of tasks.


### PR DESCRIPTION
Before this change, the class used to generate native lambdas was
always set to `MicronautLambdaRuntime`, independently of the fact
that the user declared a `mainClass` or not. With this change, the
main class defined by the user will _always_ be used. Only if no
main class is set, we will default to `MicronautLambdaRuntime`.

This will require changes to Micronaut Starter.