### PR TITLE
Fix docker plugin assuming graal plugin applied

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
@@ -94,7 +94,9 @@ public class MicronautDockerfile extends Dockerfile implements DockerBuildOption
                 }
                 break;
             case LAMBDA:
-                javaApplication.getMainClass().set(DEFAULT_LAMBDA_RUNTIME_CLASS);
+                if (!javaApplication.getMainClass().isPresent()) {
+                    javaApplication.getMainClass().set(DEFAULT_LAMBDA_RUNTIME_CLASS);
+                }
             default:
                 from(new Dockerfile.From(from != null ? from : "openjdk:17-alpine"));
                 setupResources(this);

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/FullMicronautRuntimeSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/FullMicronautRuntimeSpec.groovy
@@ -1,10 +1,10 @@
 package io.micronaut.gradle
 
-import io.micronaut.gradle.fixtures.AbstractFunctionalTest
+import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Unroll
 
-class FullMicronautRuntimeSpec extends AbstractFunctionalTest {
+class FullMicronautRuntimeSpec extends AbstractEagerConfiguringFunctionalTest {
 
     @Unroll
     def "test execute tests for application for runtime: #runtime"() {

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/AbstractAOTPluginSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/AbstractAOTPluginSpec.groovy
@@ -1,10 +1,10 @@
 package io.micronaut.gradle.aot
 
 import groovy.transform.CompileStatic
-import io.micronaut.gradle.fixtures.AbstractFunctionalTest
+import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
 
 @CompileStatic
-abstract class AbstractAOTPluginSpec extends AbstractFunctionalTest {
+abstract class AbstractAOTPluginSpec extends AbstractEagerConfiguringFunctionalTest {
     def setup() {
         withSample('aot/app-startup-fixture')
     }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/fixtures/AbstractEagerConfiguringFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/fixtures/AbstractEagerConfiguringFunctionalTest.groovy
@@ -1,0 +1,10 @@
+package io.micronaut.gradle.fixtures
+
+import org.gradle.testkit.runner.BuildResult
+
+class AbstractEagerConfiguringFunctionalTest extends AbstractFunctionalTest {
+    @Override
+    BuildResult build(String... args) {
+        return super.build("tasks", *args)
+    }
+}

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/graalvm/MicronautGraalPluginSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/graalvm/MicronautGraalPluginSpec.groovy
@@ -2,13 +2,13 @@ package io.micronaut.gradle.graalvm
 
 import groovy.json.JsonSlurper
 import io.micronaut.gradle.AbstractGradleBuildSpec
-import io.micronaut.gradle.fixtures.AbstractFunctionalTest
+import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Requires
 
 @Requires({ AbstractGradleBuildSpec.graalVmAvailable && !os.windows })
 @Requires({ jvm.isJava11Compatible() })
-class MicronautGraalPluginSpec extends AbstractFunctionalTest {
+class MicronautGraalPluginSpec extends AbstractEagerConfiguringFunctionalTest {
 
     void 'generate GraalVM resource-config.json with OpenAPI and resources included'() {
         given:

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
@@ -1,10 +1,10 @@
 package io.micronaut.gradle.kotlin
 
-import io.micronaut.gradle.fixtures.AbstractFunctionalTest
+import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.IgnoreIf
 
-class KotlinLibraryFunctionalTest extends AbstractFunctionalTest {
+class KotlinLibraryFunctionalTest extends AbstractEagerConfiguringFunctionalTest {
     @IgnoreIf({ jvm.java16Compatible }) // https://youtrack.jetbrains.com/issue/KT-45545
     def "test apply defaults for micronaut-library and kotlin with kotlin DSL"() {
         given:

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
@@ -1,7 +1,7 @@
 package io.micronaut.gradle.lambda
 
 import io.micronaut.gradle.AbstractGradleBuildSpec
-import io.micronaut.gradle.fixtures.AbstractFunctionalTest
+import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.IgnoreIf
 import spock.lang.Issue
@@ -10,7 +10,7 @@ import spock.lang.Requires
 @Requires({ AbstractGradleBuildSpec.graalVmAvailable })
 @IgnoreIf({ os.windows })
 @Requires({ jvm.isJava11Compatible() })
-class LambdaNativeImageSpec extends AbstractFunctionalTest {
+class LambdaNativeImageSpec extends AbstractEagerConfiguringFunctionalTest {
 
     void 'mainclass defaults to MicronautLambdaRuntime for an application deployed as GraalVM and Lambda'() {
         given:

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/shadow/ShadowJarSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/shadow/ShadowJarSpec.groovy
@@ -1,11 +1,11 @@
 package io.micronaut.gradle.shadow
 
-import io.micronaut.gradle.fixtures.AbstractFunctionalTest
+import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Issue
 import spock.lang.Unroll
 
-class ShadowJarSpec extends AbstractFunctionalTest {
+class ShadowJarSpec extends AbstractEagerConfiguringFunctionalTest {
 
     private static final String SHADE_VERSION = "7.1.2"
     private static final String MICRONAUT_VERSION = "3.4.0"


### PR DESCRIPTION
The Docker plugin was assuming that the GraalVM plugin was also
applied. However, this only happens if tasks are eagerly configured,
which is typically the case if you call `gradle tasks` or that
a plugin accidentally eagerly configures tasks.

Fixes #373