### PR TITLE
Fix test/run task being up-to-date

### DIFF
--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -174,15 +174,24 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
         pluginManager.withPlugin("io.micronaut.aot", unused -> TestResourcesAOT.configure(project, config, dependencies, tasks, internalStart, testResourcesClasspathConfig));
         configureServiceReset((ProjectInternal) project, settingsDirectory, stopAtEndFile);
 
-        tasks.withType(Test.class).configureEach(task -> configureServerConnection(internalStart, task));
-        tasks.withType(JavaExec.class).configureEach(task -> configureServerConnection(internalStart, task));
+        tasks.withType(Test.class).configureEach(task -> configureServerConnection(internalStart, task, config, testResourcesSourceSet));
+        tasks.withType(JavaExec.class).configureEach(task -> configureServerConnection(internalStart, task, config, testResourcesSourceSet));
 
         workaroundForIntellij(project);
 
     }
 
-    private static void configureServerConnection(TaskProvider<StartTestResourcesService> internalStart, Task task) {
+    private static void configureServerConnection(TaskProvider<StartTestResourcesService> internalStart,
+                                                  Task task,
+                                                  TestResourcesConfiguration configuration,
+                                                  SourceSet testResourcesSourceSet) {
         task.dependsOn(internalStart);
+        task.getInputs().files(configuration.getEnabled().map(enabled -> {
+            if (enabled) {
+                return testResourcesSourceSet.getRuntimeClasspath();
+            }
+            return Collections.emptyList();
+        }));
         if (task instanceof JavaForkOptions) {
             ((JavaForkOptions) task).getJvmArgumentProviders().add(new ServerConnectionParametersProvider(internalStart));
         }

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -73,7 +73,7 @@ public abstract class StartTestResourcesService extends DefaultTask {
      * @return the directory where to write settings
      */
     @OutputDirectory
-    abstract DirectoryProperty getSettingsDirectory();
+    public abstract DirectoryProperty getSettingsDirectory();
 
     /**
      * This file is used by the test server once started,
@@ -83,7 +83,7 @@ public abstract class StartTestResourcesService extends DefaultTask {
      * @return the port file
      */
     @Internal
-    abstract RegularFileProperty getPortFile();
+    public abstract RegularFileProperty getPortFile();
 
     /**
      * An explicit port to use when starting the test
@@ -93,7 +93,7 @@ public abstract class StartTestResourcesService extends DefaultTask {
      */
     @Input
     @Optional
-    abstract Property<Integer> getExplicitPort();
+    public abstract Property<Integer> getExplicitPort();
 
     /**
      * An access token which must be used by clients
@@ -103,7 +103,7 @@ public abstract class StartTestResourcesService extends DefaultTask {
      */
     @Input
     @Optional
-    abstract Property<String> getAccessToken();
+    public abstract Property<String> getAccessToken();
 
     /**
      * Client timeout, in seconds, to the server.
@@ -115,7 +115,7 @@ public abstract class StartTestResourcesService extends DefaultTask {
      */
     @Input
     @Optional
-    abstract Property<Integer> getClientTimeout();
+    public abstract Property<Integer> getClientTimeout();
 
     /**
      * Allows starting the test server in foreground
@@ -126,7 +126,7 @@ public abstract class StartTestResourcesService extends DefaultTask {
      */
     @Internal
     @Option(option = "block", description = "Runs the test server in foreground, blocking until the server is stopped.")
-    abstract Property<Boolean> getForeground();
+    public abstract Property<Boolean> getForeground();
 
     /**
      * An internal file used to determine if the server
@@ -135,14 +135,14 @@ public abstract class StartTestResourcesService extends DefaultTask {
      * @return the stop file location
      */
     @Internal
-    abstract RegularFileProperty getStopFile();
+    public abstract RegularFileProperty getStopFile();
 
     /**
      * If set to true, the service will be started with debug enabled.
      * @return the debug flag
      */
     @Internal
-    abstract Property<Boolean> getDebugServer();
+    public abstract Property<Boolean> getDebugServer();
 
     /**
      * An internal property used to determine if the
@@ -154,13 +154,13 @@ public abstract class StartTestResourcesService extends DefaultTask {
      * @return the standalone mode property
      */
     @Internal
-    abstract Property<Boolean> getStandalone();
+    public abstract Property<Boolean> getStandalone();
 
     @Internal
-    abstract Property<Boolean> getUseClassDataSharing();
+    public abstract Property<Boolean> getUseClassDataSharing();
 
     @Internal
-    abstract DirectoryProperty getClassDataSharingDir();
+    public abstract DirectoryProperty getClassDataSharingDir();
 
     @Inject
     protected abstract ExecOperations getExecOperations();

--- a/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/CustomTestResourcePluginSpec.groovy
+++ b/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/CustomTestResourcePluginSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.gradle.testresources
 
 import io.micronaut.gradle.AbstractGradleBuildSpec
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Issue
 import spock.lang.Requires
 
 @Requires({ !os.windows })
@@ -18,6 +19,28 @@ class CustomTestResourcePluginSpec extends AbstractGradleBuildSpec {
         result.output.contains "Loaded 2 test resources resolvers"
         result.output.contains "demo.GreetingTestResource"
         result.output.contains "io.micronaut.testresources.testcontainers.GenericTestContainerProvider"
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/619")
+    def "test task is not up-to-date when custom test resource is updated"() {
+        withSample("test-resources/custom-test-resource")
+
+        when:
+        def result = build 'test'
+
+        then:
+        result.task(':test').outcome == TaskOutcome.SUCCESS
+        result.output.contains "Loaded 2 test resources resolvers"
+        result.output.contains "demo.GreetingTestResource"
+        result.output.contains "io.micronaut.testresources.testcontainers.GenericTestContainerProvider"
+
+        when:
+        def ctr = file("src/testResources/java/demo/GreetingTestResource.java")
+        ctr.text = ctr.text.replace("hello", "Hola")
+
+        then:
+        fails 'test'
+
     }
 
 }


### PR DESCRIPTION
This commit fixes the test and run tasks being up-to-date whenever a custom test resource is changed.

Fixes #619