### PR TITLE
Add KSP support and re-enable Kotlin tests

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.internal.build.functional-testing.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.internal.build.functional-testing.gradle
@@ -35,6 +35,8 @@ tasks.withType(Test).configureEach { Test test ->
     repoProvider.repositoryDir.from(configurations.pluginsUnderTest)
     repoProvider.version.set(version)
     test.jvmArgumentProviders.add(repoProvider)
+    systemProperties.put("kotlinVersion", libs.versions.kotlin.get())
+    systemProperties.put("kspVersion", libs.versions.ksp.get())
 }
 
 tasks.withType(JacocoReport).configureEach {

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/Kotest5FunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/Kotest5FunctionalTest.groovy
@@ -2,16 +2,27 @@ package io.micronaut.gradle.kotlin
 
 import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Shared
 
 class Kotest5FunctionalTest extends AbstractEagerConfiguringFunctionalTest {
 
-    def "test kotest 5 test runtime with #plugin"() {
+    @Shared
+    private final String kotlinVersion = System.getProperty("kotlinVersion")
+    @Shared
+    private final String kspVersion = System.getProperty("kspVersion")
+
+    @Shared
+    private final String kaptPlugin = "id(\"org.jetbrains.kotlin.kapt\") version \"$kotlinVersion\""
+    @Shared
+    private final String kspPlugin = "id(\"com.google.devtools.ksp\") version \"$kspVersion\""
+
+    def "test kotest 5 test runtime with #plugin and #processingPlugin"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"
         buildFile << """plugins {
-                       |    id("org.jetbrains.kotlin.jvm") version "1.6.21"
-                       |    id("org.jetbrains.kotlin.kapt") version "1.6.21"
-                       |    id("org.jetbrains.kotlin.plugin.allopen") version "1.6.21"
+                       |    id("org.jetbrains.kotlin.jvm") version "$kotlinVersion"
+                       |    $processingPlugin
+                       |    id("org.jetbrains.kotlin.plugin.allopen") version "$kotlinVersion"
                        |    $plugin
                        |}
                        |
@@ -72,7 +83,7 @@ class Kotest5FunctionalTest extends AbstractEagerConfiguringFunctionalTest {
                       """.stripMargin()
 
         when:
-        def result = build('test')
+        def result = build('test', '-s')
 
         def task = result.task(":test")
         println result.output
@@ -81,9 +92,11 @@ class Kotest5FunctionalTest extends AbstractEagerConfiguringFunctionalTest {
         task.outcome == TaskOutcome.SUCCESS
 
         where:
-        plugin << [
-                'id "io.micronaut.application"',
-                'id "io.micronaut.minimal.application"',
-        ]
+        plugin                                  | processingPlugin
+        'id "io.micronaut.application"'         | kaptPlugin
+        'id "io.micronaut.minimal.application"' | kaptPlugin
+//        'id "io.micronaut.application"'         | kspPlugin
+//        'id "io.micronaut.minimal.application"' | kspPlugin
+
     }
 }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/Kotest5FunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/Kotest5FunctionalTest.groovy
@@ -95,8 +95,8 @@ class Kotest5FunctionalTest extends AbstractEagerConfiguringFunctionalTest {
         plugin                                  | processingPlugin
         'id "io.micronaut.application"'         | kaptPlugin
         'id "io.micronaut.minimal.application"' | kaptPlugin
-//        'id "io.micronaut.application"'         | kspPlugin
-//        'id "io.micronaut.minimal.application"' | kspPlugin
+        'id "io.micronaut.application"'         | kspPlugin
+        'id "io.micronaut.minimal.application"' | kspPlugin
 
     }
 }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
@@ -5,16 +5,61 @@ import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.IgnoreIf
 
 class KotlinLibraryFunctionalTest extends AbstractEagerConfiguringFunctionalTest {
-    @IgnoreIf({ jvm.java16Compatible }) // https://youtrack.jetbrains.com/issue/KT-45545
-    def "test apply defaults for micronaut-library and kotlin with kotlin DSL"() {
+
+    def "test apply defaults for micronaut-library and KSP with kotlin DSL for #plugin"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"
         buildFile.delete()
         kotlinBuildFile << """
             plugins {
-                id("org.jetbrains.kotlin.jvm") version("1.6.21")
-                id("org.jetbrains.kotlin.kapt") version("1.6.21")
-                id("org.jetbrains.kotlin.plugin.allopen") version("1.6.21")
+                id("org.jetbrains.kotlin.jvm") version("1.8.0")
+                id("com.google.devtools.ksp") version "1.8.0-1.0.8"
+                id("io.micronaut.$plugin")
+            }
+            
+            micronaut {
+                version("$micronautVersion")
+                processing {
+                    incremental(true)
+                }
+            }
+            
+            ${getRepositoriesBlock('kotlin')}
+            
+        """
+        testProjectDir.newFolder("src", "main", "kotlin", "example")
+        def javaFile = testProjectDir.newFile("src/main/kotlin/example/Foo.kt")
+        javaFile.parentFile.mkdirs()
+        javaFile << """
+package example
+
+@jakarta.inject.Singleton
+class Foo {}
+"""
+
+        when:
+        def result = build('assemble')
+
+        println result.output
+        then:
+        result.task(":assemble").outcome == TaskOutcome.SUCCESS
+        new File(testProjectDir.root, "build/generated/ksp/main/classes/example")
+                .listFiles()
+                ?.find { it.name.endsWith(".class") && it.name.contains('$Definition')}
+
+        where:
+        plugin << ['library', 'minimal.library']
+    }
+
+    def "test apply defaults for micronaut-library and kotlin with kotlin DSL for #plugin"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile.delete()
+        kotlinBuildFile << """
+            plugins {
+                id("org.jetbrains.kotlin.jvm") version("1.8.0")
+                id("org.jetbrains.kotlin.kapt") version("1.8.0")
+                id("org.jetbrains.kotlin.plugin.allopen") version("1.8.0")
                 id("io.micronaut.$plugin")
             }
             
@@ -50,16 +95,15 @@ class Foo {}
         plugin << ['library', 'minimal.library']
     }
 
-    @IgnoreIf({ jvm.java16Compatible }) // https://youtrack.jetbrains.com/issue/KT-45545
-    def "test custom sourceSet for micronaut-library and kotlin with kotlin DSL"() {
+    def "test custom sourceSet for micronaut-library and kotlin with kotlin DSL for #plugin"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"
         buildFile.delete()
         kotlinBuildFile << """
             plugins {
-                id("org.jetbrains.kotlin.jvm") version("1.6.21")
-                id("org.jetbrains.kotlin.kapt") version("1.6.21")
-                id("org.jetbrains.kotlin.plugin.allopen") version("1.6.21")
+                id("org.jetbrains.kotlin.jvm") version("1.8.0")
+                id("org.jetbrains.kotlin.kapt") version("1.8.0")
+                id("org.jetbrains.kotlin.plugin.allopen") version("1.8.0")
                 id("io.micronaut.$plugin")
             }
             

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
@@ -2,9 +2,16 @@ package io.micronaut.gradle.kotlin
 
 import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
 import org.gradle.testkit.runner.TaskOutcome
-import spock.lang.IgnoreIf
+import spock.lang.Shared
 
 class KotlinLibraryFunctionalTest extends AbstractEagerConfiguringFunctionalTest {
+
+    @Shared
+    private final String kotlinVersion = System.getProperty("kotlinVersion");
+
+    @Shared
+    private final String kspVersion = System.getProperty("kspVersion");
+
 
     def "test apply defaults for micronaut-library and KSP with kotlin DSL for #plugin"() {
         given:
@@ -12,8 +19,8 @@ class KotlinLibraryFunctionalTest extends AbstractEagerConfiguringFunctionalTest
         buildFile.delete()
         kotlinBuildFile << """
             plugins {
-                id("org.jetbrains.kotlin.jvm") version("1.8.0")
-                id("com.google.devtools.ksp") version "1.8.0-1.0.8"
+                id("org.jetbrains.kotlin.jvm") version("$kotlinVersion")
+                id("com.google.devtools.ksp") version "$kspVersion"
                 id("io.micronaut.$plugin")
             }
             
@@ -57,9 +64,9 @@ class Foo {}
         buildFile.delete()
         kotlinBuildFile << """
             plugins {
-                id("org.jetbrains.kotlin.jvm") version("1.8.0")
-                id("org.jetbrains.kotlin.kapt") version("1.8.0")
-                id("org.jetbrains.kotlin.plugin.allopen") version("1.8.0")
+                id("org.jetbrains.kotlin.jvm") version("$kotlinVersion")
+                id("org.jetbrains.kotlin.kapt") version("$kotlinVersion")
+                id("org.jetbrains.kotlin.plugin.allopen") version("$kotlinVersion")
                 id("io.micronaut.$plugin")
             }
             
@@ -101,9 +108,9 @@ class Foo {}
         buildFile.delete()
         kotlinBuildFile << """
             plugins {
-                id("org.jetbrains.kotlin.jvm") version("1.8.0")
-                id("org.jetbrains.kotlin.kapt") version("1.8.0")
-                id("org.jetbrains.kotlin.plugin.allopen") version("1.8.0")
+                id("org.jetbrains.kotlin.jvm") version("$kotlinVersion")
+                id("org.jetbrains.kotlin.kapt") version("$kotlinVersion")
+                id("org.jetbrains.kotlin.plugin.allopen") version("$kotlinVersion")
                 id("io.micronaut.$plugin")
             }
             

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
-kotlin = "1.6.21"
+kotlin = "1.8.0"
+ksp = "1.8.0-1.0.8"
 docker = "8.0.0"
 diffplug = "3.37.2"
 shadow = "7.1.2"
@@ -20,6 +21,7 @@ graalvmPlugin = { module = "org.graalvm.buildtools:native-gradle-plugin", versio
 
 kotlin-allopen = { module = "org.jetbrains.kotlin:kotlin-allopen", version.ref = "kotlin" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+ksp-gradlePlugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
 
 groovy-core = { module = "org.codehaus.groovy:groovy", version.ref = "groovy" }
 spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }
@@ -36,4 +38,4 @@ micronaut-testresources = { module = "io.micronaut.testresources:micronaut-test-
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 
 [bundles]
-optionalPlugins = [ "kotlin-allopen", "kotlin-gradlePlugin", "graalvmPlugin" ]
+optionalPlugins = [ "kotlin-allopen", "kotlin-gradlePlugin", "graalvmPlugin", "ksp-gradlePlugin" ]

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
@@ -3,6 +3,7 @@ package io.micronaut.gradle;
 import com.google.devtools.ksp.gradle.KspExtension;
 import io.micronaut.gradle.graalvm.GraalUtil;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.plugins.ExtensionContainer;
@@ -38,6 +39,7 @@ public class MicronautKotlinSupport {
             "ksp",
             "kspTest"
     };
+    public static final String KOTLIN_PROCESSORS = "kotlinProcessors";
 
     private final static List<String> KSP_ANNOTATION_PROCESSOR_MODULES = Arrays.asList("inject-kotlin", "validation");
 
@@ -67,6 +69,10 @@ public class MicronautKotlinSupport {
     public static void configureKotlin(Project project) {
         PluginManager pluginManager = project.getPluginManager();
         final TaskContainer tasks = project.getTasks();
+        project.getConfigurations().create(KOTLIN_PROCESSORS, conf -> {
+            conf.setCanBeConsumed(false);
+            conf.setCanBeConsumed(false);
+        });
         tasks.withType(KotlinCompile.class).configureEach(kotlinCompile -> {
             final KotlinJvmOptions kotlinOptions = (KotlinJvmOptions) kotlinCompile.getKotlinOptions();
             kotlinOptions.setJavaParameters(true);
@@ -141,6 +147,11 @@ public class MicronautKotlinSupport {
                         "io.micronaut:micronaut-graal"
                 );
             }
+        }
+
+        Configuration kotlinProcessors = project.getConfigurations().getByName(KOTLIN_PROCESSORS);
+        for (String compilerConfiguration : compilerConfigurations) {
+            project.getConfigurations().getByName(compilerConfiguration).extendsFrom(kotlinProcessors);
         }
 
         project.afterEvaluate(p -> {

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
@@ -1,5 +1,6 @@
 package io.micronaut.gradle;
 
+import com.google.devtools.ksp.gradle.KspExtension;
 import io.micronaut.gradle.graalvm.GraalUtil;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
@@ -33,6 +34,12 @@ public class MicronautKotlinSupport {
             "kapt",
             "kaptTest"
     };
+    private static final String[] KSP_CONFIGURATIONS = new String[]{
+            "ksp",
+            "kspTest"
+    };
+
+    private final static List<String> KSP_ANNOTATION_PROCESSOR_MODULES = Arrays.asList("inject-kotlin", "validation");
 
     public static void whenKotlinSupportPresent(Project p, Consumer<? super Project> action) {
         p.getPluginManager().withPlugin("org.jetbrains.kotlin.jvm", unused -> action.accept(p));
@@ -66,77 +73,31 @@ public class MicronautKotlinSupport {
         });
         pluginManager.withPlugin("org.jetbrains.kotlin.plugin.allopen", unused -> configureAllOpen(project));
         pluginManager.withPlugin("org.jetbrains.kotlin.kapt", unused -> configureKapt(project));
+        pluginManager.withPlugin("com.google.devtools.ksp", unused -> configureKsp(project));
+    }
+
+    private static void configureKsp(Project project) {
+        configureKotlinCompilerPlugin(project, KSP_CONFIGURATIONS, "ksp", KSP_ANNOTATION_PROCESSOR_MODULES);
+
+        final ExtensionContainer extensions = project.getExtensions();
+        extensions.configure(KspExtension.class, kspExtension -> {
+            final MicronautExtension micronautExtension = extensions.getByType(MicronautExtension.class);
+            AnnotationProcessing processingConfig = micronautExtension.getProcessing();
+            final boolean isIncremental = processingConfig.getIncremental().getOrElse(true);
+            final String group = processingConfig.getGroup().getOrElse(project.getGroup().toString());
+            final String module = processingConfig.getModule().getOrElse(project.getName());
+            if (isIncremental) {
+                kspExtension.arg("micronaut.processing.incremental", "true");
+                if (group.length() > 0) {
+                    kspExtension.arg("micronaut.processing.group,", group);
+                }
+                kspExtension.arg("micronaut.processing.module", module);
+            }
+        });
     }
 
     private static void configureKapt(Project project) {
-        // add inject-java to kapt scopes
-        DependencyHandler dependencies = project.getDependencies();
-        PluginsHelper.registerAnnotationProcessors(dependencies, KAPT_CONFIGURATIONS);
-
-        if (GraalUtil.isGraalJVM()) {
-            for (String configuration : KAPT_CONFIGURATIONS) {
-                dependencies.add(
-                        configuration,
-                        "io.micronaut:micronaut-graal"
-                );
-            }
-        }
-
-        project.afterEvaluate(p -> {
-            PluginsHelper.applyAdditionalProcessors(
-                    p,
-                    "kapt", "kaptTest"
-            );
-            final MicronautExtension micronautExtension = p
-                    .getExtensions()
-                    .getByType(MicronautExtension.class);
-            ListProperty<SourceSet> additionalSourceSets =
-                    micronautExtension.getProcessing().getAdditionalSourceSets();
-            final DependencyHandler dependencyHandler = p.getDependencies();
-            final String micronautVersion = PluginsHelper.findMicronautVersion(
-                    p,
-                    micronautExtension
-            );
-
-            final Dependency platform = resolveMicronautPlatform(dependencyHandler, micronautVersion);
-            if (additionalSourceSets.isPresent()) {
-                List<SourceSet> configurations = additionalSourceSets.get();
-                if (!configurations.isEmpty()) {
-                    for (SourceSet sourceSet : configurations) {
-                        String annotationProcessorConfigurationName = "kapt" + Strings.capitalize(sourceSet.getName());
-                        String implementationConfigurationName = sourceSet
-                                .getImplementationConfigurationName();
-                        List<String> both = Arrays.asList(
-                                implementationConfigurationName,
-                                annotationProcessorConfigurationName
-                        );
-                        for (String configuration : both) {
-                            dependencyHandler.add(
-                                    configuration,
-                                    platform
-                            );
-                        }
-                        configureAnnotationProcessors(p,
-                                implementationConfigurationName,
-                                annotationProcessorConfigurationName);
-                        if (GraalUtil.isGraalJVM()) {
-                            dependencies.add(
-                                    annotationProcessorConfigurationName,
-                                    "io.micronaut:micronaut-graal"
-                            );
-                        }
-                    }
-                }
-            }
-
-
-            for (String kaptConfig : KAPT_CONFIGURATIONS) {
-                dependencyHandler.add(
-                        kaptConfig,
-                        platform
-                );
-            }
-        });
+        configureKotlinCompilerPlugin(project, KAPT_CONFIGURATIONS, "kapt", PluginsHelper.ANNOTATION_PROCESSOR_MODULES);
 
         final ExtensionContainer extensions = project.getExtensions();
         extensions.configure(KaptExtension.class, kaptExtension -> {
@@ -165,6 +126,76 @@ public class MicronautKotlinSupport {
 
                     return null;
                 });
+            }
+        });
+    }
+
+    private static void configureKotlinCompilerPlugin(Project project, String[] compilerConfigurations, String compilerType, List<String> annotationProcessorModules) {
+        // add inject-java to kapt scopes
+        DependencyHandler dependencies = project.getDependencies();
+        PluginsHelper.registerAnnotationProcessors(dependencies, annotationProcessorModules, compilerConfigurations);
+        if (GraalUtil.isGraalJVM()) {
+            for (String configuration : compilerConfigurations) {
+                dependencies.add(
+                        configuration,
+                        "io.micronaut:micronaut-graal"
+                );
+            }
+        }
+
+        project.afterEvaluate(p -> {
+            PluginsHelper.applyAdditionalProcessors(
+                    p,
+                    compilerConfigurations
+            );
+            final MicronautExtension micronautExtension = p
+                    .getExtensions()
+                    .getByType(MicronautExtension.class);
+            ListProperty<SourceSet> additionalSourceSets =
+                    micronautExtension.getProcessing().getAdditionalSourceSets();
+            final DependencyHandler dependencyHandler = p.getDependencies();
+            final String micronautVersion = PluginsHelper.findMicronautVersion(
+                    p,
+                    micronautExtension
+            );
+
+            final Dependency platform = resolveMicronautPlatform(dependencyHandler, micronautVersion);
+            if (additionalSourceSets.isPresent()) {
+                List<SourceSet> configurations = additionalSourceSets.get();
+                if (!configurations.isEmpty()) {
+                    for (SourceSet sourceSet : configurations) {
+                        String annotationProcessorConfigurationName = compilerType + Strings.capitalize(sourceSet.getName());
+                        String implementationConfigurationName = sourceSet
+                                .getImplementationConfigurationName();
+                        List<String> both = Arrays.asList(
+                                implementationConfigurationName,
+                                annotationProcessorConfigurationName
+                        );
+                        for (String configuration : both) {
+                            dependencyHandler.add(
+                                    configuration,
+                                    platform
+                            );
+                        }
+                        configureAnnotationProcessors(p,
+                                implementationConfigurationName,
+                                annotationProcessorConfigurationName);
+                        if (GraalUtil.isGraalJVM()) {
+                            dependencies.add(
+                                    annotationProcessorConfigurationName,
+                                    "io.micronaut:micronaut-graal"
+                            );
+                        }
+                    }
+                }
+            }
+
+
+            for (String compileConfiguration : compilerConfigurations) {
+                dependencyHandler.add(
+                        compileConfiguration,
+                        platform
+                );
             }
         });
     }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
@@ -37,7 +37,7 @@ public enum MicronautTestRuntime {
      * Kotest 4.
      */
     KOTEST_4(MicronautExtension.mapOf(
-            "kaptTest",
+            MicronautKotlinSupport.KOTLIN_PROCESSORS,
             Collections.singletonList("io.micronaut:micronaut-inject-java"),
             JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME,
             Arrays.asList(
@@ -53,7 +53,7 @@ public enum MicronautTestRuntime {
      * Kotest 5.
      */
     KOTEST_5(MicronautExtension.mapOf(
-            "kaptTest",
+            MicronautKotlinSupport.KOTLIN_PROCESSORS,
             Collections.singletonList("io.micronaut:micronaut-inject-java"),
             JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME,
             Arrays.asList(

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/PluginsHelper.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/PluginsHelper.java
@@ -37,7 +37,7 @@ import static org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME;
 
 public abstract class PluginsHelper {
-    private final static List<String> ANNOTATION_PROCESSOR_MODULES = Arrays.asList("inject-java", "validation");
+    final static List<String> ANNOTATION_PROCESSOR_MODULES = Arrays.asList("inject-java", "validation");
     private final static Map<String, String> GROUP_TO_PROCESSOR_MAP = Collections.unmodifiableMap(new HashMap<String, String>() {{
         put("io.micronaut.data", "io.micronaut.data:micronaut-data-processor");
         put("io.micronaut.jaxrs", "io.micronaut.jaxrs:micronaut-jaxrs-processor");
@@ -81,7 +81,11 @@ public abstract class PluginsHelper {
     }
 
     static void registerAnnotationProcessors(DependencyHandler dependencyHandler, String... annotationProcessingConfigurations) {
-        for (String annotationProcessorModule : ANNOTATION_PROCESSOR_MODULES) {
+        registerAnnotationProcessors(dependencyHandler, ANNOTATION_PROCESSOR_MODULES, annotationProcessingConfigurations);
+    }
+
+    static void registerAnnotationProcessors(DependencyHandler dependencyHandler, List<String> annotationProcessorModules, String... annotationProcessingConfigurations) {
+        for (String annotationProcessorModule : annotationProcessorModules) {
             for (String annotationProcessingConfiguration : annotationProcessingConfigurations) {
                 dependencyHandler.add(
                         annotationProcessingConfiguration,

--- a/minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
+++ b/minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
@@ -121,11 +121,21 @@ abstract class AbstractGradleBuildSpec extends Specification {
     }
 
     def getRepositoriesBlock(String dsl = 'groovy') {
-        """repositories {
+        if (dsl == 'groovy') {
+            """repositories {
     ${guardString('mavenLocal()', allowMavenLocal)}
     mavenCentral()
     ${guardString('maven { url = "https://s01.oss.sonatype.org/content/repositories/snapshots" }', allowSnapshots)}
 }"""
+
+        } else {
+            """repositories {
+    ${guardString('mavenLocal()', allowMavenLocal)}
+    mavenCentral()
+    ${guardString('maven { setUrl("https://s01.oss.sonatype.org/content/repositories/snapshots/") }', allowSnapshots)}
+}"""
+
+        }
     }
 
     private void prepareBuild() {


### PR DESCRIPTION
Adds support for configuring KSP including handling the new `inject-kotlin` module and configuring the `ksp` and `kspTest` classpaths