### PR TITLE
Integrate with native and AOT

### DIFF
--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -100,7 +100,7 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
             "io.micronaut.core.async.publisher.Publishers.JustPublisher",
             "io.micronaut.core.async.subscriber.Completable"));
 
-    static final List<String> SERVICE_TYPES = Collections.unmodifiableList(Arrays.asList(
+    public static final List<String> SERVICE_TYPES = Collections.unmodifiableList(Arrays.asList(
             "io.micronaut.context.env.PropertySourceLoader",
             "io.micronaut.inject.BeanConfiguration",
             "io.micronaut.inject.BeanDefinitionReference",
@@ -108,6 +108,7 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
             "io.micronaut.http.HttpResponseFactory",
             "io.micronaut.core.beans.BeanIntrospectionReference"
     ));
+    public static final String AOT_APPLICATION_CLASSPATH = "aotApplicationClasspath";
 
     @Inject
     protected abstract ArchiveOperations getArchiveOperations();
@@ -377,7 +378,7 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
             c.setCanBeResolved(false);
             c.setCanBeConsumed(false);
         });
-        Configuration aotApplicationClasspath = configurations.create("aotApplicationClasspath", c -> {
+        Configuration aotApplicationClasspath = configurations.create(AOT_APPLICATION_CLASSPATH, c -> {
             configureAsRuntimeClasspath(configurations, c);
             Configuration runtimeClasspath = configurations.findByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
             runtimeClasspath.getExtendsFrom().forEach(c::extendsFrom);

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/fixtures/AbstractFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/fixtures/AbstractFunctionalTest.groovy
@@ -35,6 +35,7 @@ abstract class AbstractFunctionalTest extends AbstractGradleBuildSpec {
                     id 'io.micronaut.graalvm' version '${version}'
                     id 'io.micronaut.docker' version '${version}'
                     id 'io.micronaut.aot' version '${version}'
+                    id 'io.micronaut.test-resources' version '${version}'
                 }
             }
         """ + (settingsFile.exists() ? settingsFile.text : "")

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/AbstractTestResourcesSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/AbstractTestResourcesSpec.groovy
@@ -1,0 +1,13 @@
+package io.micronaut.gradle.testresources
+
+import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
+
+abstract class AbstractTestResourcesSpec extends AbstractEagerConfiguringFunctionalTest {
+
+    @Override
+    protected void withSample(String name) {
+        super.withSample(name)
+        patchSettings()
+    }
+
+}

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithAotSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithAotSpec.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.gradle.testresources
+
+
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.IgnoreIf
+
+@IgnoreIf({ os.windows })
+class TestResourcesWithAotSpec extends AbstractTestResourcesSpec {
+
+    def "integrates with test resources without further configuration"() {
+        withSample("test-resources/data-mysql")
+        buildFile.text = buildFile.text.replace("""plugins {
+    id("io.micronaut.minimal.application")
+    id("io.micronaut.test-resources")
+}""", """plugins {
+    id("io.micronaut.minimal.application")
+    id("io.micronaut.test-resources")
+    id("io.micronaut.aot")
+}""")
+
+        when:
+        def result = build 'optimizedRun', '-DinterruptStartup=true'
+
+        then:
+        result.task(':optimizedRun').outcome == TaskOutcome.SUCCESS
+        result.output.contains "Loaded 2 test resources resolvers"
+        result.output.contains "io.micronaut.testresources.mysql.MySQLTestResourceProvider"
+        result.output.contains "io.micronaut.testresources.testcontainers.GenericTestContainerProvider"
+    }
+}

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithGraalVMSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithGraalVMSpec.groovy
@@ -1,0 +1,64 @@
+package io.micronaut.gradle.testresources
+
+import io.micronaut.gradle.AbstractGradleBuildSpec
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Requires
+
+@Requires({ AbstractGradleBuildSpec.graalVmAvailable && !os.windows })
+@Requires({ jvm.isJava11Compatible() })
+class TestResourcesWithGraalVMSpec extends AbstractTestResourcesSpec {
+
+    def "runs native tests"() {
+        withSample("test-resources/data-mysql")
+        buildFile.text = buildFile.text.replace("""plugins {
+    id("io.micronaut.minimal.application")
+    id("io.micronaut.test-resources")
+}""", """plugins {
+    id("io.micronaut.minimal.application")
+    id("io.micronaut.test-resources")
+    id("io.micronaut.graalvm")
+}
+
+tasks.named("nativeRun") {
+    runtimeArgs.add("-DinterruptStartup=true")
+}
+
+""")
+
+        when:
+        def result = build 'nativeTest'
+
+        then:
+        result.task(':nativeTest').outcome == TaskOutcome.SUCCESS
+        result.output.contains "Loaded 2 test resources resolvers"
+        result.output.contains "io.micronaut.testresources.mysql.MySQLTestResourceProvider"
+        result.output.contains "io.micronaut.testresources.testcontainers.GenericTestContainerProvider"
+    }
+
+    def "integrates with test resources without further configuration"() {
+        withSample("test-resources/data-mysql")
+        buildFile.text = buildFile.text.replace("""plugins {
+    id("io.micronaut.minimal.application")
+    id("io.micronaut.test-resources")
+}""", """plugins {
+    id("io.micronaut.minimal.application")
+    id("io.micronaut.test-resources")
+    id("io.micronaut.graalvm")
+}
+
+tasks.named("nativeRun") {
+    runtimeArgs.add("-DinterruptStartup=true")
+}
+
+""")
+
+        when:
+        def result = build 'nativeRun'
+
+        then:
+        result.task(':nativeRun').outcome == TaskOutcome.SUCCESS
+        result.output.contains "Loaded 2 test resources resolvers"
+        result.output.contains "io.micronaut.testresources.mysql.MySQLTestResourceProvider"
+        result.output.contains "io.micronaut.testresources.testcontainers.GenericTestContainerProvider"
+    }
+}

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -67,10 +67,6 @@ public class MicronautComponentPlugin implements Plugin<Project> {
     }});
     public static final String MICRONAUT_BOMS_CONFIGURATION = "micronautBoms";
 
-    public static MicronautExtension findMicronautExtension(Project project) {
-        return project.getExtensions().getByType(MicronautExtension.class);
-    }
-
     @Override
     public void apply(Project project) {
         PluginManager plugins = project.getPluginManager();

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -67,6 +67,10 @@ public class MicronautComponentPlugin implements Plugin<Project> {
     }});
     public static final String MICRONAUT_BOMS_CONFIGURATION = "micronautBoms";
 
+    public static MicronautExtension findMicronautExtension(Project project) {
+        return project.getExtensions().getByType(MicronautExtension.class);
+    }
+
     @Override
     public void apply(Project project) {
         PluginManager plugins = project.getPluginManager();

--- a/samples/test-resources/data-mysql/build.gradle
+++ b/samples/test-resources/data-mysql/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     // TEST_DEPENDENCIES_MARKER
 }
 
-tasks.named("run") {
+tasks.withType(JavaExec) {
     if (System.getProperty("interruptStartup")) {
         systemProperty "interruptStartup", "true"
     }

--- a/test-resources-plugin/build.gradle
+++ b/test-resources-plugin/build.gradle
@@ -12,5 +12,7 @@ micronautPlugins {
 dependencies {
     implementation libs.micronaut.testresources
     implementation project(":micronaut-minimal-plugin")
+    compileOnly libs.graalvmPlugin
+    compileOnly project(":micronaut-aot-plugin")
     testImplementation testFixtures(project(":micronaut-minimal-plugin"))
 }

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -4,8 +4,8 @@
 package io.micronaut.gradle.testresources;
 
 import io.micronaut.gradle.MicronautBasePlugin;
-import io.micronaut.gradle.MicronautComponentPlugin;
 import io.micronaut.gradle.MicronautExtension;
+import io.micronaut.gradle.PluginsHelper;
 import io.micronaut.gradle.testresources.internal.TestResourcesAOT;
 import io.micronaut.gradle.testresources.internal.TestResourcesGraalVM;
 import io.micronaut.testresources.buildtools.MavenDependency;
@@ -83,7 +83,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
             }
             return Collections.emptyList();
         }));
-        conf.getDependencyConstraints().addAllLater(MicronautComponentPlugin.findMicronautExtension(project).getVersion().map(v ->
+        conf.getDependencyConstraints().addAllLater(PluginsHelper.findMicronautVersionAsProvider(project).map(v ->
                 Stream.of("micronaut-http-client", "micronaut-bom", "micronaut-inject")
                         .map(artifact -> dependencies.getConstraints().create("io.micronaut:" + artifact, dc -> {
                             dc.because("Aligning version of Micronaut the current Micronaut version");
@@ -220,7 +220,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
     }
 
     private TestResourcesConfiguration createTestResourcesConfiguration(Project project, Provider<Integer> explicitPort) {
-        MicronautExtension micronautExtension = MicronautComponentPlugin.findMicronautExtension(project);
+        MicronautExtension micronautExtension = PluginsHelper.findMicronautExtension(project);
         TestResourcesConfiguration testResources = micronautExtension.getExtensions().create("testResources", TestResourcesConfiguration.class);
         ProviderFactory providers = project.getProviders();
         testResources.getEnabled().convention(

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -47,7 +47,7 @@ import java.util.Collections;
  * The test resources server can be started for a single
  * build, for a continuous build, or outlive a single build.
  */
-abstract class StartTestResourcesService extends DefaultTask {
+public abstract class StartTestResourcesService extends DefaultTask {
 
     /**
      * The classpath of the test resources server. Once

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/TestResourcesConfiguration.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/TestResourcesConfiguration.java
@@ -15,33 +15,14 @@
  */
 package io.micronaut.gradle.testresources;
 
+import io.micronaut.testresources.buildtools.KnownModules;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
 /**
  * Configuration for the test resources plugin.
  */
-public interface TestResourcesConfiguration {
-    // JDBC databases
-    String JDBC_MARIADB = "jdbc-mariadb";
-    String JDBC_MYSQL = "jdbc-mysql";
-    String JDBC_ORACLE_XE = "jdbc-oracle-xe";
-    String JDBC_POSTGRESQL = "jdbc-postgresql";
-
-    // Reactive databases
-    String R2DBC_MARIADB = "r2dbc-mariadb";
-    String R2DBC_MYSQL = "r2dbc-mysql";
-    String R2DBC_ORACLE_XE = "r2dbc-oracle-xe";
-    String R2DBC_POSTGRESQL = "r2dbc-postgresql";
-
-    // Other modules
-    String HIVEMQ = "hivemq";
-    String KAFKA = "kafka";
-    String MONGODB = "mongodb";
-    String NEO4J = "neo4j";
-
-    // Generic Testcontainers support
-    String TESTCONTAINERS = "testcontainers";
+public interface TestResourcesConfiguration extends KnownModules {
 
     /**
      * If set to false, test resources support will be disabled.

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/internal/TestResourcesAOT.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/internal/TestResourcesAOT.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.gradle.testresources.internal;
 
-import io.micronaut.gradle.MicronautComponentPlugin;
+import io.micronaut.gradle.PluginsHelper;
 import io.micronaut.gradle.aot.AOTExtension;
 import io.micronaut.gradle.aot.MicronautAotPlugin;
 import io.micronaut.gradle.testresources.MicronautTestResourcesPlugin;
@@ -40,7 +40,7 @@ import java.util.stream.Stream;
 public final class TestResourcesAOT {
 
     public static void configure(Project project, TestResourcesConfiguration config, DependencyHandler dependencies, TaskContainer tasks, TaskProvider<StartTestResourcesService> internalStart, Configuration testResourcesClasspathConfig) {
-        AOTExtension aot = MicronautComponentPlugin.findMicronautExtension(project).getExtensions().getByType(AOTExtension.class);
+        AOTExtension aot = PluginsHelper.findMicronautExtension(project).getExtensions().getByType(AOTExtension.class);
         Configuration aotAppClasspath = project.getConfigurations().getByName(MicronautAotPlugin.AOT_APPLICATION_CLASSPATH);
         MicronautTestResourcesPlugin.addTestResourcesClientDependencies(project, config, dependencies, internalStart, aotAppClasspath);
         project.afterEvaluate(p -> {

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/internal/TestResourcesAOT.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/internal/TestResourcesAOT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle.testresources.internal;
+
+import io.micronaut.gradle.MicronautComponentPlugin;
+import io.micronaut.gradle.aot.AOTExtension;
+import io.micronaut.gradle.aot.MicronautAotPlugin;
+import io.micronaut.gradle.testresources.MicronautTestResourcesPlugin;
+import io.micronaut.gradle.testresources.StartTestResourcesService;
+import io.micronaut.gradle.testresources.TestResourcesConfiguration;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.tasks.JavaExec;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Methods for Micronaut AOT plugin integration,
+ * separated to make sure we don't run into classloading
+ * issues.
+ */
+public final class TestResourcesAOT {
+
+    public static void configure(Project project, TestResourcesConfiguration config, DependencyHandler dependencies, TaskContainer tasks, TaskProvider<StartTestResourcesService> internalStart, Configuration testResourcesClasspathConfig) {
+        AOTExtension aot = MicronautComponentPlugin.findMicronautExtension(project).getExtensions().getByType(AOTExtension.class);
+        Configuration aotAppClasspath = project.getConfigurations().getByName(MicronautAotPlugin.AOT_APPLICATION_CLASSPATH);
+        MicronautTestResourcesPlugin.addTestResourcesClientDependencies(project, config, dependencies, internalStart, aotAppClasspath);
+        project.afterEvaluate(p -> {
+            MapProperty<String, String> props = aot.getConfigurationProperties();
+            if (props.get().containsKey("service.types")) {
+                props.put("service.types", props.get().get("service.types") + ",io.micronaut.testresources.core.TestResourcesResolver");
+            } else {
+                props.put("service.types", Stream.concat(
+                        Stream.of("io.micronaut.testresources.core.TestResourcesResolver"),
+                        MicronautAotPlugin.SERVICE_TYPES.stream()
+                ).collect(Collectors.joining(",")));
+            }
+            tasks.named("optimizedRun", JavaExec.class, javaExec ->
+                    javaExec.setClasspath(javaExec.getClasspath().plus(testResourcesClasspathConfig))
+            );
+        });
+    }
+
+}

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/internal/TestResourcesGraalVM.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/internal/TestResourcesGraalVM.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle.testresources.internal;
+
+import org.graalvm.buildtools.gradle.dsl.GraalVMExtension;
+import org.graalvm.buildtools.gradle.tasks.NativeRunTask;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.tasks.TaskContainer;
+
+/**
+ * Methods for Micronaut GraalVM plugin integration,
+ * separated to make sure we don't run into classloading
+ * issues.
+ */
+public final class TestResourcesGraalVM {
+    public static void configure(Project project, TaskContainer tasks, Configuration testResourcesClasspathConfig) {
+        // The native "run" tasks are not JavaExec tasks so we need to handle them separately
+        tasks.withType(NativeRunTask.class).configureEach(t -> {
+            GraalVMExtension graalVMExtension = project.getExtensions().findByType(GraalVMExtension.class);
+            graalVMExtension.getBinaries().all(b -> b.getClasspath().from(testResourcesClasspathConfig));
+        });
+    }
+}

--- a/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/ApplicationTestResourcesPluginSpec.groovy
+++ b/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/ApplicationTestResourcesPluginSpec.groovy
@@ -30,7 +30,7 @@ class ApplicationTestResourcesPluginSpec extends AbstractGradleBuildSpec {
         def result = fails 'test'
 
         then:
-        result.task(":internalStartTestResourcesService").outcome == TaskOutcome.SKIPPED
+        result.task(":internalStartTestResourcesService") == null
         result.task(':test').outcome == TaskOutcome.FAILED
         !result.output.contains("Loaded 1 test resources resolvers: io.micronaut.testresources.testcontainers.GenericTestContainerProvider")
     }


### PR DESCRIPTION
This commit integrates the test resources support with the AOT
support and GraalVM native support, so that we can run:

- optimizedRun: the standard JVM AOT-optimized run
- nativeTest: the native version of tests
- nativeOptimizedRun: the native run

all with test resources support enabled. It's worth noting
that native run support is a bit hackish, in the sense that
if you run `nativeCompile` only, then it will produce a
native binary which is for production and doesn't contain
the test resources client, as expected.

However, if you run `nativeRun`, then the test resources
client (and the properties file containing the connection
information) need to be in the binary, so `nativeCompile`
would _include_ them. This is specific of native, because
in the JVM mode, we can simply add elements to the run
classpath. For native, there's no classpath so everything
needs to be in the binary. The consequence is that if
the user picks the result of the `nativeCompile` task
_after_ running `nativeRun`, then it would contain a
"wrong" binary containing the test resources client. This
is unlikely to be a problem in practice, though, since
you would likely not create a production artifact with
`nativeRun` before, since it would block the build.

In addition, this commit fixes an issue with the test
resources client classpath, which could include a different
version of Micronaut than the one picked by the user.

The reason is that the `developementOnly` configuration,
and similarly the configuration we create for resolving
the client, is _added_ to the run task classpath: it's
not a single dependency graph but 2 appended dependency
graphs. Therefore, this commit makes sure to override
the version used by the client to the one used by the
application.