### PR TITLE
Rework validation module annotation processor handling

### DIFF
--- a/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
@@ -170,7 +170,7 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
             $repositoriesBlock
 
             dependencies {
-                implementation("io.micronaut:micronaut-validation")
+                implementation("io.micronaut.validation:micronaut-validation")
                 implementation("io.micronaut:micronaut-runtime")
                 implementation("io.micronaut.aws:micronaut-function-aws")
                 implementation("io.micronaut.aws:micronaut-function-aws-custom-runtime")
@@ -219,7 +219,7 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
             $repositoriesBlock
 
             dependencies {
-                implementation("io.micronaut:micronaut-validation")
+                implementation("io.micronaut.validation:micronaut-validation")
                 implementation("io.micronaut:micronaut-runtime")
                 implementation("io.micronaut.aws:micronaut-function-aws")
                 implementation("io.micronaut.aws:micronaut-function-aws-custom-runtime")
@@ -271,7 +271,7 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
             $repositoriesBlock
 
             dependencies {
-                implementation("io.micronaut:micronaut-validation")
+                implementation("io.micronaut.validation:micronaut-validation")
                 implementation("io.micronaut:micronaut-runtime")
                 implementation("io.micronaut.aws:micronaut-function-aws")
                 implementation("io.micronaut.aws:micronaut-function-aws-custom-runtime")

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
@@ -41,7 +41,7 @@ public class MicronautKotlinSupport {
     };
     public static final String KOTLIN_PROCESSORS = "kotlinProcessors";
 
-    private static final List<String> KSP_ANNOTATION_PROCESSOR_MODULES = Arrays.asList("inject-kotlin", "validation");
+    private static final List<String> KSP_ANNOTATION_PROCESSOR_MODULES = Arrays.asList("inject-kotlin");
 
     public static void whenKotlinSupportPresent(Project p, Consumer<? super Project> action) {
         p.getPluginManager().withPlugin("org.jetbrains.kotlin.jvm", unused -> action.accept(p));

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/PluginsHelper.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/PluginsHelper.java
@@ -37,11 +37,12 @@ import static org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME;
 
 public abstract class PluginsHelper {
-    final static List<String> ANNOTATION_PROCESSOR_MODULES = Arrays.asList("inject-java", "validation");
+    final static List<String> ANNOTATION_PROCESSOR_MODULES = Arrays.asList("inject-java");
     private final static Map<String, String> GROUP_TO_PROCESSOR_MAP = Collections.unmodifiableMap(new HashMap<String, String>() {{
         put("io.micronaut.data", "io.micronaut.data:micronaut-data-processor");
         put("io.micronaut.jaxrs", "io.micronaut.jaxrs:micronaut-jaxrs-processor");
         put("io.micronaut.security", "io.micronaut.security:micronaut-security-annotations");
+        put("io.micronaut.validation", "io.micronaut.validation:micronaut-validation-processor");
     }});
 
     public static String findMicronautVersion(Project p, MicronautExtension micronautExtension) {

--- a/samples/aot/aws-function/build.gradle
+++ b/samples/aot/aws-function/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation("io.micronaut:micronaut-runtime")
     implementation("javax.annotation:javax.annotation-api")
     runtimeOnly("ch.qos.logback:logback-classic")
-    implementation("io.micronaut:micronaut-validation")
+    implementation("io.micronaut.validation:micronaut-validation")
 
     implementation("io.micronaut.aws:micronaut-function-aws")
     runtimeOnly("org.yaml:snakeyaml")

--- a/samples/aot/basic-app/build.gradle
+++ b/samples/aot/basic-app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation("io.micronaut:micronaut-runtime")
     implementation("javax.annotation:javax.annotation-api")
     runtimeOnly("ch.qos.logback:logback-classic")
-    implementation("io.micronaut:micronaut-validation")
+    implementation("io.micronaut.validation:micronaut-validation")
     runtimeOnly("org.yaml:snakeyaml")
 }
 

--- a/samples/aot/with-shadow/build.gradle
+++ b/samples/aot/with-shadow/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation("io.micronaut:micronaut-http-client")
     implementation("io.micronaut:micronaut-runtime")
     implementation("javax.annotation:javax.annotation-api")
-    implementation("io.micronaut:micronaut-validation")
+    implementation("io.micronaut.validation:micronaut-validation")
     runtimeOnly("ch.qos.logback:logback-classic")
     runtimeOnly("org.yaml:snakeyaml")
 }

--- a/samples/test-resources/custom-test-resource/build.gradle
+++ b/samples/test-resources/custom-test-resource/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation("io.micronaut:micronaut-jackson-databind")
     implementation("io.micronaut:micronaut-runtime")
     implementation("jakarta.annotation:jakarta.annotation-api")
-    implementation("io.micronaut:micronaut-validation")
+    implementation("io.micronaut.validation:micronaut-validation")
     runtimeOnly("ch.qos.logback:logback-classic")
     runtimeOnly("io.micronaut:micronaut-jackson-databind")
     runtimeOnly("org.yaml:snakeyaml")

--- a/samples/test-resources/data-mysql/build.gradle
+++ b/samples/test-resources/data-mysql/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation("io.micronaut:micronaut-jackson-databind")
     implementation("io.micronaut:micronaut-runtime")
     implementation("jakarta.annotation:jakarta.annotation-api")
-    implementation("io.micronaut:micronaut-validation")
+    implementation("io.micronaut.validation:micronaut-validation")
     runtimeOnly("ch.qos.logback:logback-classic")
     runtimeOnly("org.yaml:snakeyaml")
 }

--- a/samples/test-resources/isolated-multiproject/app1/build.gradle
+++ b/samples/test-resources/isolated-multiproject/app1/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation("io.micronaut:micronaut-jackson-databind")
     implementation("io.micronaut:micronaut-runtime")
     implementation("jakarta.annotation:jakarta.annotation-api")
-    implementation("io.micronaut:micronaut-validation")
+    implementation("io.micronaut.validation:micronaut-validation")
     implementation("io.micronaut.data:micronaut-data-jdbc")
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
     runtimeOnly("mysql:mysql-connector-java")

--- a/samples/test-resources/isolated-multiproject/app2/build.gradle
+++ b/samples/test-resources/isolated-multiproject/app2/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation("io.micronaut:micronaut-jackson-databind")
     implementation("io.micronaut:micronaut-runtime")
     implementation("jakarta.annotation:jakarta.annotation-api")
-    implementation("io.micronaut:micronaut-validation")
+    implementation("io.micronaut.validation:micronaut-validation")
     implementation("io.micronaut.data:micronaut-data-jdbc")
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
     runtimeOnly("ch.qos.logback:logback-classic")

--- a/samples/test-resources/multiproject/app1/build.gradle
+++ b/samples/test-resources/multiproject/app1/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation("io.micronaut:micronaut-jackson-databind")
     implementation("io.micronaut:micronaut-runtime")
     implementation("jakarta.annotation:jakarta.annotation-api")
-    implementation("io.micronaut:micronaut-validation")
+    implementation("io.micronaut.validation:micronaut-validation")
     implementation("io.micronaut.data:micronaut-data-jdbc")
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
     runtimeOnly("ch.qos.logback:logback-classic")

--- a/samples/test-resources/multiproject/app2/build.gradle
+++ b/samples/test-resources/multiproject/app2/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation("io.micronaut:micronaut-jackson-databind")
     implementation("io.micronaut:micronaut-runtime")
     implementation("jakarta.annotation:jakarta.annotation-api")
-    implementation("io.micronaut:micronaut-validation")
+    implementation("io.micronaut.validation:micronaut-validation")
     implementation("io.micronaut.data:micronaut-data-jdbc")
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
     runtimeOnly("ch.qos.logback:logback-classic")


### PR DESCRIPTION
Currently the plugin always applies the old `micronaut-validation` module which means the plugin is currently broken with:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':annotationProcessor'.
   > Could not find io.micronaut:micronaut-validation:.
     Required by:
         project :
```

This reworks the code so the validation processor is only applied if a validation module exists on the classpath