### PR TITLE
Fixes #543 APK should update with no caching enabled

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -463,7 +463,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
                 // mandatory dependency for alpine-glibc docker images
                 runCommand(getProviders().provider(() -> {
                     if (baseImageProvider.get().getImage().contains("alpine-glibc")) {
-                        return "apk update && apk add libstdc++";
+                        return "apk --no-cache update && apk add libstdc++";
                     }
                     return "";
                 }));

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -153,6 +153,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
         getDestFile().set(project.getLayout().getBuildDirectory().file("docker/DockerfileNative"));
         getBuildStrategy().convention(DockerBuildStrategy.DEFAULT);
         getRequireGraalSdk().convention(true);
+        getExposedPorts().convention(Collections.singletonList(8080));
         getJdkVersion().convention(
                 javaExtension.getToolchain()
                         .getLanguageVersion()


### PR DESCRIPTION
Small optimisation to reduce the resulting Docker image size. By adding the `--no-chache` option the package list does not get included in the Docker layer, which is fetched by `apk update.