### PR TITLE
fix(MicronautDockerPlugin): put local resources and classes at the beginning of the Class-Path

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
@@ -163,11 +163,11 @@ public class MicronautDockerPlugin implements Plugin<Project> {
                     Configuration runtimeClasspath = project.getConfigurations()
                             .getByName(RUNTIME_CLASSPATH_CONFIGURATION_NAME);
 
+                    classpath.add("resources/");
+                    classpath.add("classes/");
                     for (File file : runtimeClasspath) {
                         classpath.add("libs/" + file.getName());
                     }
-                    classpath.add("resources/");
-                    classpath.add("classes/");
                     return String.join(" ", classpath);
                 }));
                 manifest.attributes(attrs);


### PR DESCRIPTION
We're having an issue where our `application.yml` and `logback.xml`, located in the `resources` folder, are being ignored as one if the lib in the class-path already include a file with that name. I think it makes sense to put the current application's resources before the libs.