### PR TITLE
Fix `test` task being out of date with test resources

### DIFF
--- a/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithAotAndGraalVMSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithAotAndGraalVMSpec.groovy
@@ -20,7 +20,7 @@ class TestResourcesWithAotAndGraalVMSpec extends AbstractTestResourcesSpec {
     id("io.micronaut.graalvm")
 }
 
-tasks.named("nativeOptimizedRun") {
+graalvmNative.binaries.all {
     runtimeArgs.add("-DinterruptStartup=true")
 }
 

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithGraalVMSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithGraalVMSpec.groovy
@@ -19,7 +19,7 @@ class TestResourcesWithGraalVMSpec extends AbstractTestResourcesSpec {
     id("io.micronaut.graalvm")
 }
 
-tasks.named("nativeRun") {
+graalvmNative.binaries.all {
     runtimeArgs.add("-DinterruptStartup=true")
 }
 
@@ -46,7 +46,7 @@ tasks.named("nativeRun") {
     id("io.micronaut.graalvm")
 }
 
-tasks.named("nativeRun") {
+graalvmNative.binaries.all {
     runtimeArgs.add("-DinterruptStartup=true")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ spock = "2.1-groovy-3.0"
 graalvmPlugin = "0.9.18"
 micronaut = "3.2.0"
 micronaut-aot = "1.1.1"
-micronaut-testresources = "1.1.4"
+micronaut-testresources = "1.1.5"
 log4j2 = { require = "2.17.1", reject = ["]0, 2.17["] }
 jetbrains-annotations = "23.0.0"
 

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -16,6 +16,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleDependency;
@@ -36,12 +37,18 @@ import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.session.BuildSessionLifecycleListener;
+import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.process.JavaForkOptions;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -49,8 +56,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -84,12 +94,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
             }
             return Collections.emptyList();
         }));
-        conf.getDependencies().addAllLater(config.getEnabled().map(enabled -> {
-            if (Boolean.TRUE.equals(enabled)) {
-                return Collections.singleton(dependencies.create(project.files(writeTestProperties)));
-            }
-            return Collections.emptyList();
-        }));
+
         conf.getDependencyConstraints().addAllLater(PluginsHelper.findMicronautVersionAsProvider(project).map(v ->
                 Stream.of("micronaut-http-client", "micronaut-bom", "micronaut-inject")
                         .map(artifact -> dependencies.getConstraints().create("io.micronaut:" + artifact, dc -> {
@@ -165,11 +170,22 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
         outgoing.getDependencies().addLater(config.getVersion().map(v -> dependencies.create("io.micronaut.testresources:micronaut-test-resources-client:" + v)));
         Configuration testResourcesClasspathConfig = createTestResourcesClasspathConfig(project, config, internalStart);
         PluginManager pluginManager = project.getPluginManager();
-        pluginManager.withPlugin("org.graalvm.buildtools.native", unused -> TestResourcesGraalVM.configure(project, tasks, testResourcesClasspathConfig));
+        pluginManager.withPlugin("org.graalvm.buildtools.native", unused -> TestResourcesGraalVM.configure(project, testResourcesClasspathConfig, internalStart));
         pluginManager.withPlugin("io.micronaut.aot", unused -> TestResourcesAOT.configure(project, config, dependencies, tasks, internalStart, testResourcesClasspathConfig));
         configureServiceReset((ProjectInternal) project, settingsDirectory, stopAtEndFile);
 
+        tasks.withType(Test.class).configureEach(task -> configureServerConnection(internalStart, task));
+        tasks.withType(JavaExec.class).configureEach(task -> configureServerConnection(internalStart, task));
+
         workaroundForIntellij(project);
+
+    }
+
+    private static void configureServerConnection(TaskProvider<StartTestResourcesService> internalStart, Task task) {
+        task.dependsOn(internalStart);
+        if (task instanceof JavaForkOptions) {
+            ((JavaForkOptions) task).getJvmArgumentProviders().add(new ServerConnectionParametersProvider(internalStart));
+        }
     }
 
     private static void workaroundForIntellij(Project project) {
@@ -315,6 +331,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
                         .collect(Collectors.toList());
             }
             String testResourcesVersion = config.getVersion().get();
+            assertMinimalVersion(testResourcesVersion);
             return concat(concat(
                             TestResourcesClasspath.inferTestResourcesClasspath(mavenDependencies, testResourcesVersion)
                                     .stream()
@@ -326,6 +343,29 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
                     Stream.of(dependencies.create(testResourcesSourceSet.getRuntimeClasspath())))
                     .collect(Collectors.toList());
         }).orElse(Collections.emptyList());
+    }
+
+    private static void assertMinimalVersion(String testedVersion) {
+        List<Integer> testedVersionParts = parseVersion(testedVersion);
+        List<Integer> minimalVersionParts = parseVersion(VersionInfo.getVersion());
+        while (minimalVersionParts.size() < testedVersionParts.size()) {
+            minimalVersionParts.add(0);
+        }
+        for (int i = 0; i < testedVersionParts.size(); i++) {
+            int tested = testedVersionParts.get(i);
+            int reference = minimalVersionParts.get(i);
+            if (tested < reference) {
+                throw new GradleException("Micronaut Test Resources version " + testedVersion + " is not compatible with this Micronaut Gradle Plugin verson. Please use at least release " + VersionInfo.getVersion());
+            }
+        }
+    }
+
+    private static ArrayList<Integer> parseVersion(String testedVersion) {
+        return Arrays.stream(testedVersion.split("\\."))
+                .map(String::trim)
+                .map(s -> s.replaceAll("[^0-9]", ""))
+                .map(Integer::parseInt)
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     private void configureServiceReset(ProjectInternal project,
@@ -383,4 +423,29 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
         });
     }
 
+    public static class ServerConnectionParametersProvider implements CommandLineArgumentProvider {
+        private final TaskProvider<StartTestResourcesService> internalStart;
+
+        public ServerConnectionParametersProvider(TaskProvider<StartTestResourcesService> internalStart) {
+            this.internalStart = internalStart;
+        }
+
+        @Override
+        public Iterable<String> asArguments() {
+            Properties props = new Properties();
+            File serverConfig = new File(internalStart.get().getSettingsDirectory().get().getAsFile(), "test-resources.properties");
+            if (serverConfig.exists()) {
+                try (InputStream in = new FileInputStream(serverConfig)) {
+                    props.load(in);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+                return props.keySet()
+                        .stream()
+                        .map(key -> "-Dmicronaut.test.resources." + key + "=" + props.getProperty(key.toString()))
+                        .collect(Collectors.toList());
+            }
+            return Collections.emptyList();
+        }
+    }
 }

--- a/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/ApplicationTestResourcesPluginSpec.groovy
+++ b/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/ApplicationTestResourcesPluginSpec.groovy
@@ -18,6 +18,12 @@ class ApplicationTestResourcesPluginSpec extends AbstractGradleBuildSpec {
         result.output.contains "Loaded 2 test resources resolvers"
         result.output.contains "io.micronaut.testresources.mysql.MySQLTestResourceProvider"
         result.output.contains "io.micronaut.testresources.testcontainers.GenericTestContainerProvider"
+
+        when:
+        result = build 'test'
+
+        then:
+        result.task(':test').outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "creates temp test-resources directory when running 'clean build'"() {
@@ -43,7 +49,7 @@ class ApplicationTestResourcesPluginSpec extends AbstractGradleBuildSpec {
         def result = fails 'test'
 
         then:
-        result.task(":internalStartTestResourcesService") == null
+        result.task(":internalStartTestResourcesService").outcome == TaskOutcome.SKIPPED
         result.task(':test').outcome == TaskOutcome.FAILED
         !result.output.contains("Loaded 1 test resources resolvers: io.micronaut.testresources.testcontainers.GenericTestContainerProvider")
     }


### PR DESCRIPTION
This commit upgrades to Micronaut Test Resources 1.1.5, which offers the ability to pass the server connection settings to the client via system properties instead of a file on classpath.

This fixes the problem of the `test` task being constantly out-of-date when the `test-resources` plugin is applied. This does **not** fix the issue with `nativeTest`, which is still out-of-date, but will require a new release of the native build tools.

Fixes #579