### PR TITLE
Fix dependent plugins not in API dependencies

### DIFF
--- a/docker-plugin/build.gradle
+++ b/docker-plugin/build.gradle
@@ -10,7 +10,7 @@ micronautPlugins {
 
 dependencies {
     api project(":micronaut-minimal-plugin")
-    implementation libs.dockerPlug
+    api libs.dockerPlug
 
     compileOnly libs.graalvmPlugin
 

--- a/graalvm-plugin/build.gradle
+++ b/graalvm-plugin/build.gradle
@@ -10,6 +10,6 @@ micronautPlugins {
 
 dependencies {
     api project(":micronaut-minimal-plugin")
-    implementation libs.graalvmPlugin
+    api libs.graalvmPlugin
     testImplementation testFixtures(project(":micronaut-minimal-plugin"))
 }


### PR DESCRIPTION
This is similar to #438, but for external plugins instead of Micronaut plugins.

Fixes #477

Fix was verified with the reproducer at https://github.com/LazyRichard/gradle-micronaut-buidlsrc