### PR TITLE
Fix CRaC for ubuntu 22.04

### DIFF
--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
@@ -37,7 +37,7 @@ import static io.micronaut.gradle.Strings.capitalize;
 
 public class MicronautCRaCPlugin implements Plugin<Project> {
 
-    public static final String CRAC_DEFAULT_BASE_IMAGE = "ubuntu:20.04";
+    public static final String CRAC_DEFAULT_BASE_IMAGE = "ubuntu:22.04";
     public static final String CRAC_DEFAULT_BASE_IMAGE_PLATFORM = "linux/amd64";
     public static final String CRAC_DEFAULT_READINESS_COMMAND = "curl --output /dev/null --silent --head http://localhost:8080";
     private static final String CRAC_TASK_GROUP = "CRaC";

--- a/crac-plugin/src/main/resources/checkpoint.sh
+++ b/crac-plugin/src/main/resources/checkpoint.sh
@@ -8,6 +8,10 @@ echo 599 > /proc/sys/kernel/ns_last_pid
 trap 'echo "Killing $PROCESS" && kill -0 $PROCESS 2>/dev/null && kill $PROCESS' EXIT
 
 echo "Starting application"
+
+# Fix for WSL and OS X Docker Kernels
+GLIBC_TUNABLES=glibc.pthread.rseq=0
+
 # Run the app in the background
 /azul-crac-jdk/bin/java \
   -XX:CRaCCheckpointTo=cr \

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1507,7 +1507,7 @@ Micronaut CRaC is a module which adds support for https://openjdk.org/projects/c
 
 It is capable of generating a docker image containing a CRaC enabled JDK and a pre-warmed, checkpointed application via a new task `dockerCracBuild`.
 
-IMPORTANT: Currently CRaC support has only been tested on Ubuntu 18.04 and 20.04.  It also requires an x86 machine architecture.
+IMPORTANT: Currently CRaC support has only been tested on Ubuntu 18.04, 20.04 and 22.04.  It also requires an x86 machine architecture.
 
 When executed, this task will:
 
@@ -1561,7 +1561,7 @@ micronaut {
         enabled = true
 
         // the base docker image to use for the Checkpoint and final images
-        baseImage = "ubuntu:20.04"
+        baseImage = "ubuntu:22.04"
 
         // The platform to build the image for (currently must be linux/amd64)
         platform = "linux/amd64"
@@ -1586,7 +1586,7 @@ micronaut {
         enabled.set(true)
 
         // the base docker image to use for the Checkpoint and final images
-        baseImage.set("ubuntu:20.04")
+        baseImage.set("ubuntu:22.04")
 
         // The platform to build the image for (currently must be linux/amd64)
         platform.set("linux/amd64")


### PR DESCRIPTION
Previously, the CRaC JDK fails if using Ubuntu 22.04

After checking with the Azul team, this issue only affects Mac and WSL docker clients where the kernel has not yet been updated to support it.

This fix sets and environment variable that has no effect for previous versions, but fixes the kernel settings for 22.04.

I have made the default 22.04, and updated the docs accordingly