### PR TITLE
Fix eager configuration of some tasks

### DIFF
--- a/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -106,7 +106,7 @@ public class MicronautGraalPlugin implements Plugin<Project> {
                 project.afterEvaluate(unused -> {
                     // Workaround for https://github.com/graalvm/native-build-tools/issues/175
                     // and https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/306
-                    project.getTasks().withType(ProcessResources.class, task -> {
+                    project.getTasks().withType(ProcessResources.class).configureEach(task -> {
                         // yes we do this at config time, because otherwise the workaround
                         // simply doesn't work because there would be no inputs so that
                         // task would never be executed. So yes, this is incorrect because

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -104,7 +104,7 @@ public class MicronautComponentPlugin implements Plugin<Project> {
 
             if (testRuntime != MicronautTestRuntime.NONE) {
                 // set JUnit 5 platform
-                project.getTasks().withType(Test.class, test -> {
+                project.getTasks().withType(Test.class).configureEach(test -> {
                     if (!test.getTestFramework().getClass().getName().contains("JUnitPlatform")) {
                         test.useJUnitPlatform();
                     }
@@ -125,7 +125,7 @@ public class MicronautComponentPlugin implements Plugin<Project> {
                     })
                     .isEmpty();
             if (hasJunit5) {
-                project.getTasks().withType(Test.class, test -> {
+                project.getTasks().withType(Test.class).configureEach(test -> {
                     if (!test.getTestFramework().getClass().getName().contains("JUnitPlatform")) {
                         test.useJUnitPlatform();
                     }


### PR DESCRIPTION
The `withType` API is _eager_ so was trigerring configuration when it should avoid it.

Fixes #506