### PR TITLE
Fix CRaC plugin for Gradle 8

### DIFF
--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
@@ -224,6 +224,7 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
         Provider<RegularFile> targetCheckpointDockerFile = project.getLayout().getBuildDirectory().file(BUILD_DOCKER_DIRECTORY + imageName + "/Dockerfile");
         TaskProvider<CRaCFinalDockerfile> dockerFileTask = tasks.register(dockerFileTaskName, CRaCFinalDockerfile.class, task -> {
             task.setGroup(CRAC_TASK_GROUP);
+            task.mustRunAfter(start);
             task.setDescription("Builds a Docker File for CRaC checkpointed image " + imageName);
             task.getDestFile().set(targetCheckpointDockerFile);
             task.getBaseImage().set(configuration.getBaseImage());


### PR DESCRIPTION
The CRaC plugin uses the same directory for both the checkpoint and final dockerfiles. This is because the layers are used by both, and the checkpoint run creates a new CR directory of checkpoint data for the final image.

Gradle doesn't like this, as outputs from multiple tasks are going to the same location.

And in Gradle 8, this is an error instead of a warning in Gradle 7.

I tried to implement a better fix in multiple ways:

1. Separating the final docker-file into a different location (doesn't work, as the docker plugin cannot seem to find both it and the layer directories)
2. Copying the layers and CR directories out of docker/main into docker/main-final.  But I couldn't get this to work either.

So I went for a route that works.

This makes sure we create the main dockerfile AFTER all the checkpointing is done, so Gradle doesn't think we need a web of depepndencies declaring.