### PR TITLE
fix: Adds LAMBDA_JAVA and LAMBDA_PROVIDED runtimes

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
@@ -44,7 +44,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import static io.micronaut.gradle.MicronautRuntime.isLambdaProvided;
 import static io.micronaut.gradle.Strings.capitalize;
 import static org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME;
 
@@ -284,7 +283,7 @@ public class MicronautDockerPlugin implements Plugin<Project> {
 
         project.afterEvaluate(p -> {
             MicronautRuntime mr = PluginsHelper.resolveRuntime(p);
-            if (isLambdaProvided(mr)) {
+            if (mr.isLambdaProvided()) {
                 TaskContainer taskContainer = p.getTasks();
                 TaskProvider<DockerCreateContainer> createLambdaContainer = taskContainer.register(adaptTaskName("createLambdaContainer", imageName), DockerCreateContainer.class, task -> {
                     task.dependsOn(dockerBuildTask);

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import static io.micronaut.gradle.MicronautRuntime.isLambdaProvided;
 import static io.micronaut.gradle.Strings.capitalize;
 import static org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME;
 
@@ -283,7 +284,7 @@ public class MicronautDockerPlugin implements Plugin<Project> {
 
         project.afterEvaluate(p -> {
             MicronautRuntime mr = PluginsHelper.resolveRuntime(p);
-            if (mr == MicronautRuntime.LAMBDA) {
+            if (isLambdaProvided(mr)) {
                 TaskContainer taskContainer = p.getTasks();
                 TaskProvider<DockerCreateContainer> createLambdaContainer = taskContainer.register(adaptTaskName("createLambdaContainer", imageName), DockerCreateContainer.class, task -> {
                     task.dependsOn(dockerBuildTask);

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/RuntimeDependenciesSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/RuntimeDependenciesSpec.groovy
@@ -51,10 +51,16 @@ class RuntimeDependenciesSpec extends AbstractEagerConfiguringFunctionalTest {
         'oracle_function'      | 'compileClasspath'     || ["io.micronaut.oraclecloud:micronaut-oraclecloud-function-http"]
         'oracle_function'      | 'developmentOnly'      || ["io.micronaut.oraclecloud:micronaut-oraclecloud-function-http-test"]
         'oracle_function'      | 'testRuntimeClasspath' || ["io.micronaut.oraclecloud:micronaut-oraclecloud-function-http-test"]
-        'oracle_function'      | 'runtimeOnly'           || ["com.fnproject.fn:runtime"]
+        'oracle_function'      | 'runtimeOnly'          || ["com.fnproject.fn:runtime"]
+        'lambda_java'          | 'compileClasspath'     || ["io.micronaut.aws:micronaut-function-aws-api-proxy"]
+        'lambda_java'          | 'developmentOnly'      || ["io.micronaut.aws:micronaut-function-aws-api-proxy-test"]
+        'lambda_java'          | 'testRuntimeClasspath' || ["io.micronaut.aws:micronaut-function-aws-api-proxy-test"]
         'lambda'               | 'compileClasspath'     || ["io.micronaut.aws:micronaut-function-aws-api-proxy", "io.micronaut.aws:micronaut-function-aws-custom-runtime"]
         'lambda'               | 'developmentOnly'      || ["io.micronaut.aws:micronaut-function-aws-api-proxy-test"]
         'lambda'               | 'testRuntimeClasspath' || ["io.micronaut.aws:micronaut-function-aws-api-proxy-test"]
+        'lambda_provided'      | 'compileClasspath'     || ["io.micronaut.aws:micronaut-function-aws-api-proxy", "io.micronaut.aws:micronaut-function-aws-custom-runtime"]
+        'lambda_provided'      | 'developmentOnly'      || ["io.micronaut.aws:micronaut-function-aws-api-proxy-test"]
+        'lambda_provided'      | 'testRuntimeClasspath' || ["io.micronaut.aws:micronaut-function-aws-api-proxy-test"]
 
         description =  String.join(",", coordinates)
     }

--- a/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -31,6 +31,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static io.micronaut.gradle.MicronautRuntime.isLambdaProvided;
+
 /**
  * Support for building GraalVM native images.
  *
@@ -66,7 +68,7 @@ public class MicronautGraalPlugin implements Plugin<Project> {
             TaskContainer tasks = project.getTasks();
             tasks.withType(BuildNativeImageTask.class).named("nativeCompile", nativeImageTask -> {
                 MicronautRuntime mr = PluginsHelper.resolveRuntime(project);
-                if (mr == MicronautRuntime.LAMBDA) {
+                if (isLambdaProvided(mr)) {
                     DependencySet implementation = project.getConfigurations().getByName("implementation").getDependencies();
                     boolean isAwsApp = implementation.stream()
                             .noneMatch(dependency -> Objects.equals(dependency.getGroup(), "io.micronaut.aws") && dependency.getName().equals("micronaut-function-aws"));

--- a/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -31,8 +31,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static io.micronaut.gradle.MicronautRuntime.isLambdaProvided;
-
 /**
  * Support for building GraalVM native images.
  *
@@ -68,7 +66,7 @@ public class MicronautGraalPlugin implements Plugin<Project> {
             TaskContainer tasks = project.getTasks();
             tasks.withType(BuildNativeImageTask.class).named("nativeCompile", nativeImageTask -> {
                 MicronautRuntime mr = PluginsHelper.resolveRuntime(project);
-                if (isLambdaProvided(mr)) {
+                if (mr.isLambdaProvided()) {
                     DependencySet implementation = project.getConfigurations().getByName("implementation").getDependencies();
                     boolean isAwsApp = implementation.stream()
                             .noneMatch(dependency -> Objects.equals(dependency.getGroup(), "io.micronaut.aws") && dependency.getName().equals("micronaut-function-aws"));

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/Dependencies.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/Dependencies.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle;
+
+import org.gradle.api.plugins.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builder class to model build dependencies.
+ * @author Sergio del Amo
+ * @since 3.4.0
+ */
+public class Dependencies {
+    private static final String DEVELOPMENT_ONLY = "developmentOnly";
+
+    private final List<String> developmentOnlyDependencies;
+    private final List<String> implementationDependencies;
+    private final List<String> testImplementationDependencies;
+    private final List<String> runtimeOnlyDependencies;
+    private final List<String> compileOnlyDependencies;
+
+    private Dependencies(List<String> developmentOnlyDependencies,
+                        List<String> implementationDependencies,
+                        List<String> testImplementationDependencies,
+                         List<String> runtimeOnlyDependencies,
+                         List<String> compileOnlyDependencies) {
+        this.developmentOnlyDependencies = developmentOnlyDependencies;
+        this.implementationDependencies = implementationDependencies;
+        this.testImplementationDependencies = testImplementationDependencies;
+        this.runtimeOnlyDependencies = runtimeOnlyDependencies;
+        this.compileOnlyDependencies = compileOnlyDependencies;
+    }
+
+    public Map<String, List<String>> toMap() {
+        Map<String, List<String>> m = new HashMap<>();
+        if (isNotEmpty(developmentOnlyDependencies)) {
+            m.put(DEVELOPMENT_ONLY, developmentOnlyDependencies);
+        }
+        if (isNotEmpty(implementationDependencies)) {
+            m.put(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, implementationDependencies);
+        }
+        if (isNotEmpty(testImplementationDependencies)) {
+            m.put(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, testImplementationDependencies);
+        }
+        if (isNotEmpty(runtimeOnlyDependencies)) {
+            m.put(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, runtimeOnlyDependencies);
+        }
+        if (isNotEmpty(compileOnlyDependencies)) {
+            m.put(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, compileOnlyDependencies);
+        }
+        return m;
+    }
+
+    private static boolean isNotEmpty(Collection<String> col) {
+        return col != null && !col.isEmpty();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final List<String> developmentOnlyDependencies = new ArrayList<>();
+        private final List<String> implementationDependencies = new ArrayList<>();
+        private final List<String> testImplementationDependencies = new ArrayList<>();
+        private final List<String> runtimeOnlyDependencies = new ArrayList<>();
+        private final List<String> compileOnlyDependencies = new ArrayList<>();
+
+        public Builder compileOnly(String coordinate) {
+            this.compileOnlyDependencies.add(coordinate);
+            return this;
+        }
+
+        public Builder runtimeOnly(String coordinate) {
+            this. runtimeOnlyDependencies.add(coordinate);
+            return this;
+        }
+
+        public Builder developmentOnly(String coordinate) {
+            this.developmentOnlyDependencies.add(coordinate);
+            return this;
+        }
+
+        public Builder implementation(String coordinate) {
+            this.implementationDependencies.add(coordinate);
+            return this;
+        }
+
+        public Builder testImplementation(String coordinate) {
+            this.testImplementationDependencies.add(coordinate);
+            return this;
+        }
+
+        public Dependencies build() {
+            return new Dependencies(developmentOnlyDependencies,
+                    implementationDependencies,
+                    testImplementationDependencies,
+                    runtimeOnlyDependencies,
+                    compileOnlyDependencies);
+        }
+    }
+}

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/Dependencies.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/Dependencies.java
@@ -19,7 +19,7 @@ import org.gradle.api.plugins.JavaPlugin;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -50,7 +50,7 @@ public class Dependencies {
     }
 
     public Map<String, List<String>> toMap() {
-        Map<String, List<String>> m = new HashMap<>();
+        Map<String, List<String>> m = new LinkedHashMap<>();
         if (isNotEmpty(developmentOnlyDependencies)) {
             m.put(DEVELOPMENT_ONLY, developmentOnlyDependencies);
         }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
@@ -160,7 +160,9 @@ public class MicronautMinimalApplicationPlugin implements Plugin<Project> {
         project.afterEvaluate(p -> {
             MicronautRuntime micronautRuntime = resolveRuntime(p);
             DependencyHandler dependencyHandler = p.getDependencies();
-            micronautRuntime.getDependencies().forEach((scope, dependencies) -> {
+            MicronautRuntimeDependencies.findApplicationPluginDependenciesByRuntime(micronautRuntime)
+                    .toMap()
+                    .forEach((scope, dependencies) -> {
                 for (String dependency : dependencies) {
                     dependencyHandler.add(scope, dependency);
                 }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntime.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntime.java
@@ -1,12 +1,6 @@
 package io.micronaut.gradle;
 
 import io.micronaut.gradle.docker.DockerBuildStrategy;
-import org.gradle.api.plugins.JavaPlugin;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 /**
  * The packaging kind of the application.
@@ -22,92 +16,58 @@ public enum MicronautRuntime {
     /**
      * Default packaging.
      */
-    NETTY("io.micronaut:micronaut-http-server-netty"),
+    NETTY,
     /**
      * Tomcat server.
      */
-    TOMCAT("io.micronaut.servlet:micronaut-http-server-tomcat"),
+    TOMCAT,
     /**
      * Jetty server.
      */
-    JETTY("io.micronaut.servlet:micronaut-http-server-jetty"),
+    JETTY,
     /**
      * Undertow server.
      */
-    UNDERTOW("io.micronaut.servlet:micronaut-http-server-undertow"),
+    UNDERTOW,
+
     /**
-     * AWS lambda packaged as a Jar file.
+     * AWS lambda packaged as a Jar file and deploy to a Java runtime.
      */
-    LAMBDA(DockerBuildStrategy.LAMBDA, MicronautExtension.mapOf(
-            JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME,
-            Arrays.asList("io.micronaut.aws:micronaut-function-aws-api-proxy", "io.micronaut.aws:micronaut-function-aws-custom-runtime"),
-            "developmentOnly",
-            Collections.singletonList("io.micronaut.aws:micronaut-function-aws-api-proxy-test"),
-            JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME,
-            Collections.singletonList("io.micronaut.aws:micronaut-function-aws-api-proxy-test")
-    )),
+    LAMBDA_JAVA,
+
+    /**
+     * AWS lambda deployed to a Provided runtime.
+     * @deprecated Use {@link #LAMBDA_PROVIDED} instead.
+     */
+    @Deprecated
+    LAMBDA(DockerBuildStrategy.LAMBDA),
+
+    /**
+     * AWS lambda deployed to a Provided runtime.
+     */
+    LAMBDA_PROVIDED(DockerBuildStrategy.LAMBDA),
+
     /**
      * Oracle Cloud Function, packaged as a docker container.
      */
-    ORACLE_FUNCTION(DockerBuildStrategy.ORACLE_FUNCTION, MicronautExtension.mapOf(
-            JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME,
-            Collections.singletonList("io.micronaut.oraclecloud:micronaut-oraclecloud-function-http"),
-            JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME,
-            Collections.singletonList("io.micronaut.oraclecloud:micronaut-oraclecloud-function-http-test"),
-            "developmentOnly",
-            Collections.singletonList("io.micronaut.oraclecloud:micronaut-oraclecloud-function-http-test"),
-            JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME,
-            Collections.singletonList("com.fnproject.fn:runtime")
-    )),
+    ORACLE_FUNCTION(DockerBuildStrategy.ORACLE_FUNCTION),
     /**
      * Google Cloud Function, packaged as a Fat JAR.
      */
-    GOOGLE_FUNCTION(MicronautExtension.mapOf(
-            JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME,
-            Collections.singletonList("io.micronaut.gcp:micronaut-gcp-function-http"),
-            "developmentOnly",
-            Arrays.asList("com.google.cloud.functions:functions-framework-api", "io.micronaut.gcp:micronaut-gcp-function-http-test"),
-            JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME,
-            Collections.singletonList("com.google.cloud.functions:functions-framework-api"),
-            JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME,
-            Arrays.asList("com.google.cloud.functions:functions-framework-api", "io.micronaut.gcp:micronaut-gcp-function-http-test")
-    )),
+    GOOGLE_FUNCTION,
     /**
      * Azure Cloud Function.
      */
-    AZURE_FUNCTION(MicronautExtension.mapOf(
-            JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME,
-            Arrays.asList("io.micronaut.azure:micronaut-azure-function-http", "com.microsoft.azure.functions:azure-functions-java-library"),
-            "developmentOnly",
-            Collections.singletonList("io.micronaut.azure:micronaut-azure-function-http-test"),
-            JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME,
-            Collections.singletonList("io.micronaut.azure:micronaut-azure-function-http-test")
-    ));
+    AZURE_FUNCTION;
 
-    private final Map<String, List<String>> implementation;
     private final DockerBuildStrategy buildStrategy;
 
-    MicronautRuntime(String... dependencies) {
-        this.implementation = Collections.singletonMap(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, Arrays.asList(dependencies));
+    MicronautRuntime() {
         this.buildStrategy = DockerBuildStrategy.DEFAULT;
     }
 
-    MicronautRuntime(Map<String, List<String>> implementation) {
-        this.implementation = implementation;
-        this.buildStrategy = DockerBuildStrategy.DEFAULT;
-    }
-
-    MicronautRuntime(DockerBuildStrategy buildStrategy, Map<String, List<String>> implementation) {
-        this.implementation = implementation;
+    MicronautRuntime(DockerBuildStrategy buildStrategy) {
         this.buildStrategy = buildStrategy;
-    }
-
-    /**
-     * A map of dependencies and scopes
-     * @return The dependencies and scopes
-     */
-    public Map<String, List<String>> getDependencies() {
-        return implementation;
     }
 
     /**
@@ -116,4 +76,9 @@ public enum MicronautRuntime {
     public DockerBuildStrategy getBuildStrategy() {
         return buildStrategy;
     }
+
+    public static boolean isLambdaProvided(MicronautRuntime runtime) {
+        return runtime == LAMBDA_PROVIDED || runtime == LAMBDA;
+    }
+
 }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntime.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntime.java
@@ -77,8 +77,8 @@ public enum MicronautRuntime {
         return buildStrategy;
     }
 
-    public static boolean isLambdaProvided(MicronautRuntime runtime) {
-        return runtime == LAMBDA_PROVIDED || runtime == LAMBDA;
+    public boolean isLambdaProvided() {
+        return this == LAMBDA_PROVIDED || this == LAMBDA;
     }
 
 }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntime.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntime.java
@@ -77,6 +77,9 @@ public enum MicronautRuntime {
         return buildStrategy;
     }
 
+    public boolean isLambda() {
+        return this == LAMBDA_JAVA || isLambdaProvided();
+    }
     public boolean isLambdaProvided() {
         return this == LAMBDA_PROVIDED || this == LAMBDA;
     }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntimeDependencies.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntimeDependencies.java
@@ -60,12 +60,12 @@ public final class MicronautRuntimeDependencies {
      * @return The dependencies and scopes
      */
     public static Dependencies findApplicationPluginDependenciesByRuntime(MicronautRuntime runtime) {
-        if (runtime == LAMBDA_JAVA || isLambdaProvided(runtime)) {
+        if (runtime == LAMBDA_JAVA || runtime.isLambdaProvided()) {
             Dependencies.Builder builder = Dependencies.builder()
                     .implementation(micronautAwsDependency(ARTIFACT_ID_MICRONAUT_AWS_API_PROXY))
                     .developmentOnly(micronautAwsDependency(ARTIFACT_ID_MICRONAUT_AWS_API_PROXY_TEST))
                     .testImplementation(micronautAwsDependency(ARTIFACT_ID_MICRONAUT_AWS_API_PROXY_TEST));
-            if (isLambdaProvided(runtime)) {
+            if (runtime.isLambdaProvided()) {
                 builder = builder.implementation(micronautAwsDependency(ARTIFACT_ID_MICRONAUT_AWS_CUSTOM_RUNTIME));
             }
             return builder.build();

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntimeDependencies.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntimeDependencies.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle;
+
+import static io.micronaut.gradle.MicronautRuntime.*;
+
+/**
+ * Resolves the dependencies for the current runtime and application type
+ * @author Sergio del Amo
+ * @since 3.4.0
+ */
+public final class MicronautRuntimeDependencies {
+
+    private static final String GROUP_MICRONAUT = "io.micronaut";
+    private static final String ARTIFACT_ID_MICRONAUT_SERVER_NETTY = "micronaut-http-server-netty";
+    private static final String GROUP_MICRONAUT_SERVLET = "io.micronaut.servlet";
+    private static final String GROUP_MICRONAUT_AWS = "io.micronaut.aws";
+    private static final String GROUP_MICRONAUT_GCP = "io.micronaut.gcp";
+    private static final String GROUP_GOOGLE_CLOUD_FUNCTIONS = "com.google.cloud.functions";
+    private static final String ARTIFACT_ID_FUNCTIONS_FRAMEWORK_API = "functions-framework-api";
+
+    private static final String GROUP_MICRONAUT_ORACLE = "io.micronaut.oraclecloud";
+    private static final String ARTIFACT_ID_MICRONAUT_ORACLE_HTTP = "micronaut-oraclecloud-function-http";
+    private static final String ARTIFACT_ID_MICRONAUT_ORACLE_HTTP_TEST = "micronaut-oraclecloud-function-http-test";
+
+    private static final String ARTIFACT_ID_MICRONAUT_GCP_FUNCTION_HTTP = "micronaut-gcp-function-http";
+    private static final String ARTIFACT_ID_MICRONAUT_GCP_FUNCTION_HTTP_TEST = "micronaut-gcp-function-http-test";
+
+    private static final String GROUP_MICRONAUT_AZURE = "io.micronaut.azure";
+    private static final String ARTIFACT_ID_MICRONAUT_AZURE_FUNCTION_HTTP = "micronaut-azure-function-http";
+    private static final String ARTIFACT_ID_MICRONAUT_AZURE_FUNCTION_HTTP_TEST = "micronaut-azure-function-http-test";
+
+    private static final String ARTIFACT_ID_MICRONAUT_AWS_CUSTOM_RUNTIME = "micronaut-function-aws-custom-runtime";
+    private static final String ARTIFACT_ID_MICRONAUT_AWS_API_PROXY = "micronaut-function-aws-api-proxy";
+    private static final String ARTIFACT_ID_MICRONAUT_AWS_API_PROXY_TEST = "micronaut-function-aws-api-proxy-test";
+
+    private static final String ARTIFACT_ID_MICRONAUT_SERVLET_JETTY = "micronaut-http-server-jetty";
+    private static final String ARTIFACT_ID_MICRONAUT_SERVLET_TOMCAT = "micronaut-http-server-tomcat";
+    private static final String ARTIFACT_ID_MICRONAUT_SERVLET_UNDERTOW = "micronaut-http-server-undertow";
+    private static final String COLON = ":";
+
+    private MicronautRuntimeDependencies() {
+    }
+
+    /**
+     * @param runtime Micronaut runtime
+     * @return The dependencies and scopes
+     */
+    public static Dependencies findApplicationPluginDependenciesByRuntime(MicronautRuntime runtime) {
+        if (runtime == LAMBDA_JAVA || isLambdaProvided(runtime)) {
+            Dependencies.Builder builder = Dependencies.builder()
+                    .implementation(micronautAwsDependency(ARTIFACT_ID_MICRONAUT_AWS_API_PROXY))
+                    .developmentOnly(micronautAwsDependency(ARTIFACT_ID_MICRONAUT_AWS_API_PROXY_TEST))
+                    .testImplementation(micronautAwsDependency(ARTIFACT_ID_MICRONAUT_AWS_API_PROXY_TEST));
+            if (isLambdaProvided(runtime)) {
+                builder = builder.implementation(micronautAwsDependency(ARTIFACT_ID_MICRONAUT_AWS_CUSTOM_RUNTIME));
+            }
+            return builder.build();
+
+        } else if(runtime == MicronautRuntime.ORACLE_FUNCTION) {
+            return Dependencies.builder()
+                    .implementation(micronautOracleDependency(ARTIFACT_ID_MICRONAUT_ORACLE_HTTP))
+                    .testImplementation(micronautOracleDependency(ARTIFACT_ID_MICRONAUT_ORACLE_HTTP_TEST))
+                    .developmentOnly(micronautOracleDependency(ARTIFACT_ID_MICRONAUT_ORACLE_HTTP_TEST))
+                    .runtimeOnly("com.fnproject.fn:runtime")
+                    .build();
+        } else if(runtime == MicronautRuntime.GOOGLE_FUNCTION) {
+            return Dependencies.builder()
+                    .implementation(micronautGcpDependency(ARTIFACT_ID_MICRONAUT_GCP_FUNCTION_HTTP))
+                    .developmentOnly(dependency(GROUP_GOOGLE_CLOUD_FUNCTIONS, ARTIFACT_ID_FUNCTIONS_FRAMEWORK_API))
+                    .developmentOnly(micronautGcpDependency(ARTIFACT_ID_MICRONAUT_GCP_FUNCTION_HTTP_TEST))
+                    .compileOnly(dependency(GROUP_GOOGLE_CLOUD_FUNCTIONS, ARTIFACT_ID_FUNCTIONS_FRAMEWORK_API))
+                    .testImplementation(dependency(GROUP_GOOGLE_CLOUD_FUNCTIONS, ARTIFACT_ID_FUNCTIONS_FRAMEWORK_API))
+                    .testImplementation(micronautGcpDependency(ARTIFACT_ID_MICRONAUT_GCP_FUNCTION_HTTP_TEST))
+                    .build();
+        } else if (runtime == MicronautRuntime.AZURE_FUNCTION) {
+            return Dependencies.builder()
+                    .implementation(micronautAzureDependency(ARTIFACT_ID_MICRONAUT_AZURE_FUNCTION_HTTP))
+                    .implementation("com.microsoft.azure.functions:azure-functions-java-library")
+                    .developmentOnly(micronautAzureDependency(ARTIFACT_ID_MICRONAUT_AZURE_FUNCTION_HTTP_TEST))
+                    .testImplementation(micronautAzureDependency(ARTIFACT_ID_MICRONAUT_AZURE_FUNCTION_HTTP_TEST))
+                    .build();
+
+        } else if (runtime == NETTY) {
+            return Dependencies.builder().implementation(dependency(GROUP_MICRONAUT, ARTIFACT_ID_MICRONAUT_SERVER_NETTY)).build();
+
+        } else if (runtime == TOMCAT) {
+            return Dependencies.builder().implementation(micronautServletDependency(ARTIFACT_ID_MICRONAUT_SERVLET_TOMCAT)).build();
+
+        } else if (runtime == JETTY) {
+            return Dependencies.builder().implementation(micronautServletDependency(ARTIFACT_ID_MICRONAUT_SERVLET_JETTY)).build();
+
+        } else if (runtime == UNDERTOW) {
+            return Dependencies.builder().implementation(micronautServletDependency(ARTIFACT_ID_MICRONAUT_SERVLET_UNDERTOW)).build();
+        }
+        return Dependencies.builder().build();
+    }
+
+    private static String micronautOracleDependency(String artifactId) {
+        return dependency(GROUP_MICRONAUT_ORACLE, artifactId);
+    }
+
+    private static String micronautAwsDependency(String artifactId) {
+        return dependency(GROUP_MICRONAUT_AWS, artifactId);
+    }
+
+    private static String micronautGcpDependency(String artifactId) {
+        return dependency(GROUP_MICRONAUT_GCP, artifactId);
+    }
+
+    private static String micronautAzureDependency(String artifactId) {
+        return dependency(GROUP_MICRONAUT_AZURE, artifactId);
+    }
+
+    private static String micronautServletDependency(String artifactId) {
+        return dependency(GROUP_MICRONAUT_SERVLET, artifactId);
+    }
+
+    private static String dependency(String groupId, String artifactId) {
+        return String.join(COLON, groupId, artifactId);
+    }
+
+}

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntimeDependencies.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntimeDependencies.java
@@ -62,7 +62,7 @@ public final class MicronautRuntimeDependencies {
      * @return The dependencies and scopes
      */
     public static Dependencies findApplicationPluginDependenciesByRuntime(MicronautRuntime runtime) {
-        if (runtime == LAMBDA_JAVA || runtime.isLambdaProvided()) {
+        if (runtime.isLambda()) {
             Dependencies.Builder builder = Dependencies.builder()
                     .implementation(micronautAwsDependency(ARTIFACT_ID_MICRONAUT_AWS_API_PROXY))
                     .developmentOnly(micronautAwsDependency(ARTIFACT_ID_MICRONAUT_AWS_API_PROXY_TEST))

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntimeDependencies.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntimeDependencies.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.gradle;
 
+import org.gradle.api.GradleException;
+
 import static io.micronaut.gradle.MicronautRuntime.*;
 
 /**
@@ -105,6 +107,8 @@ public final class MicronautRuntimeDependencies {
 
         } else if (runtime == UNDERTOW) {
             return Dependencies.builder().implementation(micronautServletDependency(ARTIFACT_ID_MICRONAUT_SERVLET_UNDERTOW)).build();
+        } else if (runtime != NONE) {
+            throw new GradleException("Application plugin dependencies not specified for runtime " + runtime.name());
         }
         return Dependencies.builder().build();
     }


### PR DESCRIPTION
Fixes: https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/433

Adds two Micronaut runtime environments:

- LAMBDA_JAVA
- LAMBDA_PROVIDED

This matches the Lambda Runtime names:

https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-lambda.Runtime.html

```
static JAVA_11
static JAVA_8
static JAVA_8_CORRETTO
static PROVIDED
static PROVIDED_AL2
```

This allows to differentiate easily the dependencies to include automatically.