### PR TITLE
Allow setting a network for the crac checkpoint

### DIFF
--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCConfiguration.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCConfiguration.java
@@ -27,6 +27,12 @@ public interface CRaCConfiguration {
     Property<String> getPlatform();
 
     /**
+     * The optional docker network name to use during building
+     * @return the network name
+     */
+    Property<String> getNetwork();
+
+    /**
      * Any arguments passed to java in the final image
      * @return list of arguments
      */

--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCConfiguration.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCConfiguration.java
@@ -3,6 +3,7 @@ package io.micronaut.gradle.crac;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 
@@ -30,6 +31,7 @@ public interface CRaCConfiguration {
      * The optional docker network name to use during building
      * @return the network name
      */
+    @Optional
     Property<String> getNetwork();
 
     /**

--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
@@ -162,6 +162,9 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
             task.targetImageId("checkpoint:latest");
             task.getContainerName().set(CRAC_CHECKPOINT);
             task.getHostConfig().getPrivileged().set(true);
+            if (configuration.getNetwork().isPresent()) {
+                task.getHostConfig().getNetwork().set(configuration.getNetwork());
+            }
             String local = project.getLayout().getBuildDirectory().dir(BUILD_DOCKER_DIRECTORY + imageName + "/cr").map(d -> d.getAsFile().getAbsolutePath()).get();
             task.getHostConfig().getBinds().put(local, "/home/app/cr");
         });

--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
@@ -162,9 +162,7 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
             task.targetImageId("checkpoint:latest");
             task.getContainerName().set(CRAC_CHECKPOINT);
             task.getHostConfig().getPrivileged().set(true);
-            if (configuration.getNetwork().isPresent()) {
-                task.getHostConfig().getNetwork().set(configuration.getNetwork());
-            }
+            task.getHostConfig().getNetwork().convention(configuration.getNetwork());
             String local = project.getLayout().getBuildDirectory().dir(BUILD_DOCKER_DIRECTORY + imageName + "/cr").map(d -> d.getAsFile().getAbsolutePath()).get();
             task.getHostConfig().getBinds().put(local, "/home/app/cr");
         });


### PR DESCRIPTION
If using mysql in a container, we need to be able to specify the network it is running on.