### PR TITLE
Fix documentation for 3.7.5

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1533,7 +1533,7 @@ WARNING: The Micronaut CRaC module is in experimental stages. Use at your own ri
 The `io.micronaut.crac` plugin provides extra integration with https://micronaut-projects.github.io/micronaut-crac/latest/guide/[Micronaut CRaC].
 Micronaut CRaC is a module which adds support for https://openjdk.org/projects/crac/[Coordinated Restore at Checkpoint] to Micronaut applications.
 
-It is capable of generating a docker image containing a CRaC enabled JDK and a pre-warmed, checkpointed application via a new task `dockerCracBuild`.
+It is capable of generating a docker image containing a CRaC enabled JDK and a pre-warmed, checkpointed application via a new task `dockerBuildCrac`.
 
 IMPORTANT: Currently CRaC support has only been tested on Ubuntu 18.04, 20.04 and 22.04.  It also requires an x86 machine architecture.
 


### PR DESCRIPTION
It's `dockerBuildCrac`, not `dockerCracBuild`