### PR TITLE
Bump minimal requirements to Java 17

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11']
+        java: ['17']
         graalvm: ['latest', 'dev']
     steps:
        # https://github.com/actions/virtual-environments/issues/709

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '17']
+        java: ['17']
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: '8'
+          java-version: '17'
       - name: Publish to Sonatype Snapshots
         if: success()
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: '8'
+          java-version: '17'
       - name: Set the current release version
         id: release_version
         run: echo ::set-output name=release_version::${GITHUB_REF:11}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -38,7 +38,7 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           version: '22.2.0'
-          java-version: '11'
+          java-version: '17'
           components: 'native-image'
       - name: Optional setup step
         env:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        java: ['11']
+        java: ['17']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3.0.8

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
@@ -175,16 +175,16 @@ public class MicronautDockerfile extends Dockerfile implements DockerBuildOption
 
     private String getProjectFnVersion() {
         JavaVersion javaVersion = Jvm.current().getJavaVersion();
-        if (javaVersion != null && javaVersion.isJava11Compatible()) {
-            return "jre11-latest";
+        if (javaVersion != null && javaVersion.isCompatibleWith(JavaVersion.VERSION_17)) {
+            return "jre17-latest";
         }
         return "latest";
     }
 
     static void setupResources(Dockerfile task) {
         String workDir = DEFAULT_WORKING_DIR;
-        if (task instanceof DockerBuildOptions) {
-            workDir = ((DockerBuildOptions) task).getTargetWorkingDirectory().get();
+        if (task instanceof DockerBuildOptions dbo) {
+            workDir = dbo.getTargetWorkingDirectory().get();
         }
         task.workingDir(workDir);
         task.copyFile("layers/libs", workDir + "/libs");

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -54,7 +54,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
 
     private static final List<Integer> SUPPORTED_JAVA_VERSIONS = Collections.unmodifiableList(
             // keep those in descending order
-            Arrays.asList(17, 11)
+            Arrays.asList(17)
     );
     private static final String ARM_ARCH = "aarch64";
     private static final String X86_64_ARCH = "amd64";
@@ -361,7 +361,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
                 return javaVersion;
             }
         }
-        return SUPPORTED_JAVA_VERSIONS.stream().reduce((x, y) -> y).orElse(11);
+        return SUPPORTED_JAVA_VERSIONS.stream().reduce((x, y) -> y).orElse(17);
     }
 
     @TaskAction
@@ -408,7 +408,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
                         .getFiles()
                         .stream()
                         .map(this::toCopyResourceDirectoryInstruction)
-                        .collect(Collectors.toList())
+                        .toList()
         ));
         runCommand(getProviders().provider(() -> String.join(" ", buildActualCommandLine(executable, buildStrategy, imageResolver))));
         switch (buildStrategy) {
@@ -530,7 +530,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
                         }
                         return arg;
                     })
-                    .collect(Collectors.toList());
+                    .toList();
         }
         return args;
     }
@@ -553,7 +553,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
                 .getFiles()
                 .stream()
                 .map(f -> getTargetWorkingDirectory().get() + "/config-dirs/" + f.getName())
-                .collect(Collectors.toList())
+                .toList()
         );
         options.getConfigurationFileDirectories().setFrom(
                 remappedConfigDirectories
@@ -609,8 +609,8 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
 
     private String getProjectFnVersion() {
         JavaVersion javaVersion = Jvm.current().getJavaVersion();
-        if (javaVersion != null && javaVersion.isJava11Compatible()) {
-            return "jre11-latest";
+        if (javaVersion != null && javaVersion.isCompatibleWith(JavaVersion.VERSION_17)) {
+            return "jre17-latest";
         }
         return "latest";
     }

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/model/MicronautDockerImage.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/model/MicronautDockerImage.java
@@ -20,7 +20,6 @@ import org.gradle.api.Named;
 import org.gradle.api.provider.ListProperty;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Represents a Micronaut docker image, represented
@@ -36,7 +35,7 @@ public interface MicronautDockerImage extends Named {
     default List<Layer> findLayers(RuntimeKind runtimeKind) {
         return getLayers().map(layers -> layers.stream()
                 .filter(layer -> layer.getRuntimeKind().get().isCompatibleWith(runtimeKind))
-                .collect(Collectors.toList()))
+                .toList())
                 .get();
     }
 }

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
@@ -3,10 +3,8 @@ package io.micronaut.gradle
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.IgnoreIf
 import spock.lang.Issue
-import spock.lang.Requires
 
 @IgnoreIf({ os.windows })
-@Requires({ jvm.isJava11Compatible() })
 class DockerBuildTaskSpec extends AbstractGradleBuildSpec {
 
     def "test build docker image"() {

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
@@ -2,9 +2,7 @@ package io.micronaut.gradle.aot
 
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Issue
-import spock.lang.Requires
 
-@Requires({ jvm.isJava11Compatible() })
 class BasicMicronautAOTSpec extends AbstractAOTPluginSpec {
 
     def "generates optimizations for #runtime (#kind)"() {

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/FunctionsMicronautAOTSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/FunctionsMicronautAOTSpec.groovy
@@ -4,7 +4,6 @@ import io.micronaut.gradle.AbstractGradleBuildSpec
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Requires
 
-@Requires({ jvm.isJava11Compatible() })
 class FunctionsMicronautAOTSpec extends AbstractAOTPluginSpec {
     private static final List<String> PROVIDERS = ["aws"]
     private static final List<String> RUNTIMES = ["jit", "native"]

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -2,10 +2,8 @@ package io.micronaut.gradle.aot
 
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.IgnoreIf
-import spock.lang.Requires
 
 @IgnoreIf({ os.windows })
-@Requires({ jvm.isJava11() })
 class MicronautAOTDockerSpec extends AbstractAOTPluginSpec {
 
     def "generates an optimized docker file"() {
@@ -74,7 +72,7 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
         result.task(":optimizedDockerBuildNative").outcome == TaskOutcome.SUCCESS
 
         def dockerFile = normalizeLineEndings(file("build/docker/native-optimized/DockerfileNative").text)
-        dockerFile == """FROM ghcr.io/graalvm/native-image:ol7-java11-22.2.0 AS graalvm
+        dockerFile == """FROM ghcr.io/graalvm/native-image:ol7-java17-22.2.0 AS graalvm
 WORKDIR /home/app
 COPY layers/libs /home/app/libs
 COPY layers/classes /home/app/classes

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/ShadowMicronautAOTSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/ShadowMicronautAOTSpec.groovy
@@ -1,8 +1,5 @@
 package io.micronaut.gradle.aot
 
-import spock.lang.Requires
-
-@Requires({ jvm.isJava11Compatible() })
 class ShadowMicronautAOTSpec extends AbstractAOTPluginSpec {
 
     def "builds a fatjar optimized flavor"() {

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -9,7 +9,6 @@ import spock.lang.Requires
 
 @Requires({ AbstractGradleBuildSpec.graalVmAvailable })
 @IgnoreIf({ os.windows })
-@Requires({ jvm.isJava11Compatible() })
 class DockerNativeFunctionalTest extends AbstractEagerConfiguringFunctionalTest {
 
     def "test build docker native image for runtime #runtime"() {
@@ -33,8 +32,8 @@ class DockerNativeFunctionalTest extends AbstractEagerConfiguringFunctionalTest 
             mainClassName="example.Application"
             
             java {
-                sourceCompatibility = JavaVersion.toVersion('11')
-                targetCompatibility = JavaVersion.toVersion('11')
+                sourceCompatibility = JavaVersion.toVersion('17')
+                targetCompatibility = JavaVersion.toVersion('17')
             }
             
             dockerfileNative {
@@ -122,8 +121,8 @@ micronaut:
             }
 
             java {
-                sourceCompatibility = JavaVersion.toVersion('11')
-                targetCompatibility = JavaVersion.toVersion('11')
+                sourceCompatibility = JavaVersion.toVersion('17')
+                targetCompatibility = JavaVersion.toVersion('17')
             }
 
             dockerfileNative {
@@ -170,8 +169,8 @@ micronaut:
             }
 
             java {
-                sourceCompatibility = JavaVersion.toVersion('11')
-                targetCompatibility = JavaVersion.toVersion('11')
+                sourceCompatibility = JavaVersion.toVersion('17')
+                targetCompatibility = JavaVersion.toVersion('17')
             }
         """
 
@@ -211,8 +210,8 @@ micronaut:
             }
 
             java {
-                sourceCompatibility = JavaVersion.toVersion('11')
-                targetCompatibility = JavaVersion.toVersion('11')
+                sourceCompatibility = JavaVersion.toVersion('17')
+                targetCompatibility = JavaVersion.toVersion('17')
             }
         """
 
@@ -256,8 +255,8 @@ micronaut:
             }
             
             java {
-                sourceCompatibility = JavaVersion.toVersion('11')
-                targetCompatibility = JavaVersion.toVersion('11')
+                sourceCompatibility = JavaVersion.toVersion('17')
+                targetCompatibility = JavaVersion.toVersion('17')
             }
             
             mainClassName="example.Application"
@@ -429,8 +428,8 @@ class Application {
             }
                     
             java {
-                sourceCompatibility = JavaVersion.toVersion('11')
-                targetCompatibility = JavaVersion.toVersion('11')
+                sourceCompatibility = JavaVersion.toVersion('17')
+                targetCompatibility = JavaVersion.toVersion('17')
             }
             
             dockerfile {
@@ -510,8 +509,8 @@ class Application {
             mainClassName="example.Application"
             
             java {
-                sourceCompatibility = JavaVersion.toVersion('11')
-                targetCompatibility = JavaVersion.toVersion('11')
+                sourceCompatibility = JavaVersion.toVersion('17')
+                targetCompatibility = JavaVersion.toVersion('17')
             }
             
             dockerfileNative {
@@ -565,7 +564,7 @@ micronaut:
         expect:
         task.outcome == TaskOutcome.SUCCESS
         dockerFile == """
-FROM ghcr.io/graalvm/native-image:ol7-java11-22.2.0 AS graalvm
+FROM ghcr.io/graalvm/native-image:ol7-java17-22.2.0 AS graalvm
 WORKDIR /home/alternate
 COPY layers/libs /home/alternate/libs
 COPY layers/classes /home/alternate/classes

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/graalvm/MicronautGraalPluginSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/graalvm/MicronautGraalPluginSpec.groovy
@@ -7,7 +7,6 @@ import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Requires
 
 @Requires({ AbstractGradleBuildSpec.graalVmAvailable && !os.windows })
-@Requires({ jvm.isJava11Compatible() })
 class MicronautGraalPluginSpec extends AbstractEagerConfiguringFunctionalTest {
 
     void 'generate GraalVM resource-config.json with OpenAPI and resources included'() {

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
@@ -6,11 +6,9 @@ import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Requires
-import spock.util.environment.RestoreSystemProperties
 
 @Requires({ AbstractGradleBuildSpec.graalVmAvailable })
 @IgnoreIf({ os.windows })
-@Requires({ jvm.isJava11Compatible() })
 class LambdaNativeImageSpec extends AbstractFunctionalTest {
 
     void 'mainclass is set correctly for an application deployed as GraalVM and Lambda'() {
@@ -35,8 +33,8 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
             }
             
             java {
-                sourceCompatibility = JavaVersion.toVersion('11')
-                targetCompatibility = JavaVersion.toVersion('11')
+                sourceCompatibility = JavaVersion.toVersion('17')
+                targetCompatibility = JavaVersion.toVersion('17')
             }
         """
 
@@ -77,8 +75,8 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
             }
 
             java {
-                sourceCompatibility = JavaVersion.toVersion('11')
-                targetCompatibility = JavaVersion.toVersion('11')
+                sourceCompatibility = JavaVersion.toVersion('17')
+                targetCompatibility = JavaVersion.toVersion('17')
             }
 
             dockerfileNative {
@@ -126,8 +124,8 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
             }
             
             java {
-                sourceCompatibility = JavaVersion.toVersion('11')
-                targetCompatibility = JavaVersion.toVersion('11')
+                sourceCompatibility = JavaVersion.toVersion('17')
+                targetCompatibility = JavaVersion.toVersion('17')
             }
             
             graalvmNative {
@@ -185,8 +183,8 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
             }
 
             java {
-                sourceCompatibility = JavaVersion.toVersion('11')
-                targetCompatibility = JavaVersion.toVersion('11')
+                sourceCompatibility = JavaVersion.toVersion('17')
+                targetCompatibility = JavaVersion.toVersion('17')
             }
         """
 
@@ -234,8 +232,8 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
             }
 
             java {
-                sourceCompatibility = JavaVersion.toVersion('11')
-                targetCompatibility = JavaVersion.toVersion('11')
+                sourceCompatibility = JavaVersion.toVersion('17')
+                targetCompatibility = JavaVersion.toVersion('17')
             }
 
             dockerfileNative {
@@ -286,8 +284,8 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
             }
 
             java {
-                sourceCompatibility = JavaVersion.toVersion('11')
-                targetCompatibility = JavaVersion.toVersion('11')
+                sourceCompatibility = JavaVersion.toVersion('17')
+                targetCompatibility = JavaVersion.toVersion('17')
             }
         """
 

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithAotAndGraalVMSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithAotAndGraalVMSpec.groovy
@@ -5,7 +5,6 @@ import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Requires
 
 @Requires({ AbstractGradleBuildSpec.graalVmAvailable && !os.windows })
-@Requires({ jvm.isJava11Compatible() })
 class TestResourcesWithAotAndGraalVMSpec extends AbstractTestResourcesSpec {
 
     def "runs optimized binary"() {

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithGraalVMSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithGraalVMSpec.groovy
@@ -5,7 +5,6 @@ import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Requires
 
 @Requires({ AbstractGradleBuildSpec.graalVmAvailable && !os.windows })
-@Requires({ jvm.isJava11Compatible() })
 class TestResourcesWithGraalVMSpec extends AbstractTestResourcesSpec {
 
     def "runs native tests"() {

--- a/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -168,7 +168,7 @@ public class MicronautGraalPlugin implements Plugin<Project> {
         addGraalVMAnnotationProcessorDependency(project,
                 sourceSets.stream()
                         .filter(sourceSet -> SOURCE_SETS.contains(sourceSet.getName()))
-                        .collect(Collectors.toList())
+                        .toList()
         );
     }
 
@@ -184,6 +184,6 @@ public class MicronautGraalPlugin implements Plugin<Project> {
     public static List<String> getGraalVMBuilderExports() {
         return GRAALVM_MODULE_EXPORTS.stream()
                 .map(module -> "--add-exports=org.graalvm.nativeimage.builder/" + module + "=ALL-UNNAMED")
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/graalvm-plugin/src/test/groovy/io/micronaut/gradle/NativeImageMultiProjectSpec.groovy
+++ b/graalvm-plugin/src/test/groovy/io/micronaut/gradle/NativeImageMultiProjectSpec.groovy
@@ -7,7 +7,6 @@ import spock.lang.Requires
 
 @Requires({ AbstractGradleBuildSpec.graalVmAvailable })
 @IgnoreIf({ os.isWindows() })
-@Requires({ jvm.isJava11() })
 class NativeImageMultiProjectSpec extends AbstractGradleBuildSpec {
 
     def setup() {

--- a/graalvm-plugin/src/test/groovy/io/micronaut/gradle/NativeImageTaskSpec.groovy
+++ b/graalvm-plugin/src/test/groovy/io/micronaut/gradle/NativeImageTaskSpec.groovy
@@ -6,7 +6,6 @@ import spock.lang.IgnoreIf
 import spock.lang.Requires
 
 @Requires({ AbstractGradleBuildSpec.graalVmAvailable })
-@Requires({ jvm.isJava11() })
 class NativeImageTaskSpec extends AbstractGradleBuildSpec {
 
     @IgnoreIf({ os.isWindows() })

--- a/graalvm-plugin/src/test/groovy/io/micronaut/gradle/NativeImageTestTaskSpec.groovy
+++ b/graalvm-plugin/src/test/groovy/io/micronaut/gradle/NativeImageTestTaskSpec.groovy
@@ -5,7 +5,6 @@ import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Requires
 
 @Requires({ AbstractGradleBuildSpec.graalVmAvailable && !os.windows })
-@Requires({ jvm.isJava11() })
 class NativeImageTestTaskSpec extends AbstractGradleBuildSpec {
 
     def "test execute tests against native image"() {

--- a/samples/aot/aws-function/build.gradle
+++ b/samples/aot/aws-function/build.gradle
@@ -42,8 +42,8 @@ dependencies {
 
 
 java {
-    sourceCompatibility = JavaVersion.toVersion("11")
-    targetCompatibility = JavaVersion.toVersion("11")
+    sourceCompatibility = JavaVersion.toVersion("17")
+    targetCompatibility = JavaVersion.toVersion("17")
 }
 
 tasks.named("assemble") {

--- a/samples/aot/basic-app/build.gradle
+++ b/samples/aot/basic-app/build.gradle
@@ -52,6 +52,6 @@ application {
 }
 
 java {
-    sourceCompatibility = JavaVersion.toVersion("11")
-    targetCompatibility = JavaVersion.toVersion("11")
+    sourceCompatibility = JavaVersion.toVersion("17")
+    targetCompatibility = JavaVersion.toVersion("17")
 }

--- a/samples/aot/with-shadow/build.gradle
+++ b/samples/aot/with-shadow/build.gradle
@@ -52,6 +52,6 @@ application {
 }
 
 java {
-    sourceCompatibility = JavaVersion.toVersion("11")
-    targetCompatibility = JavaVersion.toVersion("11")
+    sourceCompatibility = JavaVersion.toVersion("17")
+    targetCompatibility = JavaVersion.toVersion("17")
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,8 +1,8 @@
 = Micronaut Gradle plugin
-:native-build-tools-version: 0.9.11
+:native-build-tools-version: 0.9.13
 :kotlin-version: 1.6.21
 :micronaut-version: 3.5.1
-:gradle-version: 7.4.1
+:gradle-version: 7.5.1
 :shadow-version: 7.1.2
 :native-gradle-plugin: https://graalvm.github.io/native-build-tools/{native-build-tools-version}/gradle-plugin.html
 :gradle-docs: https://docs.gradle.org/{gradle-version}/userguide
@@ -669,18 +669,18 @@ The default uses an `{default-docker-image}` base image, however you can easily 
 [source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
 ----
 tasks.named("dockerfile") {
-  baseImage = "oracle/graalvm-ce:20.3.0-java11"
+  baseImage = "oracle/graalvm-ce:22.2.0-java17"
 }
 ----
 
 [source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
 ----
 tasks.named<MicronautDockerfile>("dockerfile") {
-  baseImage.set("oracle/graalvm-ce:20.3.0-java11")
+  baseImage.set("oracle/graalvm-ce:22.2.0-java17")
 }
 ----
 
-The above examples switches to use GraalVM CE 20.3.0 as a base image.
+The above examples switches to use GraalVM CE 22.2.0 as a base image.
 
 To build the application into a Native Image you can run:
 
@@ -1511,7 +1511,7 @@ Similarly, to compile the native image, you now need to run `nativeCompile` inst
 In addition, the official GraalVM plugin makes use of Gradle toolchains support, which can lead to surprising behavior if you are used to switching between local JDKs. If you are facing errors like this one:
 
 ----
-> No compatible toolchains found for request filter: {languageVersion=11, vendor=matching('GraalVM'), implementation=vendor-specific} (auto-detect true, auto-download true)
+> No compatible toolchains found for request filter: {languageVersion=17, vendor=matching('GraalVM'), implementation=vendor-specific} (auto-detect true, auto-download true)
 ----
 
 then we recommend tweaking toolchain detection as described in <<#toolchain-behavior, this section of the documentation>>.

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -90,7 +90,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
                             dc.because("Aligning version of Micronaut the current Micronaut version");
                             dc.version(version -> version.strictly(v));
                         }))
-                        .collect(Collectors.toList())
+                        .toList()
         ));
     }
 
@@ -279,7 +279,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
                         .filter(ModuleDependency.class::isInstance)
                         .map(ModuleDependency.class::cast)
                         .map(d -> new MavenDependency(d.getGroup(), d.getName(), d.getVersion()))
-                        .collect(Collectors.toList());
+                        .toList();
             }
             String testResourcesVersion = config.getVersion().get();
             return concat(concat(
@@ -291,7 +291,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
                                     .map(m -> "io.micronaut.testresources:micronaut-test-resources-" + m + ":" + testResourcesVersion))
                             .map(dependencies::create),
                     Stream.of(dependencies.create(testResourcesSourceSet.getRuntimeClasspath())))
-                    .collect(Collectors.toList());
+                    .toList();
         }).orElse(Collections.emptyList());
     }
 


### PR DESCRIPTION
This commit upgrades the plugin to build with Java 17, but also require everything to use Java 17 minimally: this is preparation work for supporting Micronaut 4 which will raise the minimal JDK version to 17.

This doesn't upgrade transitive plugins like the Docker plugin yet.