### PR TITLE
Fix regression in test framework usage

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -51,7 +51,6 @@ import static org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.TEST_ANNOTATION_PROCESSOR_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME;
-import static org.gradle.api.plugins.JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME;
 
 /**
  * A base plugin which configures Micronaut components, which are either a Micronaut
@@ -100,14 +99,7 @@ public class MicronautComponentPlugin implements Plugin<Project> {
     private void configureTesting(Project project, MicronautExtension micronautExtension, TaskProvider<ApplicationClasspathInspector> inspectRuntimeClasspath) {
         project.getTasks().withType(Test.class).configureEach(t -> {
             t.dependsOn(inspectRuntimeClasspath);
-            Configuration testConfig = project.getConfigurations().getByName(TEST_IMPLEMENTATION_CONFIGURATION_NAME);
-            boolean hasJunit5 = !testConfig.getAllDependencies()
-                    .matching(dependency -> {
-                        String name = dependency.getName();
-                        return name.equals("junit-jupiter-engine") || name.equals("micronaut-test-junit5");
-                    })
-                    .isEmpty();
-            if (hasJunit5 || micronautExtension.getTestRuntime().get().equals(MicronautTestRuntime.JUNIT_5)) {
+            if (micronautExtension.getTestRuntime().get().isUsingJunitPlatform()) {
                 t.useJUnitPlatform();
             }
         });

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
@@ -19,7 +19,7 @@ public enum MicronautTestRuntime {
             Arrays.asList("org.junit.jupiter:junit-jupiter-api", "io.micronaut.test:micronaut-test-junit5"),
             JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME,
             Collections.singletonList("org.junit.jupiter:junit-jupiter-engine")
-    )),
+    ), true),
     /**
      * Spock 2.
      */
@@ -32,7 +32,7 @@ public enum MicronautTestRuntime {
                     "io.micronaut.test:micronaut-test-spock",
                     "org.codehaus.groovy:groovy"
             )
-    )),
+    ), true),
     /**
      * Kotest 4.
      */
@@ -47,7 +47,7 @@ public enum MicronautTestRuntime {
             ),
             JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME,
             Collections.singletonList("io.kotest:kotest-runner-junit5-jvm")
-    )),
+    ), true),
 
     /**
      * Kotest 5.
@@ -63,20 +63,23 @@ public enum MicronautTestRuntime {
             ),
             JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME,
             Collections.singletonList("io.kotest:kotest-runner-junit5-jvm")
-    )),
+    ), true),
     /**
      * No test runtime.
      */
     NONE;
 
     private final Map<String, List<String>> implementation;
+    private final boolean usesJunitPlatform;
 
-    MicronautTestRuntime(String... dependencies) {
-        this.implementation = Collections.singletonMap(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, Arrays.asList(dependencies));
+    MicronautTestRuntime() {
+        this.implementation = Collections.singletonMap(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, Collections.emptyList());
+        this.usesJunitPlatform = false;
     }
 
-    MicronautTestRuntime(Map<String, List<String>> implementation) {
+    MicronautTestRuntime(Map<String, List<String>> implementation, boolean usesJunitPlatform) {
         this.implementation = implementation;
+        this.usesJunitPlatform = usesJunitPlatform;
     }
 
     public Map<String, List<String>> getDependencies() {
@@ -105,5 +108,9 @@ public enum MicronautTestRuntime {
             }
         }
         return MicronautTestRuntime.NONE;
+    }
+
+    public boolean isUsingJunitPlatform() {
+        return usesJunitPlatform;
     }
 }


### PR DESCRIPTION
The fix introduced in #640 fixed the problem for JUnit as a test framework, which is the default when using starter. However, it broke when using Spock or Kotest.

However, all of the test frameworks that we use require JUnit Platform. This means that the code was probably used when we supported JUnit 4 without the legacy runner, and that it can be simplified now. Basically as soon as we use a test framework we can configure JUnit Platform.

Fixes #643