### PR TITLE
Fix integration with Micronaut Test Resources

### DIFF
--- a/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracBuildTaskSpec.groovy
+++ b/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracBuildTaskSpec.groovy
@@ -3,7 +3,7 @@ package io.micronaut.gradle.crac
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.IgnoreIf
 
-@IgnoreIf({ os.windows })
+@IgnoreIf({ os.windows || !jvm.current.java17 })
 class CracBuildTaskSpec extends BaseCracGradleBuildSpec {
 
     def "test build docker image when #desc"() {

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/fixtures/AbstractFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/fixtures/AbstractFunctionalTest.groovy
@@ -23,10 +23,10 @@ abstract class AbstractFunctionalTest extends AbstractGradleBuildSpec {
                 repositories {
                     ${guardString('mavenLocal()', allowMavenLocal)}
                     mavenCentral()
-                    ${guardString('maven { url = "https://s01.oss.sonatype.org/content/repositories/snapshots" }', allowSnapshots)}
                     maven {
                         url = "${System.getProperty("internal.plugin.repo")}"
                     }
+                    ${guardString('maven { url = "https://s01.oss.sonatype.org/content/repositories/snapshots" }', allowSnapshots)}
                     gradlePluginPortal()
                 }
                 plugins {

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautBasePlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautBasePlugin.java
@@ -18,9 +18,16 @@ package io.micronaut.gradle;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
+import static io.micronaut.gradle.MicronautComponentPlugin.MICRONAUT_BOMS_CONFIGURATION;
+
 public class MicronautBasePlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getExtensions().create("micronaut", MicronautExtension.class);
+        project.getConfigurations().create(MICRONAUT_BOMS_CONFIGURATION, conf -> {
+            conf.setCanBeResolved(false);
+            conf.setCanBeConsumed(false);
+            conf.setDescription("BOMs which will be applied by the Micronaut plugins");
+        });
     }
 }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -144,11 +144,7 @@ public class MicronautComponentPlugin implements Plugin<Project> {
     }
 
     private void configureMicronautBom(Project project, MicronautExtension micronautExtension) {
-        Configuration micronautBoms = project.getConfigurations().create(MICRONAUT_BOMS_CONFIGURATION, conf -> {
-            conf.setCanBeResolved(false);
-            conf.setCanBeConsumed(false);
-            conf.setDescription("BOMs which will be applied by the Micronaut plugins");
-        });
+        Configuration micronautBoms = project.getConfigurations().getByName(MICRONAUT_BOMS_CONFIGURATION);
         DependencyHandler dependencyHandler = project.getDependencies();
         project.afterEvaluate(p -> {
             dependencyHandler.addProvider(micronautBoms.getName(), project.getProviders().provider(() -> {
@@ -191,7 +187,7 @@ public class MicronautComponentPlugin implements Plugin<Project> {
     }
 
 
-    static Dependency resolveMicronautPlatform(DependencyHandler dependencyHandler, String micronautVersion) {
+    public static Dependency resolveMicronautPlatform(DependencyHandler dependencyHandler, String micronautVersion) {
         return dependencyHandler.platform("io.micronaut.platform:micronaut-platform:" + micronautVersion);
     }
 

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/PluginsHelper.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/PluginsHelper.java
@@ -44,7 +44,7 @@ public abstract class PluginsHelper {
         put("io.micronaut.security", "io.micronaut.security:micronaut-security-annotations");
     }});
 
-    static String findMicronautVersion(Project p, MicronautExtension micronautExtension) {
+    public static String findMicronautVersion(Project p, MicronautExtension micronautExtension) {
         String v = micronautExtension.getVersion().getOrNull();
         if (v == null) {
             final Object o = p.getProperties().get("micronautVersion");

--- a/minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
+++ b/minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
@@ -77,7 +77,9 @@ abstract class AbstractGradleBuildSpec extends Specification {
         File sampleDir = new File("../samples/$name").canonicalFile
         copySample(sampleDir.toPath(), baseDir)
         buildFile << """
-            $repositoriesBlock
+            allprojects {
+                $repositoriesBlock
+            }
         """
         def jacocoConf = AbstractGradleBuildSpec.classLoader.getResourceAsStream("testkit-gradle.properties")?.text
         if (jacocoConf) {

--- a/samples/aot/aws-function/build.gradle
+++ b/samples/aot/aws-function/build.gradle
@@ -7,10 +7,6 @@ plugins {
 version = "0.1"
 group = "example.micronaut"
 
-repositories {
-    mavenCentral()
-}
-
 micronaut {
     runtime("lambda")
     testRuntime("junit5")

--- a/samples/aot/basic-app/build.gradle
+++ b/samples/aot/basic-app/build.gradle
@@ -6,10 +6,6 @@ plugins {
 version = "0.1"
 group = "demo.app"
 
-repositories {
-    mavenCentral()
-}
-
 micronaut {
     runtime("netty")
     testRuntime("junit5")

--- a/samples/aot/with-shadow/build.gradle
+++ b/samples/aot/with-shadow/build.gradle
@@ -7,10 +7,6 @@ plugins {
 version = "0.1"
 group = "demo.app"
 
-repositories {
-    mavenCentral()
-}
-
 micronaut {
     runtime("netty")
     testRuntime("junit5")

--- a/samples/test-resources/custom-test-resource/build.gradle
+++ b/samples/test-resources/custom-test-resource/build.gradle
@@ -6,10 +6,6 @@ plugins {
 version = "0.1"
 group = "demo"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     annotationProcessor("io.micronaut:micronaut-http-validation")
     implementation("io.micronaut:micronaut-http-client")

--- a/samples/test-resources/data-mysql/build.gradle
+++ b/samples/test-resources/data-mysql/build.gradle
@@ -38,8 +38,8 @@ micronaut {
 }
 
 dependencies {
-    annotationProcessor("io.micronaut.data:micronaut-data-processor:4.0.0-SNAPSHOT")
-    implementation("io.micronaut.data:micronaut-data-jdbc:4.0.0-SNAPSHOT")
+    annotationProcessor("io.micronaut.data:micronaut-data-processor")
+    implementation("io.micronaut.data:micronaut-data-jdbc")
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
     runtimeOnly("mysql:mysql-connector-java")
     runtimeOnly("io.micronaut:micronaut-jackson-databind")

--- a/samples/test-resources/data-mysql/build.gradle
+++ b/samples/test-resources/data-mysql/build.gradle
@@ -6,10 +6,6 @@ plugins {
 version = "0.1"
 group = "demo"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     annotationProcessor("io.micronaut:micronaut-http-validation")
     implementation("io.micronaut:micronaut-http-client")

--- a/samples/test-resources/isolated-multiproject/app1/build.gradle
+++ b/samples/test-resources/isolated-multiproject/app1/build.gradle
@@ -6,22 +6,15 @@ plugins {
 version = "0.1"
 group = "demo"
 
-repositories {
-    mavenCentral()
-    maven {
-        url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-    }
-}
-
 dependencies {
     annotationProcessor("io.micronaut:micronaut-http-validation")
-    annotationProcessor("io.micronaut.data:micronaut-data-processor:4.0.0-SNAPSHOT")
+    annotationProcessor("io.micronaut.data:micronaut-data-processor")
     implementation("io.micronaut:micronaut-http-client")
     implementation("io.micronaut:micronaut-jackson-databind")
     implementation("io.micronaut:micronaut-runtime")
     implementation("jakarta.annotation:jakarta.annotation-api")
     implementation("io.micronaut:micronaut-validation")
-    implementation("io.micronaut.data:micronaut-data-jdbc:4.0.0-SNAPSHOT")
+    implementation("io.micronaut.data:micronaut-data-jdbc")
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
     runtimeOnly("mysql:mysql-connector-java")
     runtimeOnly("ch.qos.logback:logback-classic")

--- a/samples/test-resources/isolated-multiproject/app2/build.gradle
+++ b/samples/test-resources/isolated-multiproject/app2/build.gradle
@@ -6,22 +6,15 @@ plugins {
 version = "0.1"
 group = "demo"
 
-repositories {
-    mavenCentral()
-    maven {
-        url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-    }
-}
-
 dependencies {
     annotationProcessor("io.micronaut:micronaut-http-validation")
-    annotationProcessor("io.micronaut.data:micronaut-data-processor:4.0.0-SNAPSHOT")
+    annotationProcessor("io.micronaut.data:micronaut-data-processor")
     implementation("io.micronaut:micronaut-http-client")
     implementation("io.micronaut:micronaut-jackson-databind")
     implementation("io.micronaut:micronaut-runtime")
     implementation("jakarta.annotation:jakarta.annotation-api")
     implementation("io.micronaut:micronaut-validation")
-    implementation("io.micronaut.data:micronaut-data-jdbc:4.0.0-SNAPSHOT")
+    implementation("io.micronaut.data:micronaut-data-jdbc")
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
     runtimeOnly("ch.qos.logback:logback-classic")
     runtimeOnly("io.micronaut:micronaut-jackson-databind")

--- a/samples/test-resources/isolated-multiproject/app3/build.gradle
+++ b/samples/test-resources/isolated-multiproject/app3/build.gradle
@@ -6,13 +6,6 @@ plugins {
 version = "0.1"
 group = "demo"
 
-repositories {
-    mavenCentral()
-    maven {
-        url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-    }
-}
-
 dependencies {
     annotationProcessor("io.micronaut:micronaut-http-validation")
     runtimeOnly("io.micronaut:micronaut-jackson-databind")

--- a/samples/test-resources/multiproject/app1/build.gradle
+++ b/samples/test-resources/multiproject/app1/build.gradle
@@ -6,22 +6,15 @@ plugins {
 version = "0.1"
 group = "demo"
 
-repositories {
-    mavenCentral()
-    maven {
-        url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-    }
-}
-
 dependencies {
     annotationProcessor("io.micronaut:micronaut-http-validation")
-    annotationProcessor("io.micronaut.data:micronaut-data-processor:4.0.0-SNAPSHOT")
+    annotationProcessor("io.micronaut.data:micronaut-data-processor")
     implementation("io.micronaut:micronaut-http-client")
     implementation("io.micronaut:micronaut-jackson-databind")
     implementation("io.micronaut:micronaut-runtime")
     implementation("jakarta.annotation:jakarta.annotation-api")
     implementation("io.micronaut:micronaut-validation")
-    implementation("io.micronaut.data:micronaut-data-jdbc:4.0.0-SNAPSHOT")
+    implementation("io.micronaut.data:micronaut-data-jdbc")
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
     runtimeOnly("ch.qos.logback:logback-classic")
     runtimeOnly("io.micronaut:micronaut-jackson-databind")

--- a/samples/test-resources/multiproject/app2/build.gradle
+++ b/samples/test-resources/multiproject/app2/build.gradle
@@ -6,22 +6,15 @@ plugins {
 version = "0.1"
 group = "demo"
 
-repositories {
-    mavenCentral()
-    maven {
-        url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-    }
-}
-
 dependencies {
     annotationProcessor("io.micronaut:micronaut-http-validation")
-    annotationProcessor("io.micronaut.data:micronaut-data-processor:4.0.0-SNAPSHOT")
+    annotationProcessor("io.micronaut.data:micronaut-data-processor")
     implementation("io.micronaut:micronaut-http-client")
     implementation("io.micronaut:micronaut-jackson-databind")
     implementation("io.micronaut:micronaut-runtime")
     implementation("jakarta.annotation:jakarta.annotation-api")
     implementation("io.micronaut:micronaut-validation")
-    implementation("io.micronaut.data:micronaut-data-jdbc:4.0.0-SNAPSHOT")
+    implementation("io.micronaut.data:micronaut-data-jdbc")
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
     runtimeOnly("ch.qos.logback:logback-classic")
     runtimeOnly("io.micronaut:micronaut-jackson-databind")

--- a/samples/test-resources/multiproject/app3/build.gradle
+++ b/samples/test-resources/multiproject/app3/build.gradle
@@ -6,13 +6,6 @@ plugins {
 version = "0.1"
 group = "demo"
 
-repositories {
-    mavenCentral()
-    maven {
-        url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-    }
-}
-
 dependencies {
     annotationProcessor("io.micronaut:micronaut-http-validation")
     runtimeOnly("io.micronaut:micronaut-jackson-databind")

--- a/samples/test-resources/multiproject/testresources/build.gradle
+++ b/samples/test-resources/multiproject/testresources/build.gradle
@@ -5,13 +5,6 @@ plugins {
 version = "0.1"
 group = "demo"
 
-repositories {
-    mavenCentral()
-    maven {
-        url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-    }
-}
-
 micronaut {
     testResources {
         // app1 uses MySQL

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -410,7 +410,6 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
     }
 
     private static Configuration createTestResourcesServerConfiguration(Project project, MicronautExtension micronautExtension) {
-        // Legacy configuration was only used in 3.5.0 so it's relatively safe
         ConfigurationContainer configurations = project.getConfigurations();
         Configuration boms = configurations.findByName(MICRONAUT_BOMS_CONFIGURATION);
         DependencyHandler dependencyHandler = project.getDependencies();


### PR DESCRIPTION
This commit fixes how the Gradle plugin integrates with Micronaut
Test Resources. The latest version of test resources makes use of
a fat jar, which allows us to inject the Micronaut Platform BOM
to the test resources service classpath, so that the inferred
dependencies, like the database drivers, can be resolved even if
the user didn't specify a particular version.

Previously to this change, it was possible that the database
drivers were accidentally resolved because the test resources
service itself was built with Micronaut, and therefore adding
the Micronaut core BOM on classpath.

@alvarosanchez you will probably need to do something similar in the Maven plugin. I think I recall we already apply the Micronaut BOM, but this has to be changed to use the Micronaut Platform BOM.