### PR TITLE
Add Kotest5 as a testRuntime

### DIFF
--- a/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/Kotest5FunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/Kotest5FunctionalTest.groovy
@@ -1,0 +1,87 @@
+package io.micronaut.gradle.kotlin
+
+import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
+import org.gradle.testkit.runner.TaskOutcome
+
+class Kotest5FunctionalTest extends AbstractEagerConfiguringFunctionalTest {
+    def "test kotest 5 test runtime with #plugin"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """plugins {
+                       |    id("org.jetbrains.kotlin.jvm") version "1.6.21"
+                       |    id("org.jetbrains.kotlin.kapt") version "1.6.21"
+                       |    id("org.jetbrains.kotlin.plugin.allopen") version "1.6.21"
+                       |    $plugin
+                       |}
+                       |
+                       |tasks {
+                       |    compileKotlin {
+                       |        kotlinOptions {
+                       |            jvmTarget = "11"
+                       |        }
+                       |    }
+                       |    compileTestKotlin {
+                       |        kotlinOptions {
+                       |            jvmTarget = "11"
+                       |        }
+                       |    }
+                       |}
+                       |
+                       |micronaut {
+                       |    version "3.5.1"
+                       |    runtime "netty"
+                       |    testRuntime "kotest5"
+                       |}
+                       |
+                       |dependencies {
+                       |    implementation("io.micronaut.kotlin:micronaut-kotlin-runtime")
+                       |}
+                       |
+                       |$repositoriesBlock
+                       |
+                       |mainClassName="example.Application"
+                       """.stripMargin()
+        testProjectDir.newFolder("src", "test", "kotlin", "example")
+        def testFile = testProjectDir.newFile("src/test/kotlin/example/ExampleTest.kt")
+        testFile << """package com.example
+                        |
+                        |import io.micronaut.runtime.EmbeddedApplication
+                        |import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+                        |import io.kotest.core.spec.style.StringSpec
+                        |
+                        |@MicronautTest
+                        |class ExampleTest(private val application: EmbeddedApplication<*>): StringSpec({
+                        |
+                        |    "test the server is running" {
+                        |        assert(application.isRunning)
+                        |    }
+                        |})
+                        """.stripMargin()
+        def configFile = testProjectDir.newFile("src/test/kotlin/example/ProjectConfig.kt")
+        configFile << """package example
+                      |
+                      |import io.kotest.core.config.AbstractProjectConfig
+                      |import io.micronaut.test.extensions.kotest5.MicronautKotest5Extension
+                      |
+                      |object ProjectConfig : AbstractProjectConfig() {
+                      |    override fun listeners() = listOf(MicronautKotest5Extension)
+                      |    override fun extensions() = listOf(MicronautKotest5Extension)
+                      |}
+                      """.stripMargin()
+
+        when:
+        def result = build('test')
+
+        def task = result.task(":test")
+        println result.output
+
+        then:
+        task.outcome == TaskOutcome.SUCCESS
+
+        where:
+        plugin << [
+                'id "io.micronaut.application"',
+                'id "io.micronaut.minimal.application"',
+        ]
+    }
+}

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/Kotest5FunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/Kotest5FunctionalTest.groovy
@@ -2,8 +2,11 @@ package io.micronaut.gradle.kotlin
 
 import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.IgnoreIf
 
+@IgnoreIf({ jvm.java8 })
 class Kotest5FunctionalTest extends AbstractEagerConfiguringFunctionalTest {
+
     def "test kotest 5 test runtime with #plugin"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/Kotest5FunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/Kotest5FunctionalTest.groovy
@@ -2,9 +2,7 @@ package io.micronaut.gradle.kotlin
 
 import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
 import org.gradle.testkit.runner.TaskOutcome
-import spock.lang.IgnoreIf
 
-@IgnoreIf({ jvm.java8 })
 class Kotest5FunctionalTest extends AbstractEagerConfiguringFunctionalTest {
 
     def "test kotest 5 test runtime with #plugin"() {
@@ -20,12 +18,12 @@ class Kotest5FunctionalTest extends AbstractEagerConfiguringFunctionalTest {
                        |tasks {
                        |    compileKotlin {
                        |        kotlinOptions {
-                       |            jvmTarget = "11"
+                       |            jvmTarget = "1.8"
                        |        }
                        |    }
                        |    compileTestKotlin {
                        |        kotlinOptions {
-                       |            jvmTarget = "11"
+                       |            jvmTarget = "1.8"
                        |        }
                        |    }
                        |}

--- a/gradle-plugin/src/test/groovy/io/micronaut/gradle/MicronautApplicationPluginSpec.groovy
+++ b/gradle-plugin/src/test/groovy/io/micronaut/gradle/MicronautApplicationPluginSpec.groovy
@@ -1,8 +1,6 @@
 package io.micronaut.gradle
 
-
 import org.gradle.testkit.runner.TaskOutcome
-import spock.lang.Ignore
 import spock.lang.Issue
 
 class MicronautApplicationPluginSpec extends AbstractGradleBuildSpec {
@@ -63,88 +61,6 @@ public class ExampleTest {
 
         where:
         plugins << [
-                'id "io.micronaut.application"',
-                'id "io.micronaut.minimal.application"',
-        ]
-    }
-
-    @Ignore("Not sure how to fix java.lang.NoClassDefFoundError: org/jetbrains/kotlin/allopen/gradle/AllOpenExtension")
-    def "test kotest 5 test runtime with #plugin"() {
-        given:
-        settingsFile << "rootProject.name = 'hello-world'"
-        buildFile << """plugins {
-                       |    id("org.jetbrains.kotlin.jvm") version "1.6.21"
-                       |    id("org.jetbrains.kotlin.kapt") version "1.6.21"
-                       |    id("org.jetbrains.kotlin.plugin.allopen") version "1.6.21"
-                       |    $plugin
-                       |}
-                       |
-                       |tasks {
-                       |    compileKotlin {
-                       |        kotlinOptions {
-                       |            jvmTarget = "11"
-                       |        }
-                       |    }
-                       |    compileTestKotlin {
-                       |        kotlinOptions {
-                       |            jvmTarget = "11"
-                       |        }
-                       |    }
-                       |}
-                       |
-                       |micronaut {
-                       |    version "3.5.1"
-                       |    runtime "netty"
-                       |    testRuntime "kotest5"
-                       |}
-                       |
-                       |dependencies {
-                       |    implementation("io.micronaut.kotlin:micronaut-kotlin-runtime")
-                       |}
-                       |
-                       |$repositoriesBlock
-                       |
-                       |mainClassName="example.Application"
-                       """.stripMargin()
-        testProjectDir.newFolder("src", "test", "kotlin", "example")
-        def testFile = testProjectDir.newFile("src/test/kotlin/example/ExampleTest.kt")
-        testFile << """package com.example
-                        |
-                        |import io.micronaut.runtime.EmbeddedApplication
-                        |import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
-                        |import io.kotest.core.spec.style.StringSpec
-                        |
-                        |@MicronautTest
-                        |class ExampleTest(private val application: EmbeddedApplication<*>): StringSpec({
-                        |
-                        |    "test the server is running" {
-                        |        assert(application.isRunning)
-                        |    }
-                        |})
-                        """.stripMargin()
-        def configFile = testProjectDir.newFile("src/test/kotlin/example/ProjectConfig.kt")
-        testFile << """package example
-                      |
-                      |import io.kotest.core.config.AbstractProjectConfig
-                      |import io.micronaut.test.extensions.kotest5.MicronautKotestExtension
-                      |
-                      |object ProjectConfig : AbstractProjectConfig() {
-                      |    override fun listeners() = listOf(MicronautKotestExtension)
-                      |    override fun extensions() = listOf(MicronautKotestExtension)
-                      |}
-                      """.stripMargin()
-
-        when:
-        def result = build('test')
-
-        def task = result.task(":test")
-        println result.output
-
-        then:
-        task.outcome == TaskOutcome.SUCCESS
-
-        where:
-        plugin << [
                 'id "io.micronaut.application"',
                 'id "io.micronaut.minimal.application"',
         ]

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
@@ -48,6 +48,22 @@ public enum MicronautTestRuntime {
             JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME,
             Collections.singletonList("io.kotest:kotest-runner-junit5-jvm")
     )),
+
+    /**
+     * Kotest 5.
+     */
+    KOTEST_5(MicronautExtension.mapOf(
+            "kaptTest",
+            Collections.singletonList("io.micronaut:micronaut-inject-java"),
+            JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME,
+            Arrays.asList(
+                    "io.mockk:mockk",
+                    "io.micronaut.test:micronaut-test-kotest5",
+                    "io.kotest:kotest-assertions-core-jvm"
+            ),
+            JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME,
+            Collections.singletonList("io.kotest:kotest-runner-junit5-jvm")
+    )),
     /**
      * No test runtime.
      */
@@ -83,6 +99,9 @@ public enum MicronautTestRuntime {
                 case "KOTEST4":
                 case "KOTEST_4":
                     return MicronautTestRuntime.KOTEST_4;
+                case "KOTEST5":
+                case "KOTEST_5":
+                    return MicronautTestRuntime.KOTEST_5;
             }
         }
         return MicronautTestRuntime.NONE;


### PR DESCRIPTION
We desire to migrate from kotest 4 to kotest 5.  This PR adds a new testRuntime option
'kotest5' which injects the correct dependencies.

I couldn't find any tests for this, and we should add it as an option to launch once
this PR is accepted and released

See discussion here https://github.com/micronaut-projects/micronaut-starter/pull/1296#pullrequestreview-1008860774