### PR TITLE
Pull GraalVM JDK based on system architecture

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -856,6 +856,9 @@ The advantage of allowing your dependencies to be dictated by the runtime is tha
 If you are interested in deploying your Micronaut application to AWS Lambda using GraalVM you only need to set the runtime to `lambda` and execute `./gradlew buildNativeLambda`.
 This task will generate a GraalVM native image inside a Docker container and then it will create the file `build/libs/your-app.zip` file ready to be deployed to AWS Lambda using a custom runtime. See more information in {aws-docs}[Micronaut AWS documentation].
 
+The plugin will detect the host operating system architecture (based on the `os.arch` Java system property) and will install the corresponding GraalVM  binary distribution inside the Docker image.
+This means that when running packaging from an X86_64 (Intel/AMD) machine, the produced native image will be an `amd64` binary, whilst on an ARM host (such as the new Mac M1) it will be an `aarch64` binary.
+
 === Packaging the application
 
 By default the plugin doesn't create a runnable fatjar when running `./gradlew assemble`.

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -859,6 +859,15 @@ This task will generate a GraalVM native image inside a Docker container and the
 The plugin will detect the host operating system architecture (based on the `os.arch` Java system property) and will install the corresponding GraalVM  binary distribution inside the Docker image.
 This means that when running packaging from an X86_64 (Intel/AMD) machine, the produced native image will be an `amd64` binary, whilst on an ARM host (such as the new Mac M1) it will be an `aarch64` binary.
 
+To override this automatic selection, you can configure the `graalArch` property in a `dockerfileNative` configuration block in your build:
+
+[source, groovy]
+----
+dockerfileNative {
+    graalArch.set("amd64")
+}
+----
+
 === Packaging the application
 
 By default the plugin doesn't create a runnable fatjar when running `./gradlew assemble`.


### PR DESCRIPTION
When a user builds a native lambda via docker, docker first pulls amazonlinux:latest

If they are on an M1, docker will pull the ARM version of amazonlinux, then later on
in the dockerfile, it will cURL and unzip the X86 version of GraalVM.

This then fails when it tries to install native-image

This fix allows us to specify an architecture of GraalVM to pull, which defaults to
that of the current system.

It effectively mirrors this change made in the maven plugin for the same issue:

https://github.com/micronaut-projects/micronaut-maven-plugin/pull/369