### PR TITLE
Add custom `testResources` source set

### DIFF
--- a/samples/test-resources/custom-test-resource/build.gradle
+++ b/samples/test-resources/custom-test-resource/build.gradle
@@ -1,0 +1,48 @@
+plugins {
+    id("io.micronaut.minimal.application")
+    id("io.micronaut.test-resources")
+}
+
+version = "0.1"
+group = "demo"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    annotationProcessor("io.micronaut:micronaut-http-validation")
+    implementation("io.micronaut:micronaut-http-client")
+    implementation("io.micronaut:micronaut-jackson-databind")
+    implementation("io.micronaut:micronaut-runtime")
+    implementation("jakarta.annotation:jakarta.annotation-api")
+    runtimeOnly("ch.qos.logback:logback-classic")
+    implementation("io.micronaut:micronaut-validation")
+}
+
+application {
+    mainClass.set("demo.Application")
+}
+
+micronaut {
+    version = "3.5.1"
+    runtime("netty")
+    testRuntime("junit5")
+    processing {
+        incremental(true)
+        annotations("demo.*")
+    }
+    testResources {
+        // TEST_RESOURCES_MARKER
+    }
+}
+
+dependencies {
+    // TEST_DEPENDENCIES_MARKER
+}
+
+tasks.named("run") {
+    if (System.getProperty("interruptStartup")) {
+        systemProperty "interruptStartup", "true"
+    }
+}

--- a/samples/test-resources/custom-test-resource/gradle.properties
+++ b/samples/test-resources/custom-test-resource/gradle.properties
@@ -1,0 +1,1 @@
+micronautVersion=3.5.1

--- a/samples/test-resources/custom-test-resource/settings.gradle
+++ b/samples/test-resources/custom-test-resource/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name="demo"

--- a/samples/test-resources/custom-test-resource/src/main/java/demo/Application.java
+++ b/samples/test-resources/custom-test-resource/src/main/java/demo/Application.java
@@ -1,0 +1,44 @@
+package demo;
+
+import io.micronaut.context.ApplicationContextBuilder;
+import io.micronaut.context.ApplicationContextConfigurer;
+import io.micronaut.context.annotation.ContextConfigurer;
+import io.micronaut.context.event.StartupEvent;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.runtime.Micronaut;
+import io.micronaut.runtime.event.annotation.EventListener;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.util.Collections;
+
+@Singleton
+public class Application {
+
+    private final String greeting;
+
+    public Application(@Value("${greeting.message}") String greeting) {
+        this.greeting = greeting;
+    }
+
+    @ContextConfigurer
+    public static class Configurer implements ApplicationContextConfigurer {
+        @Override
+        public void configure(ApplicationContextBuilder builder) {
+            builder.deduceEnvironment(false);
+            builder.banner(false);
+        }
+    }
+
+    public static void main(String[] args) {
+        Micronaut.run(Application.class, args);
+        if (System.getProperty("interruptStartup") != null) {
+            System.exit(0);
+        }
+    }
+
+    @EventListener
+    public void onStart(StartupEvent event) {
+        System.out.println(greeting);
+    }
+}

--- a/samples/test-resources/custom-test-resource/src/main/resources/application.yml
+++ b/samples/test-resources/custom-test-resource/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+micronaut:
+  application:
+    name: demo
+  server:
+    port: -1
+netty:
+  default:
+    allocator:
+      max-order: 3

--- a/samples/test-resources/custom-test-resource/src/main/resources/logback.xml
+++ b/samples/test-resources/custom-test-resource/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/samples/test-resources/custom-test-resource/src/test/java/demo/DemoTest.java
+++ b/samples/test-resources/custom-test-resource/src/test/java/demo/DemoTest.java
@@ -1,0 +1,24 @@
+package demo;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import io.micronaut.context.annotation.Value;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@MicronautTest
+class DemoTest {
+
+    @Value("${greeting.message}")
+    String greeting;
+
+    @Test
+    void testItWorks() {
+        assertEquals("Hello from my test resource!", greeting);
+    }
+
+}

--- a/samples/test-resources/custom-test-resource/src/testResources/java/demo/GreetingTestResource.java
+++ b/samples/test-resources/custom-test-resource/src/testResources/java/demo/GreetingTestResource.java
@@ -1,0 +1,28 @@
+package demo;
+
+import io.micronaut.testresources.core.TestResourcesResolver;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class GreetingTestResource implements TestResourcesResolver {
+
+    public static final String PROPERTY = "greeting.message";
+
+    @Override
+    public List<String> getResolvableProperties(Map<String, Collection<String>> propertyEntries, Map<String, Object> testResourcesConfig) {
+        return Collections.singletonList(PROPERTY);
+    }
+
+    @Override
+    public Optional<String> resolve(String propertyName, Map<String, Object> properties, Map<String, Object> testResourcesConfiguration) {
+        if (PROPERTY.equals(propertyName)) {
+            return Optional.of("Hello from my test resource!");
+        }
+        return Optional.empty();
+    }
+
+}

--- a/samples/test-resources/custom-test-resource/src/testResources/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
+++ b/samples/test-resources/custom-test-resource/src/testResources/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver
@@ -1,0 +1,1 @@
+demo.GreetingTestResource

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -3,6 +3,7 @@
  */
 package io.micronaut.gradle.testresources;
 
+import io.micronaut.gradle.MicronautBasePlugin;
 import io.micronaut.gradle.MicronautExtension;
 import io.micronaut.testresources.buildtools.MavenDependency;
 import io.micronaut.testresources.buildtools.ServerUtils;
@@ -19,9 +20,13 @@ import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.plugins.PluginManager;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.JavaExec;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
@@ -40,6 +45,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.stream.Stream.concat;
+
 /**
  * This plugin integrates with Micronaut Test Resources.
  * It handles the lifecycle of the test resources server
@@ -54,17 +61,25 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
     private static final int DEFAULT_CLIENT_TIMEOUT_SECONDS = 60;
 
     public void apply(Project project) {
-        project.getPluginManager().withPlugin("io.micronaut.component", unused -> configurePlugin(project));
+        PluginManager pluginManager = project.getPluginManager();
+        pluginManager.apply(JavaPlugin.class);
+        pluginManager.apply(MicronautBasePlugin.class);
+        configurePlugin(project);
     }
 
     private void configurePlugin(Project project) {
         Configuration server = createTestResourcesServerConfiguration(project);
-        Provider<Integer> explicitPort = project.getProviders().systemProperty("micronaut.test-resources.server.port").map(Integer::parseInt);
+        ProviderFactory providers = project.getProviders();
+        Provider<Integer> explicitPort = providers.systemProperty("micronaut.test-resources.server.port").map(Integer::parseInt);
         TestResourcesConfiguration config = createTestResourcesConfiguration(project, explicitPort);
+        JavaPluginExtension javaPluginExtension = project.getExtensions().findByType(JavaPluginExtension.class);
+        SourceSet testResourcesSourceSet = createTestResourcesSourceSet(javaPluginExtension);
         DependencyHandler dependencies = project.getDependencies();
-        server.getDependencies().addAllLater(buildTestResourcesDependencyList(project, dependencies, config));
+        Configuration testResourcesApi = project.getConfigurations().getByName(testResourcesSourceSet.getImplementationConfigurationName());
+        testResourcesApi.getDependencies().addLater(config.getVersion().map(v -> dependencies.create("io.micronaut.testresources:micronaut-test-resources-core:" + v)));
+        server.getDependencies().addAllLater(buildTestResourcesDependencyList(project, dependencies, config, testResourcesSourceSet));
         String accessToken = UUID.randomUUID().toString();
-        Provider<String> accessTokenProvider = project.getProviders().provider(() -> accessToken);
+        Provider<String> accessTokenProvider = providers.provider(() -> accessToken);
         Provider<Directory> settingsDirectory = config.getSharedServer().flatMap(shared -> {
             DirectoryProperty directoryProperty = project.getObjects().directoryProperty();
             if (Boolean.TRUE.equals(shared)) {
@@ -87,7 +102,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
             throw new GradleException("Unable to create temp file", e);
         }
         TaskContainer tasks = project.getTasks();
-        Provider<Boolean> isStandalone = config.getSharedServer().zip(project.getProviders().provider(() -> {
+        Provider<Boolean> isStandalone = config.getSharedServer().zip(providers.provider(() -> {
             boolean singleTask = project.getGradle().getStartParameter().getTaskNames().size() == 1;
             boolean onlyStartTask = project.getGradle().getTaskGraph()
                     .getAllTasks()
@@ -96,17 +111,23 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
             return singleTask && onlyStartTask;
         }), (shared, singleTask) -> shared || singleTask);
         TaskProvider<StartTestResourcesService> startTestResourcesService = createStartServiceTask(server, config, settingsDirectory, accessTokenProvider, tasks, portFile, stopAtEndFile, isStandalone);
-        TaskProvider<StopTestResourcesService> stopTestResourcesService = createStopServiceTask(settingsDirectory, tasks);
+        createStopServiceTask(settingsDirectory, tasks);
         project.afterEvaluate(p -> p.getConfigurations().all(conf -> configureDependencies(project, config, dependencies, startTestResourcesService, conf)));
 
-        tasks.withType(Test.class).configureEach(t -> t.dependsOn(startTestResourcesService));
-        tasks.withType(JavaExec.class).configureEach(t -> t.dependsOn(startTestResourcesService));
+        project.getPluginManager().withPlugin("io.micronaut.component", unused -> {
+            tasks.withType(Test.class).configureEach(t -> t.dependsOn(startTestResourcesService));
+            tasks.withType(JavaExec.class).configureEach(t -> t.dependsOn(startTestResourcesService));
+        });
 
         configureServiceReset((ProjectInternal) project, settingsDirectory, stopAtEndFile);
     }
 
-    private TaskProvider<StopTestResourcesService> createStopServiceTask(Provider<Directory> settingsDirectory, TaskContainer tasks) {
-        return tasks.register(STOP_TEST_RESOURCES_SERVICE, StopTestResourcesService.class, task -> task.getSettingsDirectory().convention(settingsDirectory));
+    private SourceSet createTestResourcesSourceSet(JavaPluginExtension javaPluginExtension) {
+        return javaPluginExtension.getSourceSets().create("testResources");
+    }
+
+    private void  createStopServiceTask(Provider<Directory> settingsDirectory, TaskContainer tasks) {
+        tasks.register(STOP_TEST_RESOURCES_SERVICE, StopTestResourcesService.class, task -> task.getSettingsDirectory().convention(settingsDirectory));
     }
 
 
@@ -193,10 +214,10 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
         return false;
     }
 
-    private Provider<List<Dependency>> buildTestResourcesDependencyList(Project project, DependencyHandler dependencies, TestResourcesConfiguration config) {
+    private Provider<List<Dependency>> buildTestResourcesDependencyList(Project project, DependencyHandler dependencies, TestResourcesConfiguration config, SourceSet testResourcesSourceSet) {
         return config.getEnabled().zip(config.getInferClasspath(), (enabled, infer) -> {
             if (Boolean.FALSE.equals(enabled)) {
-                return Collections.<Dependency>emptyList();
+                return Collections.singletonList(dependencies.create(testResourcesSourceSet.getOutput()));
             }
             List<MavenDependency> mavenDependencies = Collections.emptyList();
             if (Boolean.TRUE.equals(infer)) {
@@ -209,14 +230,15 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
                         .collect(Collectors.toList());
             }
             String testResourcesVersion = config.getVersion().get();
-            return Stream.concat(
+            return concat(concat(
                             TestResourcesClasspath.inferTestResourcesClasspath(mavenDependencies, testResourcesVersion)
                                     .stream()
                                     .map(Object::toString),
                             config.getAdditionalModules().getOrElse(Collections.emptyList())
                                     .stream()
                                     .map(m -> "io.micronaut.testresources:micronaut-test-resources-" + m + ":" + testResourcesVersion))
-                    .map(dependencies::create)
+                            .map(dependencies::create),
+                    Stream.of(dependencies.create(testResourcesSourceSet.getOutput())))
                     .collect(Collectors.toList());
         }).orElse(Collections.emptyList());
     }

--- a/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/ApplicationTestResourcesPluginSpec.groovy
+++ b/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/ApplicationTestResourcesPluginSpec.groovy
@@ -30,7 +30,7 @@ class ApplicationTestResourcesPluginSpec extends AbstractGradleBuildSpec {
         def result = fails 'test'
 
         then:
-        result.task(":startTestResourcesService").outcome == TaskOutcome.SKIPPED
+        result.task(":internalStartTestResourcesService").outcome == TaskOutcome.SKIPPED
         result.task(':test').outcome == TaskOutcome.FAILED
         !result.output.contains("Loaded 1 test resources resolvers: io.micronaut.testresources.testcontainers.GenericTestContainerProvider")
     }
@@ -45,7 +45,7 @@ class ApplicationTestResourcesPluginSpec extends AbstractGradleBuildSpec {
         def result = fails 'test'
 
         then:
-        result.task(":startTestResourcesService").outcome == TaskOutcome.SUCCESS
+        result.task(":internalStartTestResourcesService").outcome == TaskOutcome.SUCCESS
         result.task(':test').outcome == TaskOutcome.FAILED
         result.output.contains "Loaded 1 test resources resolvers: io.micronaut.testresources.testcontainers.GenericTestContainerProvider"
     }

--- a/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/CustomTestResourcePluginSpec.groovy
+++ b/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/CustomTestResourcePluginSpec.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.gradle.testresources
+
+import io.micronaut.gradle.AbstractGradleBuildSpec
+import org.gradle.testkit.runner.TaskOutcome
+
+class CustomTestResourcePluginSpec extends AbstractGradleBuildSpec {
+
+    def "can implement a custom test resource using the testResources source set"() {
+        withSample("test-resources/custom-test-resource")
+
+        when:
+        def result = build 'test'
+
+        then:
+        result.task(':test').outcome == TaskOutcome.SUCCESS
+        result.output.contains "Loaded 2 test resources resolvers"
+        result.output.contains "demo.GreetingTestResource"
+        result.output.contains "io.micronaut.testresources.testcontainers.GenericTestContainerProvider"
+    }
+
+}


### PR DESCRIPTION
This commit adds a `testResources` source set when applying the
test resources plugin. This makes it easy to implement custom
test resources in a single project, by implementing the test
resource resolver in `src/testResources/java` for example.

The test resources declares in that source set are automatically
added to the test resources classpath.