### PR TITLE
Support AppCDS to improve startup time of test resource server

### DIFF
--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -114,14 +114,15 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
         server.getDependencies().addAllLater(buildTestResourcesDependencyList(project, dependencies, config, testResourcesSourceSet));
         String accessToken = UUID.randomUUID().toString();
         Provider<String> accessTokenProvider = providers.provider(() -> accessToken);
+        DirectoryProperty buildDirectory = project.getLayout().getBuildDirectory();
         Provider<Directory> settingsDirectory = config.getSharedServer().flatMap(shared -> {
             DirectoryProperty directoryProperty = project.getObjects().directoryProperty();
             if (Boolean.TRUE.equals(shared)) {
                 directoryProperty.set(ServerUtils.getDefaultSharedSettingsPath().toFile());
             }
             return directoryProperty;
-        }).orElse(project.getLayout().getBuildDirectory().dir("test-resources-settings"));
-        Provider<RegularFile> portFile = project.getLayout().getBuildDirectory().file("test-resources-port.txt");
+        }).orElse(buildDirectory.dir("test-resources-settings"));
+        Provider<RegularFile> portFile = buildDirectory.file("test-resources-port.txt");
         Path stopAtEndFile = createStopFile(project);
         TaskContainer tasks = project.getTasks();
         Provider<Boolean> isStandalone = config.getSharedServer().zip(providers.provider(() -> {
@@ -132,7 +133,8 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
                     .anyMatch(task -> task.getProject().equals(project) && task.getName().equals(START_TEST_RESOURCES_SERVICE));
             return singleTask && onlyStartTask;
         }), (shared, singleTask) -> shared || singleTask);
-        TaskProvider<StartTestResourcesService> internalStart = createStartServiceTask(server, config, settingsDirectory, accessTokenProvider, tasks, portFile, stopAtEndFile, isStandalone);
+        Provider<Directory> cdsDir = buildDirectory.dir("test-resources/cds");
+        TaskProvider<StartTestResourcesService> internalStart = createStartServiceTask(server, config, settingsDirectory, accessTokenProvider, tasks, portFile, stopAtEndFile, isStandalone, cdsDir);
         tasks.register(START_TEST_RESOURCES_SERVICE, task -> {
             task.dependsOn(internalStart);
             task.setOnlyIf(t -> config.getEnabled().get());
@@ -204,7 +206,8 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
                                                                            TaskContainer tasks,
                                                                            Provider<RegularFile> portFile,
                                                                            Path stopFile,
-                                                                           Provider<Boolean> isStandalone) {
+                                                                           Provider<Boolean> isStandalone,
+                                                                           Provider<Directory> cdsDir) {
         return tasks.register(START_TEST_RESOURCES_SERVICE_INTERNAL, StartTestResourcesService.class, task -> {
             task.setOnlyIf(t -> config.getEnabled().get());
             task.getPortFile().convention(portFile);
@@ -216,6 +219,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
             task.getForeground().convention(false);
             task.getStopFile().set(stopFile.toFile());
             task.getStandalone().set(isStandalone);
+            task.getClassDataSharingDir().convention(cdsDir);
         });
     }
 

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -218,11 +218,11 @@ public abstract class StartTestResourcesService extends DefaultTask {
                                     List<String> fileContent = new ArrayList<>(Files.readAllLines(cdsListPath, StandardCharsets.UTF_8));
                                     fileContent.removeIf(content ->
                                             content.contains("SingleThreadedBufferingProcessor") ||
-//                                                    content.contains("HandlerPublisher") ||
-//                                                    content.contains("SingleThreadedBufferingSubscriber") ||
+                                                    content.contains("io/netty/channel/$Proxy") ||
                                                     content.contains("org/testcontainers") ||
                                                     content.contains("org/graalvm") ||
                                                     content.contains("io/netty/handler") ||
+                                                    content.contains("jdk/internal/event") ||
                                                     content.contains("jdk/proxy"));
                                     Files.write(cdsListPath, fileContent, StandardCharsets.UTF_8);
                                 } catch (IOException e) {

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -234,7 +234,6 @@ public abstract class StartTestResourcesService extends DefaultTask {
                                 }
                             }
                             getExecOperations().javaexec(spec -> {
-                                spec.getMainClass().set(processParameters.getMainClass());
                                 configureJavaExec(processParameters, spec);
                                 if (cdsEnabled) {
                                     spec.setWorkingDir(cdsDir);
@@ -262,6 +261,7 @@ public abstract class StartTestResourcesService extends DefaultTask {
     }
 
     private void configureJavaExec(ServerUtils.ProcessParameters processParameters, JavaExecSpec spec) {
+        spec.getMainClass().set(processParameters.getMainClass());
         spec.setClasspath(getObjects().fileCollection().from(processParameters.getClasspath().stream().filter(File::isFile).collect(Collectors.toList())));
         spec.getJvmArgs().addAll(processParameters.getJvmArguments());
         processParameters.getSystemProperties().forEach(spec::systemProperty);

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -206,14 +206,17 @@ public abstract class StartTestResourcesService extends DefaultTask {
                             }
                             boolean cdsEnabled = Boolean.TRUE.equals(useCDS);
                             File cdsFile = getClassDataSharingDir().file(CDS_FILE).get().getAsFile();
+                            File cdsClassList = getClassDataSharingDir().file(CDS_CLASS_LST).get().getAsFile();
                             getExecOperations().javaexec(spec -> {
                                 spec.getMainClass().set(processParameters.getMainClass());
                                 if (cdsEnabled) {
                                     spec.setWorkingDir(cdsDir);
-                                    if (cdsFile.exists()) {
-                                        spec.jvmArgs("-Xlog:cds", "-Xshare:on", "-XX:SharedArchiveFile=" + CDS_FILE);
+                                    if (!cdsClassList.exists()) {
+                                        spec.jvmArgs("-Xlog:cds", "-Xshare:off", "-XX:DumpLoadedClassList=" + CDS_CLASS_LST);
+                                    } else if (!cdsFile.exists()) {
+                                        spec.jvmArgs("-Xlog:cds", "-Xshare:dump", "-XX:SharedClassListFile=" + CDS_CLASS_LST, "-XX:SharedArchiveFile=" + CDS_FILE);
                                     } else {
-                                        spec.jvmArgs("-Xlog:cds", "-XX:ArchiveClassesAtExit=" + CDS_FILE);
+                                        spec.jvmArgs("-Xlog:cds", "-XX:SharedArchiveFile=" + CDS_FILE);
                                     }
                                 }
                                 spec.setClasspath(getObjects().fileCollection().from(processParameters.getClasspath().stream().filter(File::isFile).collect(Collectors.toList())));

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -206,25 +206,14 @@ public abstract class StartTestResourcesService extends DefaultTask {
                             }
                             boolean cdsEnabled = Boolean.TRUE.equals(useCDS);
                             File cdsFile = getClassDataSharingDir().file(CDS_FILE).get().getAsFile();
-                            File cdsClassList = getClassDataSharingDir().file(CDS_CLASS_LST).get().getAsFile();
-                            if (cdsClassList.exists() && !cdsFile.exists()) {
-                                getExecOperations().javaexec(spec -> {
-                                    spec.setWorkingDir(cdsDir);
-                                    spec.getMainClass().set("dummy");
-                                    spec.jvmArgs("-Xlog:cds",
-                                            "-Xshare:dump",
-                                            "-XX:SharedClassListFile=" + CDS_CLASS_LST,
-                                            "-XX:SharedArchiveFile=" + CDS_FILE);
-                                });
-                            }
                             getExecOperations().javaexec(spec -> {
                                 spec.getMainClass().set(processParameters.getMainClass());
                                 if (cdsEnabled) {
                                     spec.setWorkingDir(cdsDir);
                                     if (cdsFile.exists()) {
-                                        spec.jvmArgs("-Xlog:cds", "-XX:SharedArchiveFile=" + CDS_FILE);
+                                        spec.jvmArgs("-Xshare:on", "-XX:SharedArchiveFile=" + CDS_FILE);
                                     } else {
-                                        spec.jvmArgs("-Xlog:cds", "-XX:DumpLoadedClassList=" + CDS_CLASS_LST);
+                                        spec.jvmArgs("-XX:ArchiveClassesAtExit=" + CDS_FILE);
                                     }
                                 }
                                 spec.setClasspath(getObjects().fileCollection().from(processParameters.getClasspath().stream().filter(File::isFile).collect(Collectors.toList())));

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -226,7 +226,10 @@ public abstract class StartTestResourcesService extends DefaultTask {
                                     try {
                                         Path cdsListPath = cdsClassList.toPath();
                                         List<String> fileContent = new ArrayList<>(Files.readAllLines(cdsListPath, StandardCharsets.UTF_8));
-                                        fileContent.removeIf(content -> content.contains("SingleThreadedBufferingProcessor") || content.contains("HandlerPublisher"));
+                                        fileContent.removeIf(content ->
+                                                content.contains("SingleThreadedBufferingProcessor") ||
+                                                content.contains("HandlerPublisher") ||
+                                                content.contains("SingleThreadedBufferingSubscriber"));
                                         Files.write(cdsListPath, fileContent, StandardCharsets.UTF_8);
                                     } catch (IOException e) {
                                         // ignore

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -229,7 +229,8 @@ public abstract class StartTestResourcesService extends DefaultTask {
                                         fileContent.removeIf(content ->
                                                 content.contains("SingleThreadedBufferingProcessor") ||
                                                 content.contains("HandlerPublisher") ||
-                                                content.contains("SingleThreadedBufferingSubscriber"));
+                                                content.contains("SingleThreadedBufferingSubscriber") ||
+                                                content.contains("jdk/proxy"));
                                         Files.write(cdsListPath, fileContent, StandardCharsets.UTF_8);
                                     } catch (IOException e) {
                                         // ignore
@@ -242,8 +243,6 @@ public abstract class StartTestResourcesService extends DefaultTask {
                                     spec.setWorkingDir(cdsDir);
                                     if (!cdsClassList.exists()) {
                                         spec.jvmArgs("-Xlog:cds", "-Xshare:off", "-XX:DumpLoadedClassList=" + CDS_CLASS_LST);
-                                    } else if (!cdsFile.exists()) {
-                                        spec.jvmArgs("-Xlog:cds", "-Xshare:dump", "-XX:SharedClassListFile=" + CDS_CLASS_LST, "-XX:SharedArchiveFile=" + CDS_FILE);
                                     } else {
                                         spec.jvmArgs("-Xlog:cds", "-XX:SharedArchiveFile=" + CDS_FILE);
                                     }

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -226,7 +226,7 @@ public abstract class StartTestResourcesService extends DefaultTask {
                                     try {
                                         Path cdsListPath = cdsClassList.toPath();
                                         List<String> fileContent = new ArrayList<>(Files.readAllLines(cdsListPath, StandardCharsets.UTF_8));
-                                        fileContent.removeIf(content -> content.contains("SingleThreadedBufferingProcessor"));
+                                        fileContent.removeIf(content -> content.contains("SingleThreadedBufferingProcessor") || content.contains("HandlerPublisher"));
                                         Files.write(cdsListPath, fileContent, StandardCharsets.UTF_8);
                                     } catch (IOException e) {
                                         // ignore

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -218,8 +218,11 @@ public abstract class StartTestResourcesService extends DefaultTask {
                                     List<String> fileContent = new ArrayList<>(Files.readAllLines(cdsListPath, StandardCharsets.UTF_8));
                                     fileContent.removeIf(content ->
                                             content.contains("SingleThreadedBufferingProcessor") ||
-                                                    content.contains("HandlerPublisher") ||
-                                                    content.contains("SingleThreadedBufferingSubscriber") ||
+//                                                    content.contains("HandlerPublisher") ||
+//                                                    content.contains("SingleThreadedBufferingSubscriber") ||
+                                                    content.contains("org/testcontainers") ||
+                                                    content.contains("org/graalvm") ||
+                                                    content.contains("io/netty/handler") ||
                                                     content.contains("jdk/proxy"));
                                     Files.write(cdsListPath, fileContent, StandardCharsets.UTF_8);
                                 } catch (IOException e) {

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -218,11 +218,9 @@ public abstract class StartTestResourcesService extends DefaultTask {
                                     List<String> fileContent = new ArrayList<>(Files.readAllLines(cdsListPath, StandardCharsets.UTF_8));
                                     fileContent.removeIf(content ->
                                             content.contains("SingleThreadedBufferingProcessor") ||
-                                                    content.contains("io/netty/channel/$Proxy") ||
                                                     content.contains("org/testcontainers") ||
                                                     content.contains("org/graalvm") ||
                                                     content.contains("io/netty/handler") ||
-                                                    content.contains("jdk/internal/event") ||
                                                     content.contains("jdk/proxy"));
                                     Files.write(cdsListPath, fileContent, StandardCharsets.UTF_8);
                                 } catch (IOException e) {

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -228,7 +228,7 @@ public abstract class StartTestResourcesService extends DefaultTask {
                                 getExecOperations().javaexec(spec -> {
                                     spec.setWorkingDir(cdsDir);
                                     configureJavaExec(processParameters, spec);
-                                    spec.jvmArgs("-Xlog:cds",
+                                    spec.jvmArgs(
                                             "-Xshare:dump",
                                             "-XX:SharedClassListFile=" + CDS_CLASS_LST,
                                             "-XX:SharedArchiveFile=" + CDS_FILE);
@@ -240,9 +240,9 @@ public abstract class StartTestResourcesService extends DefaultTask {
                                 if (cdsEnabled) {
                                     spec.setWorkingDir(cdsDir);
                                     if (!cdsClassList.exists()) {
-                                        spec.jvmArgs("-Xlog:cds", "-Xshare:off", "-XX:DumpLoadedClassList=" + CDS_CLASS_LST);
+                                        spec.jvmArgs("-Xshare:off", "-XX:DumpLoadedClassList=" + CDS_CLASS_LST);
                                     } else {
-                                        spec.jvmArgs("-Xlog:cds", "-XX:SharedArchiveFile=" + CDS_FILE);
+                                        spec.jvmArgs("-XX:SharedArchiveFile=" + CDS_FILE);
                                     }
                                 }
 

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -211,9 +211,9 @@ public abstract class StartTestResourcesService extends DefaultTask {
                                 if (cdsEnabled) {
                                     spec.setWorkingDir(cdsDir);
                                     if (cdsFile.exists()) {
-                                        spec.jvmArgs("-Xshare:on", "-XX:SharedArchiveFile=" + CDS_FILE);
+                                        spec.jvmArgs("-Xlog:cds", "-Xshare:on", "-XX:SharedArchiveFile=" + CDS_FILE);
                                     } else {
-                                        spec.jvmArgs("-XX:ArchiveClassesAtExit=" + CDS_FILE);
+                                        spec.jvmArgs("-Xlog:cds", "-XX:ArchiveClassesAtExit=" + CDS_FILE);
                                     }
                                 }
                                 spec.setClasspath(getObjects().fileCollection().from(processParameters.getClasspath().stream().filter(File::isFile).collect(Collectors.toList())));


### PR DESCRIPTION
This PR allows the server to be optimised with AppCDS 

Unfortunately due to issues with the server we have to limited the classes in the class list when creating the archive, but this doesn't seem to impact startup time.