### PR TITLE
Use Oracle Linux 7

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -331,7 +331,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
     }
 
     private static String toGraalVMBaseImageName(String graalVersion, String jdkVersion) {
-        return "ghcr.io/graalvm/native-image:ol8-" + jdkVersion + '-' + graalVersion;
+        return "ghcr.io/graalvm/native-image:ol7-" + jdkVersion + '-' + graalVersion;
     }
 
     private static int toSupportedJavaVersion(int version) {

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -74,7 +74,7 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
         result.task(":optimizedDockerBuildNative").outcome == TaskOutcome.SUCCESS
 
         def dockerFile = normalizeLineEndings(file("build/docker/native-optimized/DockerfileNative").text)
-        dockerFile == """FROM ghcr.io/graalvm/native-image:ol8-java11-22.1.0 AS graalvm
+        dockerFile == """FROM ghcr.io/graalvm/native-image:ol7-java11-22.1.0 AS graalvm
 WORKDIR /home/app
 COPY layers/libs /home/app/libs
 COPY layers/classes /home/app/classes

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -94,9 +94,9 @@ micronaut:
 
         where:
         runtime  | nativeImage
-        "netty"  | 'FROM ghcr.io/graalvm/native-image:ol8-java'
+        "netty"  | 'FROM ghcr.io/graalvm/native-image:ol7-java'
         "lambda" | 'FROM amazonlinux:latest AS graalvm'
-        "jetty"  | 'FROM ghcr.io/graalvm/native-image:ol8-java'
+        "jetty"  | 'FROM ghcr.io/graalvm/native-image:ol7-java'
     }
 
     void 'build mostly static native images when using distroless docker image for runtime=#runtime'() {
@@ -484,9 +484,9 @@ class Application {
 
         where:
         runtime  | nativeImage
-        "netty"  | 'FROM ghcr.io/graalvm/native-image:ol8-java'
+        "netty"  | 'FROM ghcr.io/graalvm/native-image:ol7-java'
         "lambda" | 'FROM amazonlinux:latest AS graalvm'
-        "jetty"  | 'FROM ghcr.io/graalvm/native-image:ol8-java'
+        "jetty"  | 'FROM ghcr.io/graalvm/native-image:ol7-java'
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/402")
@@ -565,7 +565,7 @@ micronaut:
         expect:
         task.outcome == TaskOutcome.SUCCESS
         dockerFile == """
-FROM ghcr.io/graalvm/native-image:ol8-java11-22.1.0 AS graalvm
+FROM ghcr.io/graalvm/native-image:ol7-java11-22.1.0 AS graalvm
 WORKDIR /home/alternate
 COPY layers/libs /home/alternate/libs
 COPY layers/classes /home/alternate/classes


### PR DESCRIPTION
This commit switches from Oracle Linux 7 to Oracle Linux 8 as a base
image for GraalVM: a bug in Oracle Linux 8 prevents zips from unzipping
correctly.

Relates to https://github.com/micronaut-projects/micronaut-starter/pull/1271