### PR TITLE
Enable GraalVM metadata repository

### DIFF
--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/AbstractMicronautAotCliTask.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/AbstractMicronautAotCliTask.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -75,7 +76,7 @@ abstract class AbstractMicronautAotCliTask extends DefaultTask implements Optimi
     public final void execute() throws IOException {
         File outputDir = getOutputDirectory().getAsFile().get();
         getFileOperations().delete(outputDir);
-        File argFile = File.createTempFile("aot", "args");
+        File argFile = Files.createTempFile("aot", "args").toFile();
         try {
             ExecResult javaexec = getExecOperations().javaexec(spec -> {
                 FileCollection aotClasspath = getOptimizerClasspath();

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
@@ -1,6 +1,5 @@
 package io.micronaut.gradle.docker;
 
-import com.bmuschko.gradle.docker.DockerExtension;
 import com.bmuschko.gradle.docker.DockerRemoteApiPlugin;
 import com.bmuschko.gradle.docker.tasks.container.DockerCopyFileFromContainer;
 import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer;
@@ -18,6 +17,7 @@ import io.micronaut.gradle.docker.model.MicronautDockerImage;
 import io.micronaut.gradle.docker.model.RuntimeKind;
 import io.micronaut.gradle.docker.tasks.BuildLayersTask;
 import io.micronaut.gradle.docker.tasks.PrepareDockerContext;
+import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
@@ -248,9 +248,8 @@ public class MicronautDockerPlugin implements Plugin<Project> {
             // Because docker requires all files to be found in the build context we need to
             // copy the configuration file directories into the build context
             context.getOutputDirectory().set(project.getLayout().getBuildDirectory().dir("docker/native-" + imageName + "/config-dirs"));
-            context.getInputDirectories().from(dockerFileTask.map(t -> t.getNativeImageOptions()
-                    .get()
-                    .getConfigurationFileDirectories()
+            context.getInputDirectories().from(dockerFileTask.flatMap(t -> t.getNativeImageOptions()
+                    .map(NativeImageOptions::getConfigurationFileDirectories)
             ));
         });
         TaskProvider<DockerBuildImage> dockerBuildTask = tasks.register(adaptTaskName("dockerBuildNative", imageName), DockerBuildImage.class, task -> {

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/DockerResourceConfigDirectoryNamer.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/DockerResourceConfigDirectoryNamer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle.docker.tasks;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DockerResourceConfigDirectoryNamer {
+    private final Map<String, Integer> counter = new HashMap<>();
+
+    public String determineNameFor(File configDir) {
+        String name = configDir.getName();
+        File currentDir = configDir;
+        for (int i = 0; i < 3; i++) {
+            if (currentDir != null) {
+                currentDir = currentDir.getParentFile();
+            }
+        }
+        if (currentDir != null && "exploded".equals(currentDir.getName())) {
+            // This directory likely comes from the GraalVM metadata repository plugin
+            Path fullPath = configDir.toPath();
+            Path relativePath = currentDir.toPath().relativize(fullPath);
+            name = relativePath.toString();
+        }
+        Integer count = counter.computeIfAbsent(name, k -> 0);
+        if (count == 0) {
+            return name;
+        } else {
+            count++;
+            counter.put(name, count);
+            return name + "/" + count;
+        }
+    }
+}

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/PrepareDockerContext.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/PrepareDockerContext.java
@@ -47,8 +47,12 @@ public abstract class PrepareDockerContext extends DefaultTask {
 
     @TaskAction
     void copy() {
+        DockerResourceConfigDirectoryNamer namer = new DockerResourceConfigDirectoryNamer();
         for (File directory : getInputDirectories().getFiles()) {
-            getFileOperations().copy(spec -> spec.into(getOutputDirectory().dir(directory.getName())).from(directory));
+            if (directory.exists()) {
+                getFileOperations().copy(spec -> spec.into(getOutputDirectory().dir(namer.determineNameFor(directory))).from(directory));
+            }
         }
     }
+
 }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -79,8 +79,13 @@ COPY layers/classes /home/app/classes
 COPY layers/resources /home/app/resources
 COPY layers/application.jar /home/app/application.jar
 RUN mkdir /home/app/config-dirs
+RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
+RUN mkdir -p /home/app/config-dirs/io.netty/netty-common/4.1.80.Final
+RUN mkdir -p /home/app/config-dirs/ch.qos.logback/logback-classic/1.4.1
 COPY config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
-RUN native-image -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -H:Name=application $graalVMBuilderExports -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile -H:Class=demo.app.Application
+COPY config-dirs/io.netty/netty-common/4.1.80.Final /home/app/config-dirs/io.netty/netty-common/4.1.80.Final
+COPY config-dirs/ch.qos.logback/logback-classic/1.4.1 /home/app/config-dirs/ch.qos.logback/logback-classic/1.4.1
+RUN native-image -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -H:Name=application -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.configure=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jni=ALL-UNNAMED -J--add-exports=org.graalvm.sdk/org.graalvm.nativeimage.impl=ALL-UNNAMED -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile,/home/app/config-dirs/4.1.80.Final,/home/app/config-dirs/1.4.1 -H:Class=demo.app.Application
 FROM frolvlad/alpine-glibc:alpine-3.12
 RUN apk --no-cache update && apk add libstdc++
 EXPOSE 8080

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -1,7 +1,9 @@
 package io.micronaut.gradle.aot
 
+import io.micronaut.gradle.AbstractGradleBuildSpec
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.IgnoreIf
+import spock.lang.Requires
 
 @IgnoreIf({ os.windows })
 class MicronautAOTDockerSpec extends AbstractAOTPluginSpec {
@@ -56,6 +58,7 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
 
     }
 
+    @Requires({ AbstractGradleBuildSpec.graalVmAvailable && !os.windows })
     def "generates a native optimized docker image"() {
         withSample("aot/basic-app")
 

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -582,8 +582,11 @@ COPY layers/classes /home/alternate/classes
 COPY layers/resources /home/alternate/resources
 COPY layers/application.jar /home/alternate/application.jar
 RUN mkdir /home/alternate/config-dirs
+RUN mkdir -p /home/alternate/config-dirs/generateResourcesConfigFile
+RUN mkdir -p /home/alternate/config-dirs/io.netty/netty-common/4.1.80.Final
 COPY config-dirs/generateResourcesConfigFile /home/alternate/config-dirs/generateResourcesConfigFile
-RUN native-image -cp /home/alternate/libs/*.jar:/home/alternate/resources:/home/alternate/application.jar --no-fallback -H:Name=application $graalVMBuilderExports -H:ConfigurationFileDirectories=/home/alternate/config-dirs/generateResourcesConfigFile -H:Class=example.Application
+COPY config-dirs/io.netty/netty-common/4.1.80.Final /home/alternate/config-dirs/io.netty/netty-common/4.1.80.Final
+RUN native-image -cp /home/alternate/libs/*.jar:/home/alternate/resources:/home/alternate/application.jar --no-fallback -H:Name=application -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.configure=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jni=ALL-UNNAMED -J--add-exports=org.graalvm.sdk/org.graalvm.nativeimage.impl=ALL-UNNAMED -H:ConfigurationFileDirectories=/home/alternate/config-dirs/generateResourcesConfigFile,/home/alternate/config-dirs/4.1.80.Final -H:Class=example.Application
 FROM frolvlad/alpine-glibc:alpine-3.12
 RUN apk --no-cache update && apk add libstdc++
 EXPOSE 8080

--- a/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -5,10 +5,12 @@ import io.micronaut.gradle.MicronautRuntime;
 import io.micronaut.gradle.PluginsHelper;
 import org.graalvm.buildtools.gradle.NativeImagePlugin;
 import org.graalvm.buildtools.gradle.dsl.GraalVMExtension;
+import org.graalvm.buildtools.gradle.dsl.GraalVMReachabilityMetadataRepositoryExtension;
 import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.DependencySet;
+import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
@@ -57,6 +59,8 @@ public class MicronautGraalPlugin implements Plugin<Project> {
             configureAnnotationProcessing(project, extension);
         });
         GraalVMExtension graal = project.getExtensions().findByType(GraalVMExtension.class);
+        GraalVMReachabilityMetadataRepositoryExtension reachability = ((ExtensionAware)graal).getExtensions().getByType(GraalVMReachabilityMetadataRepositoryExtension.class);
+        reachability.getEnabled().convention(true);
         graal.getBinaries().configureEach(options ->
                 {
                     options.resources(rsrc -> rsrc.autodetection(inf -> {
@@ -71,8 +75,8 @@ public class MicronautGraalPlugin implements Plugin<Project> {
                     }
                 }
         );
+        TaskContainer tasks = project.getTasks();
         project.getPluginManager().withPlugin("application", plugin -> {
-            TaskContainer tasks = project.getTasks();
             tasks.withType(BuildNativeImageTask.class).named("nativeCompile", nativeImageTask -> {
                 MicronautRuntime mr = PluginsHelper.resolveRuntime(project);
                 if (mr.isLambdaProvided()) {

--- a/gradle-plugin/src/test/groovy/io/micronaut/gradle/MicronautLibraryPluginSpec.groovy
+++ b/gradle-plugin/src/test/groovy/io/micronaut/gradle/MicronautLibraryPluginSpec.groovy
@@ -150,8 +150,8 @@ class FooTest {
         javaFile << """
 package example;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
 
 @Path("/foo")
 public class Foo {

--- a/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMinimalLibraryPluginSpec.groovy
+++ b/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMinimalLibraryPluginSpec.groovy
@@ -150,8 +150,8 @@ class FooTest {
         javaFile << """
 package example;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
 
 @Path("/foo")
 public class Foo {


### PR DESCRIPTION
This commit enables use of the GraalVM metadata repository by default. It changes how the files are copied when working on Docker images, because previously, we had a single directory of resources (the generated one), but now it is possible to have multiple directories. For example, if netty is present on classpath, we will need to copy the configuration files for netty.

In practice, when we prepare the docker build context, we need to scan those directories and copy them. It is however possible that several directories have the same name, because the directory names are derived from GAV coordinates, so the same version can appear multiple times.

In order to:
   - avoid overwriting configuration files for several modules which have the same version
   - make things easier to debug when reading the docker files

we add inference to figure out if a configuration directory comes from the metadata repository, in which case we wouldn't use only the directory name, but the 3 last directories which correspond to the GAV coordinates. For example, instead of a directory named `1.0.0`, we would have a directory named `org.company:artifact:1.0.0`.