### PR TITLE
Fix compatibility with Gradle 8

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.internal.build.gradle-plugin.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.internal.build.gradle-plugin.gradle
@@ -30,13 +30,6 @@ configurations {
     }
 }
 
-pluginBundle {
-    website = 'https://micronaut.io/'
-    vcsUrl = 'https://github.com/micronaut-projects/micronaut-gradle-plugins'
-    description = 'Gradle Plugins for Micronaut'
-    tags = ['micronaut']
-}
-
 publishing {
     repositories {
         maven {


### PR DESCRIPTION
This commit reworks how the `useJUnitPlatform()` call is made, so that it's done _when the test task is configured_, rather than in afterEvaluate. It is not strictly equivalent, especially if the user makes use (accidentally or not) of eager APIs to configure tests, but it's a low risk change, due to the fact that the previous behavior was actually broken: in Gradle 8, changing the test framework after it has been configured is an error.

Previously to this change, if the user had configured a different testing framework, then our code would have been silently ignored.