### PR TITLE
Use buildArgs.add()

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -572,8 +572,8 @@ For example you can add options to the main image by doing:
 graalvmNative {
     binaries {
         main {
-            buildArgs << "-H:-DeleteLocalSymbols"
-            buildArgs << "-H:+PreserveFramePointer"
+            buildArgs.add("-H:-DeleteLocalSymbols")
+            buildArgs.add("-H:+PreserveFramePointer")
         }
     }
 }


### PR DESCRIPTION
The current variant did not work for me; `buildArgs.add()` works.

```bash
$ ./gradlew build
Starting a Gradle Daemon (subsequent builds will be faster)

> Configure project :
[native-image-plugin] Instrumenting task with the native-image-agent: test

FAILURE: Build failed with an exception.

* Where:
Build file '/workspaces/greeting-microservice/build.gradle' line: 304

* What went wrong:
A problem occurred evaluating root project 'greeter-microservice'.
> No signature of method: build_3jy7t3tr4x9k8bhkeq65paqfe.graalvmNative() is applicable for argument types: (build_3jy7t3tr4x9k8bhkeq65paqfe$_run_closure16) values: [build_3jy7t3tr4x9k8bhkeq65paqfe$_run_closure16@43a5a2f0]

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
```