### PR TITLE
Fixes #543 Docker multi-stage build for native image should not cache…

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -463,7 +463,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
                 // mandatory dependency for alpine-glibc docker images
                 runCommand(getProviders().provider(() -> {
                     if (baseImageProvider.get().getImage().contains("alpine-glibc")) {
-                        return "apk update && apk add libstdc++";
+                        return "apk --no-cache update && apk add libstdc++";
                     }
                     return "";
                 }));


### PR DESCRIPTION
This PR fixes issue #543 

# Motivation

This tiny change reduces the size of the final Docker image, since it does not include the package tar downloaded by `apk update` within the Docker image. It is a common practice to avoid unnecessary data in the Docker image.

# Description

Using version 3.5.3 of the Gradle plugins produces a `DockerfileNative` such as.

```Dockerfile
FROM ghcr.io/graalvm/native-image:ol7-java17-22.2.0 AS graalvm
WORKDIR /home/app
COPY layers/libs /home/app/libs
COPY layers/classes /home/app/classes
COPY layers/resources /home/app/resources
COPY layers/application.jar /home/app/application.jar
RUN mkdir /home/app/config-dirs
COPY config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
RUN native-image -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -H:Name=application -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.configure=ALL-UNNAMED -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile -H:Class=ch.onstructive.www.Application
FROM frolvlad/alpine-glibc:alpine-3.12
RUN apk update && apk add libstdc++
COPY --from=graalvm /home/app/application /app/application
ENTRYPOINT ["/app/application"]
```

In the final stage the Dockerfile updates the `apk` index and adds `libstdc++` to the Docker image. The index isn't thrown away and remains in the image.

Instead of calling 

```sh
RUN apk update && apk add libstdc++
```
the plugin should add the `--no-cache` option, which will purge the data afterwards. (see https://stackoverflow.com/a/49119046/960875)

```sh
RUN apk --no-cache update && apk add libstdc++
```
