### PR TITLE
Add support for AppCDS

### DIFF
--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -82,7 +82,7 @@ COPY layers/resources /home/app/resources
 COPY layers/application.jar /home/app/application.jar
 RUN mkdir /home/app/config-dirs
 COPY config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
-RUN native-image -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -H:Name=application -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile -H:Class=demo.app.Application
+RUN native-image -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -H:Name=application $graalVMBuilderExports -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile -H:Class=demo.app.Application
 FROM frolvlad/alpine-glibc:alpine-3.12
 RUN apk update && apk add libstdc++
 COPY --from=graalvm /home/app/application /app/application

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -573,7 +573,7 @@ COPY layers/resources /home/alternate/resources
 COPY layers/application.jar /home/alternate/application.jar
 RUN mkdir /home/alternate/config-dirs
 COPY config-dirs/generateResourcesConfigFile /home/alternate/config-dirs/generateResourcesConfigFile
-RUN native-image -cp /home/alternate/libs/*.jar:/home/alternate/resources:/home/alternate/application.jar --no-fallback -H:Name=application -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED -H:ConfigurationFileDirectories=/home/alternate/config-dirs/generateResourcesConfigFile -H:Class=example.Application
+RUN native-image -cp /home/alternate/libs/*.jar:/home/alternate/resources:/home/alternate/application.jar --no-fallback -H:Name=application $graalVMBuilderExports -H:ConfigurationFileDirectories=/home/alternate/config-dirs/generateResourcesConfigFile -H:Class=example.Application
 FROM frolvlad/alpine-glibc:alpine-3.12
 RUN apk update && apk add libstdc++
 HEALTHCHECK CMD curl -s localhost:8090/health | grep '"status":"UP"'

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/fixtures/AbstractEagerConfiguringFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/fixtures/AbstractEagerConfiguringFunctionalTest.groovy
@@ -7,4 +7,12 @@ class AbstractEagerConfiguringFunctionalTest extends AbstractFunctionalTest {
     BuildResult build(String... args) {
         return super.build("tasks", *args)
     }
+
+
+    String getGraalVMBuilderExports() {
+        ["com.oracle.svm.core.jdk",
+         "com.oracle.svm.core.configure"].collect {
+            "-J--add-exports=org.graalvm.nativeimage.builder/$it=ALL-UNNAMED"
+        }.join(" ")
+    }
 }

--- a/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -43,6 +44,10 @@ public class MicronautGraalPlugin implements Plugin<Project> {
     public static final String RICH_OUTPUT_PROPERTY = "io.micronaut.graalvm.rich.output";
 
     private static final Set<String> SOURCE_SETS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("main", "test")));
+    private static final List<String> GRAALVM_MODULE_EXPORTS = Collections.unmodifiableList(Arrays.asList(
+            "com.oracle.svm.core.jdk",
+            "com.oracle.svm.core.configure"
+    ));
 
     @Override
     public void apply(Project project) {
@@ -64,7 +69,7 @@ public class MicronautGraalPlugin implements Plugin<Project> {
                         inf.getIgnoreExistingResourcesConfigFile().convention(true);
                         inf.getRestrictToProjectDependencies().convention(true);
                     }));
-                    options.jvmArgs("--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED");
+                    options.jvmArgs(getGraalVMBuilderExports());
                     Provider<String> richOutput = project.getProviders().systemProperty(RICH_OUTPUT_PROPERTY);
                     if (richOutput.isPresent()) {
                         options.getRichOutput().convention(richOutput.map(Boolean::parseBoolean));
@@ -174,5 +179,11 @@ public class MicronautGraalPlugin implements Plugin<Project> {
                     "io.micronaut:micronaut-graal"
             );
         }
+    }
+
+    public static List<String> getGraalVMBuilderExports() {
+        return GRAALVM_MODULE_EXPORTS.stream()
+                .map(module -> "--add-exports=org.graalvm.nativeimage.builder/" + module + "=ALL-UNNAMED")
+                .collect(Collectors.toList());
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ spock = "2.1-groovy-3.0"
 graalvmPlugin = "0.9.13"
 micronaut = "3.2.0"
 micronaut-aot = "1.1.0"
-micronaut-testresources = "1.0.0"
+micronaut-testresources = "1.0.1"
 log4j2 = { require = "2.17.1", reject = ["]0, 2.17["] }
 
 [libraries]

--- a/samples/test-resources/multiproject/app1/build.gradle
+++ b/samples/test-resources/multiproject/app1/build.gradle
@@ -39,5 +39,5 @@ dependencies {
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
     runtimeOnly("mysql:mysql-connector-java")
 
-    testresources(project(":testresources"))
+    testResourcesService(project(":testresources"))
 }

--- a/samples/test-resources/multiproject/app2/build.gradle
+++ b/samples/test-resources/multiproject/app2/build.gradle
@@ -39,5 +39,5 @@ dependencies {
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
     runtimeOnly("org.postgresql:postgresql")
 
-    testresources(project(":testresources"))
+    testResourcesService(project(":testresources"))
 }

--- a/samples/test-resources/multiproject/app3/build.gradle
+++ b/samples/test-resources/multiproject/app3/build.gradle
@@ -13,7 +13,7 @@ repositories {
 dependencies {
     annotationProcessor("io.micronaut:micronaut-http-validation")
 
-    testresources(project(":testresources"))
+    testResourcesService(project(":testresources"))
 }
 
 micronaut {

--- a/samples/test-resources/multiproject/testresources/build.gradle
+++ b/samples/test-resources/multiproject/testresources/build.gradle
@@ -20,6 +20,6 @@ micronaut {
 }
 
 dependencies {
-    testresources 'mysql:mysql-connector-java'
-    testresources 'org.postgresql:postgresql'
+    testResourcesService 'mysql:mysql-connector-java'
+    testResourcesService 'org.postgresql:postgresql'
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1203,6 +1203,27 @@ A test resources request is, to simplify, a request to resolve a _missing config
 For example, if the `kafka.bootstrap-servers` property isn't set, Micronaut will query the test resources service for the value of this property.
 This will trigger the creaton of a a Kafka test container, and the service will answer with the URI to the bootstrap server.
 
+[NOTE]
+====
+The test resources service makes use of https://docs.oracle.com/en/java/javase/17/vm/class-data-sharing.html[Class Data Sharing] on Java 17+ in order to make startup faster.
+In general, this shouldn't be a problem but there may be cases where the test resources service fails to load because of a https://bugs.openjdk.org/browse/JDK-8290417[bug in the JDK].
+Should this happen to you, you can disable class data sharing explicitly using this configuration:
+
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+tasks.withType(StartTestResourcesService).configureEach {
+    useClassDataSharing = false
+}
+----
+
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+tasks.withType<StartTestResourcesService>().configureEach {
+    useClassDataSharing.set(false)
+}
+----
+====
+
 === The test resources plugin
 
 The easiest way to add test resources support is to apply the `io.micronaut.test-resources` plugin:

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1284,12 +1284,12 @@ micronaut {
 
 [NOTE]
 ====
-The `additionalModules` property can be used to declare {testresources-guide}[Micronaut Test Resources] modules. However, it might be necessary to add more libraries on the test resources classpath. For example, you may need to add additional JDBC drivers. For this, you can use the `testresources` configuration:
+The `additionalModules` property can be used to declare {testresources-guide}[Micronaut Test Resources] modules. However, it might be necessary to add more libraries on the test resources classpath. For example, you may need to add additional JDBC drivers. For this, you can use the `testResourcesService` configuration:
 [source,groovy]
 ----
 dependencies {
     // declare an additional dependency on test resources classpath
-    testresources "my:jdbc-driver:1.0"
+    testResourcesService "my:jdbc-driver:1.0"
 }
 ----
 ====
@@ -1361,7 +1361,7 @@ plugins {
 }
 
 dependencies {
-    testresources project(':shared-testresources')           // <2>
+    testResourcesService project(':shared-testresources')           // <2>
 }
 ----
 

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesConsumerPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesConsumerPlugin.java
@@ -44,7 +44,14 @@ public class MicronautTestResourcesConsumerPlugin implements Plugin<Project> {
     }
 
     private Configuration createTestResourcesExtension(Project project) {
+        // Legacy configuration was only used in 3.5.0 so it's relatively safe
+        Configuration legacyConf = project.getConfigurations().create("testresources", conf -> {
+            conf.setCanBeConsumed(false);
+            conf.setCanBeResolved(false);
+            conf.setDescription("[deprecated] Please use " + MicronautTestResourcesPlugin.TESTRESOURCES_CONFIGURATION + " instead.");
+        });
         return project.getConfigurations().create(MicronautTestResourcesPlugin.TESTRESOURCES_CONFIGURATION, conf -> {
+            conf.extendsFrom(legacyConf);
             conf.setCanBeConsumed(false);
             conf.setCanBeResolved(false);
             conf.setDescription("Used to declare projects which provide test resources");

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -63,7 +63,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
     public static final String START_TEST_RESOURCES_SERVICE_INTERNAL = "internalStartTestResourcesService";
     public static final String STOP_TEST_RESOURCES_SERVICE = "stopTestResourcesService";
     public static final String GROUP = "Micronaut Test Resources";
-    public static final String TESTRESOURCES_CONFIGURATION = "testresources";
+    public static final String TESTRESOURCES_CONFIGURATION = "testResourcesService";
     public static final String TESTRESOURCES_ELEMENTS_CONFIGURATION = "testresourcesSettingsElements";
     public static final String MICRONAUT_TEST_RESOURCES_USAGE = "micronaut.test.resources";
 
@@ -321,7 +321,14 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
     }
 
     private static Configuration createTestResourcesServerConfiguration(Project project) {
+        // Legacy configuration was only used in 3.5.0 so it's relatively safe
+        Configuration legacyConf = project.getConfigurations().create("testresources", conf -> {
+            conf.setCanBeConsumed(false);
+            conf.setCanBeResolved(false);
+            conf.setDescription("[deprecated] Please use " + MicronautTestResourcesPlugin.TESTRESOURCES_CONFIGURATION + " instead.");
+        });
         return project.getConfigurations().create(TESTRESOURCES_CONFIGURATION, conf -> {
+            conf.extendsFrom(legacyConf);
             conf.setDescription("Dependencies for the Micronaut test resources service");
             conf.setCanBeConsumed(false);
             conf.setCanBeResolved(true);

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -13,6 +13,7 @@ import io.micronaut.testresources.buildtools.ServerUtils;
 import io.micronaut.testresources.buildtools.TestResourcesClasspath;
 import io.micronaut.testresources.buildtools.VersionInfo;
 import org.gradle.api.GradleException;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -114,14 +115,15 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
         server.getDependencies().addAllLater(buildTestResourcesDependencyList(project, dependencies, config, testResourcesSourceSet));
         String accessToken = UUID.randomUUID().toString();
         Provider<String> accessTokenProvider = providers.provider(() -> accessToken);
+        DirectoryProperty buildDirectory = project.getLayout().getBuildDirectory();
         Provider<Directory> settingsDirectory = config.getSharedServer().flatMap(shared -> {
             DirectoryProperty directoryProperty = project.getObjects().directoryProperty();
             if (Boolean.TRUE.equals(shared)) {
                 directoryProperty.set(ServerUtils.getDefaultSharedSettingsPath().toFile());
             }
             return directoryProperty;
-        }).orElse(project.getLayout().getBuildDirectory().dir("test-resources-settings"));
-        Provider<RegularFile> portFile = project.getLayout().getBuildDirectory().file("test-resources-port.txt");
+        }).orElse(buildDirectory.dir("test-resources-settings"));
+        Provider<RegularFile> portFile = buildDirectory.file("test-resources-port.txt");
         Path stopAtEndFile = createStopFile(project);
         TaskContainer tasks = project.getTasks();
         Provider<Boolean> isStandalone = config.getSharedServer().zip(providers.provider(() -> {
@@ -132,7 +134,8 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
                     .anyMatch(task -> task.getProject().equals(project) && task.getName().equals(START_TEST_RESOURCES_SERVICE));
             return singleTask && onlyStartTask;
         }), (shared, singleTask) -> shared || singleTask);
-        TaskProvider<StartTestResourcesService> internalStart = createStartServiceTask(server, config, settingsDirectory, accessTokenProvider, tasks, portFile, stopAtEndFile, isStandalone);
+        Provider<Directory> cdsDir = buildDirectory.dir("test-resources/cds");
+        TaskProvider<StartTestResourcesService> internalStart = createStartServiceTask(server, config, settingsDirectory, accessTokenProvider, tasks, portFile, stopAtEndFile, isStandalone, cdsDir);
         tasks.register(START_TEST_RESOURCES_SERVICE, task -> {
             task.dependsOn(internalStart);
             task.setOnlyIf(t -> config.getEnabled().get());
@@ -204,7 +207,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
                                                                            TaskContainer tasks,
                                                                            Provider<RegularFile> portFile,
                                                                            Path stopFile,
-                                                                           Provider<Boolean> isStandalone) {
+                                                                           Provider<Boolean> isStandalone, Provider<Directory> cdsDir) {
         return tasks.register(START_TEST_RESOURCES_SERVICE_INTERNAL, StartTestResourcesService.class, task -> {
             task.setOnlyIf(t -> config.getEnabled().get());
             task.getPortFile().convention(portFile);
@@ -216,6 +219,8 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
             task.getForeground().convention(false);
             task.getStopFile().set(stopFile.toFile());
             task.getStandalone().set(isStandalone);
+            task.getClassDataSharingDir().convention(cdsDir);
+            task.getUseClassDataSharing().convention(JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17));
         });
     }
 

--- a/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/ApplicationTestResourcesPluginSpec.groovy
+++ b/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/ApplicationTestResourcesPluginSpec.groovy
@@ -58,7 +58,7 @@ class ApplicationTestResourcesPluginSpec extends AbstractGradleBuildSpec {
             additionalModules.addAll(JDBC_MYSQL, KAFKA)
         """
         withDependencies """
-            testresources "mysql:mysql-connector-java"
+            testResourcesService "mysql:mysql-connector-java"
         """
 
         when:


### PR DESCRIPTION
Support application class data sharing by upgrading to Micronaut Test Resources 1.0.1.
This PR also renames the `testresources` configuration to `testResourcesService` for clarity (in a backwards compatible way). This should have been done in 3.5.0 but for some reason slipped out of the release.