### PR TITLE
Upgrade to Micronaut AOT 1.1.0

### DIFF
--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/AOTOptimizations.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/AOTOptimizations.java
@@ -15,10 +15,13 @@
  */
 package io.micronaut.gradle.aot;
 
+import org.gradle.api.Action;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 
 /**
@@ -135,4 +138,27 @@ public interface AOTOptimizations {
     @Input
     @Optional
     MapProperty<String, String> getEnvironmentVariables();
+
+    /**
+     * Returns the Netty optimizations
+     * @return the netty optimizations
+     */
+    @Nested
+    NettyOptimizations getNettyOptimizations();
+
+    /**
+     * Configures the Netty optimizations
+     */
+    default void netty(Action<? super NettyOptimizations> configuration) {
+        configuration.execute(getNettyOptimizations());
+    }
+
+    /**
+     * A short-hand notation to enable Netty optimizations
+     * @return the netty optimizations property
+     */
+    @Internal
+    default Property<Boolean> getOptimizeNetty() {
+        return getNettyOptimizations().getEnabled();
+    }
 }

--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAOTConfigWriterTask.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAOTConfigWriterTask.java
@@ -26,6 +26,7 @@ import io.micronaut.aot.std.sourcegen.JitStaticServiceLoaderSourceGenerator;
 import io.micronaut.aot.std.sourcegen.KnownMissingTypesSourceGenerator;
 import io.micronaut.aot.std.sourcegen.LogbackConfigurationSourceGenerator;
 import io.micronaut.aot.std.sourcegen.NativeStaticServiceLoaderSourceGenerator;
+import io.micronaut.aot.std.sourcegen.NettyPropertiesSourceGenerator;
 import io.micronaut.aot.std.sourcegen.PublishersSourceGenerator;
 import io.micronaut.aot.std.sourcegen.YamlPropertySourceGenerator;
 import org.gradle.api.DefaultTask;
@@ -90,6 +91,11 @@ public abstract class MicronautAOTConfigWriterTask extends DefaultTask {
             }
         }
     }
+    private static void stringParameter(Properties props, String parameter, Property<String> provider) {
+        if (provider.isPresent()) {
+            props.put(parameter, provider.get());
+        }
+    }
 
     @TaskAction
     void writeConfigFile() {
@@ -129,6 +135,11 @@ public abstract class MicronautAOTConfigWriterTask extends DefaultTask {
         booleanOptimization(props, DeduceEnvironmentSourceGenerator.ID, optimizations.getDeduceEnvironment());
         stringListParameter(props, Environments.POSSIBLE_ENVIRONMENTS_NAMES, optimizations.getPossibleEnvironments());
         stringListParameter(props, Environments.TARGET_ENVIRONMENTS_NAMES, optimizations.getTargetEnvironments());
+        booleanOptimization(props, NettyPropertiesSourceGenerator.ID, optimizations.getOptimizeNetty());
+        if (optimizations.getOptimizeNetty().isPresent() && optimizations.getOptimizeNetty().get()) {
+            stringParameter(props, NettyPropertiesSourceGenerator.MACHINE_ID, optimizations.getNettyOptimizations().getMachineId());
+            stringParameter(props, NettyPropertiesSourceGenerator.PROCESS_ID, optimizations.getNettyOptimizations().getPid());
+        }
         File outputFile = getOutputFile().getAsFile().get();
         if (outputFile.getParentFile().isDirectory() || outputFile.getParentFile().mkdirs()) {
             try (OutputStream out = new FileOutputStream(outputFile)) {

--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -142,6 +142,7 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
                 return "io.micronaut.aot.generated";
             }
         }));
+        aotExtension.getOptimizeNetty().convention(false);
     }
 
     private void registerPrepareOptimizationsTasks(Project project, Configurations configurations, AOTExtension aotExtension) {

--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/NettyOptimizations.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/NettyOptimizations.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle.aot;
+
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+
+public interface NettyOptimizations {
+    /**
+     * Determines if Netty optimizations are enabled.
+     * @return the enabled property
+     */
+    @Input
+    Property<Boolean> getEnabled();
+
+    /**
+     * If Netty optimizations are optimized, you can set
+     * this property to a fixed machine ID instead of Micronaut AOT
+     * computing a random ID at runtime (not recommended).
+     * If you set the value to "netty", then Netty will determine
+     * the machine id at runtime, effectively disabling this optimization.
+     * @return the machine ID
+     */
+    @Input
+    @Optional
+    Property<String> getMachineId();
+
+    /**
+     * If Netty optimizations are optimized, you can set
+     * this property to a fixed PID instead of Micronaut AOT
+     * computing a random ID at runtime (not recommended).
+     * If you set the value to "netty", then Netty will determine
+     * the PID at runtime, effectively disabling this optimization.
+     * @return the machine ID
+     */
+    @Input
+    @Optional
+    Property<String> getPid();
+
+}

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
@@ -27,6 +27,7 @@ class BasicMicronautAOTSpec extends AbstractAOTPluginSpec {
             withProperty('sealed.property.source.enabled', 'true')
             withProperty('precompute.environment.properties.enabled', 'true')
             withProperty('deduce.environment.enabled', 'true')
+            withProperty('netty.properties.enabled', 'true')
             withExtraPropertyKeys 'service.types', 'known.missing.types.list'
         }
 
@@ -89,6 +90,7 @@ class BasicMicronautAOTSpec extends AbstractAOTPluginSpec {
             withProperty('precompute.environment.properties.enabled', 'true')
             withProperty('deduce.environment.enabled', 'true')
             withProperty('some.plugin.enabled', 'true')
+            withProperty('netty.properties.enabled', 'true')
             withExtraPropertyKeys 'service.types', 'known.missing.types.list'
         }
 

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/FunctionsMicronautAOTSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/FunctionsMicronautAOTSpec.groovy
@@ -28,6 +28,7 @@ class FunctionsMicronautAOTSpec extends AbstractAOTPluginSpec {
             withProperty('sealed.property.source.enabled', 'true')
             withProperty('precompute.environment.properties.enabled', 'true')
             withProperty('deduce.environment.enabled', 'false')
+            withProperty('netty.properties.enabled', 'false')
             withExtraPropertyKeys 'service.types', 'known.missing.types.list'
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ groovy = "3.0.9"
 spock = "2.0-groovy-3.0"
 graalvmPlugin = "0.9.11"
 micronaut = "3.2.0"
-micronaut-aot = "1.0.3"
+micronaut-aot = "1.1.0"
 log4j2 = { require = "2.17.1", reject = ["]0, 2.17["] }
 
 [libraries]

--- a/samples/aot/basic-app/build.gradle
+++ b/samples/aot/basic-app/build.gradle
@@ -26,6 +26,7 @@ micronaut {
         convertYamlToJava = true
         precomputeOperations = true
         deduceEnvironment = true
+        optimizeNetty = true
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '5.3.2'
+    id 'io.micronaut.build.shared.settings' version '5.3.3'
 }
 
 rootProject.name = 'micronaut-gradle-plugin-parent'

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -954,6 +954,9 @@ micronaut {
         convertYamlToJava = true
         precomputeOperations = true
         cacheEnvironment = true
+        netty {
+            enabled = true
+        }
     }
 }
 ----
@@ -971,6 +974,9 @@ micronaut {
         convertYamlToJava.set(true)
         precomputeOperations.set(true)
         cacheEnvironment.set(true)
+        netty {
+            enabled.set(true)
+        }
     }
 }
 ----


### PR DESCRIPTION
This commit bumps Micronaut AOT to version 1.1.0, which adds a new
optimization for Netty. This optimization is disabled by default like
the others (`starter` can enable it). Because it's likely that they
will be more Netty optimizations in the future, there's a `netty`
configuration block within the `aot` one.