### PR TITLE
Use `api` dependencies between plugins

### DIFF
--- a/aot-plugin/build.gradle
+++ b/aot-plugin/build.gradle
@@ -10,9 +10,9 @@ micronautPlugins {
 }
 
 dependencies {
-    implementation project(":micronaut-minimal-plugin")
-    implementation project(":micronaut-docker-plugin")
-    implementation project(":micronaut-graalvm-plugin")
+    api project(":micronaut-minimal-plugin")
+    api project(":micronaut-docker-plugin")
+    api project(":micronaut-graalvm-plugin")
     implementation libs.micronaut.aot.api
     implementation libs.micronaut.aot.core
     implementation libs.micronaut.aot.std

--- a/docker-plugin/build.gradle
+++ b/docker-plugin/build.gradle
@@ -9,7 +9,7 @@ micronautPlugins {
 }
 
 dependencies {
-    implementation project(":micronaut-minimal-plugin")
+    api project(":micronaut-minimal-plugin")
     implementation libs.dockerPlug
 
     compileOnly libs.graalvmPlugin

--- a/graalvm-plugin/build.gradle
+++ b/graalvm-plugin/build.gradle
@@ -9,7 +9,7 @@ micronautPlugins {
 }
 
 dependencies {
-    implementation project(":micronaut-minimal-plugin")
+    api project(":micronaut-minimal-plugin")
     implementation libs.graalvmPlugin
     testImplementation testFixtures(project(":micronaut-minimal-plugin"))
 }

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -15,10 +15,10 @@ dependencies {
             because("Log4j2 <2.15 is vulnerable to RCE (CVE-2021-44228)")
         }
     }
-    implementation project(":micronaut-minimal-plugin")
-    implementation project(":micronaut-docker-plugin")
-    implementation project(":micronaut-graalvm-plugin")
-    implementation project(":micronaut-aot-plugin")
+    api project(":micronaut-minimal-plugin")
+    api project(":micronaut-docker-plugin")
+    api project(":micronaut-graalvm-plugin")
+    api project(":micronaut-aot-plugin")
 
     implementation libs.diffplugPlugin
 


### PR DESCRIPTION
This introduces `api` dependencies between plugins, instead of
`implementation`, so that the transitive Micronaut Gradle plugins
are on classpath when used in `buildSrc` or included builds.

Fixes #438