### PR TITLE
Fix compatibility with Gradle 8

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -578,7 +578,11 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
         options.getConfigurationFileDirectories().setFrom(
                 remappedConfigDirectories
         );
-        options.getClasspath().from(getTargetWorkingDirectory().map(d -> d + "/libs/*.jar"), getTargetWorkingDirectory().map(d -> d + "/resources:" + d + "/application.jar"));
+        options.getClasspath().from(
+                getTargetWorkingDirectory().map(d -> d + "/libs/*.jar"),
+                getTargetWorkingDirectory().map(d -> d + "/resources"),
+                getTargetWorkingDirectory().map(d -> d + "/application.jar")
+        );
         options.getImageName().set("application");
     }
 


### PR DESCRIPTION
This commit fixes the `dockerbuildNative` task which is not compatible with Gradle 8, due to the presence of a `:` in a single entry path.

Fixes #649