### PR TITLE
Bump pid to 599 to avoid pid conflicts when restoring

### DIFF
--- a/crac-plugin/src/main/resources/checkpoint.sh
+++ b/crac-plugin/src/main/resources/checkpoint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+
+# Bump pid to avoid pid conflicts when restroing
+echo 599 > /proc/sys/kernel/ns_last_pid
+
 # Set a trap to close the app once the script finishes
 trap 'echo "Killing $PROCESS" && kill -0 $PROCESS 2>/dev/null && kill $PROCESS' EXIT
 

--- a/crac-plugin/src/main/resources/checkpoint.sh
+++ b/crac-plugin/src/main/resources/checkpoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-# Bump pid to avoid pid conflicts when restroing
+# Bump pid to avoid pid conflicts when restoring
 echo 599 > /proc/sys/kernel/ns_last_pid
 
 # Set a trap to close the app once the script finishes

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1521,7 +1521,7 @@ You will then be able to run your image via:
 
 [source, bash]
 ----
-docker run --privileged -p 8080:8080 <image-name>
+docker run --cap-add=cap_sys_ptrace -p 8080:8080 <image-name>
 ----
 
 === Configuration


### PR DESCRIPTION
This allows users to restore without running docker with `--privileged`

If pid is 599 there is a low likelihood will conflict with an existing one, so CRIU does not need to fork the process or use pid namespaces to restore. This means that we can run without elevated permissions