### PR TITLE
CRaC support without elevated permissions

### DIFF
--- a/crac-plugin/src/main/resources/checkpoint.sh
+++ b/crac-plugin/src/main/resources/checkpoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Make sure last pid is bumped to 199 so java processes will not have pid conflicts when restroing
+echo 199 > /proc/sys/kernel/ns_last_pid
+
 # Set a trap to close the app once the script finishes
 trap 'echo "Killing $PROCESS" && kill -0 $PROCESS 2>/dev/null && kill $PROCESS' EXIT
 


### PR DESCRIPTION
make sure that pid doesn't conflict so no elevated permissions are required (to use pid namespaces)