### PR TITLE
Fix native lambda builds within Docker

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -400,7 +400,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
         if (buildStrategy == DockerBuildStrategy.LAMBDA) {
             from(new From(imageResolver.resolve()).withStage("graalvm"));
             environmentVariable("LANG", "en_US.UTF-8");
-            runCommand("yum install -y gcc gcc-c++ libc6-dev zlib1g-dev curl bash zlib zlib-devel zlib-static zip tar gzip");
+            runCommand("yum install -y gcc gcc-c++ bash zlib zlib-devel zlib-static zip tar gzip");
             String jdkVersion = getJdkVersion().get();
             String graalVersion = getGraalVersion().get();
             String graalArch = getGraalArch().get();
@@ -658,7 +658,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
             String baseImage = getBaseImage().getOrNull();
 
             if (strategy == DockerBuildStrategy.LAMBDA && baseImage == null) {
-                baseImage = "amazonlinux:latest";
+                baseImage = "amazonlinux:2023";
             } else if (baseImage == null) {
                 baseImage = "frolvlad/alpine-glibc:alpine-3.12";
             }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -95,7 +95,7 @@ micronaut:
         where:
         runtime  | nativeImage
         "netty"  | 'FROM ghcr.io/graalvm/native-image:ol7-java'
-        "lambda" | 'FROM amazonlinux:latest AS graalvm'
+        "lambda" | 'FROM amazonlinux:2023 AS graalvm'
         "jetty"  | 'FROM ghcr.io/graalvm/native-image:ol7-java'
     }
 
@@ -485,7 +485,7 @@ class Application {
         where:
         runtime  | nativeImage
         "netty"  | 'FROM ghcr.io/graalvm/native-image:ol7-java'
-        "lambda" | 'FROM amazonlinux:latest AS graalvm'
+        "lambda" | 'FROM amazonlinux:2023 AS graalvm'
         "jetty"  | 'FROM ghcr.io/graalvm/native-image:ol7-java'
     }
 

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
@@ -238,7 +238,7 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
             }
 
             dockerfileNative {
-                baseImage('internal.proxy.com/amazonlinux:latest')
+                baseImage('internal.proxy.com/amazonlinux:2023')
             }
         """
 
@@ -252,7 +252,7 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
         dockerfileNativeTask.outcome == TaskOutcome.SUCCESS
 
         and:
-        dockerFileNative.find() { it.contains('internal.proxy.com/amazonlinux:latest')}
+        dockerFileNative.find() { it.contains('internal.proxy.com/amazonlinux:2023')}
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/279")
@@ -300,7 +300,7 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
         dockerfileNativeTask.outcome == TaskOutcome.SUCCESS
 
         and:
-        dockerFileNative.find() { it.contains('amazonlinux:latest')}
+        dockerFileNative.find() { it.contains('amazonlinux:2023')}
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/pull/537")


### PR DESCRIPTION
The image that we use, `amazonlinux:latest` was recently updated and it now fails to run the `yum` command that we used to prepare the image for installation of GraalVM.

This commit fixes the problem by using image `amazonlinux:2023` and updating the `yum` command.