### PR TITLE
Build fixes

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -44,7 +44,7 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Gradle
-        run: ./gradlew check --continue --no-daemon --no-parallel
+        run: ./gradlew check --continue --no-daemon
         env:
            TESTCONTAINERS_RYUK_DISABLED: true
            GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -48,10 +48,7 @@ jobs:
         run: |
           [ -f ./setup.sh ] && ./setup.sh || true
       - name: Build with Gradle
-        run: |
-          # Awful hack for kapt and JDK 16. See https://youtrack.jetbrains.com/issue/KT-45545
-          if [ ${{ matrix.java }} == 16 ]; then export GRADLE_OPTS="-Dorg.gradle.jvmargs=--illegal-access=permit"; fi
-          ./gradlew dependencyUpdates check --no-daemon --parallel --continue
+        run: ./gradlew dependencyUpdates check --no-daemon --continue
         env:
            TESTCONTAINERS_RYUK_DISABLED: true
            GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -50,7 +50,7 @@ jobs:
           [ -f ./setup.sh ] && ./setup.sh || true
       - name: Analyse with Gradle
         run: |
-          ./gradlew check sonarqube --no-daemon --no-parallel --continue --no-build-cache
+          ./gradlew check sonarqube --no-daemon --continue --no-build-cache
         env:
           PREDICTIVE_TEST_SELECTION: false
           TESTCONTAINERS_RYUK_DISABLED: true

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -32,7 +32,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Gradle
         shell: cmd
-        run: ./gradlew.bat check --no-daemon --continue
+        run: ./gradlew.bat check --no-daemon --continue --configuration-cache
         env:
           TESTCONTAINERS_RYUK_DISABLED: true
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -32,7 +32,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Gradle
         shell: cmd
-        run: ./gradlew.bat check --no-daemon --continue --configuration-cache
+        run: ./gradlew.bat check --no-daemon --continue
         env:
           TESTCONTAINERS_RYUK_DISABLED: true
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/buildSrc/src/main/groovy/io.micronaut.internal.build.functional-testing.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.internal.build.functional-testing.gradle
@@ -1,7 +1,7 @@
 import io.micronaut.internal.build.test.FunctionalTestingExtension
 plugins {
     id 'groovy'
-    id "io.micronaut.internal.build.testing"
+    id 'io.micronaut.internal.build.testing'
 }
 
 pluginManager.apply(io.micronaut.build.MicronautQualityChecksParticipantPlugin)
@@ -30,9 +30,14 @@ configurations {
 
 extensions.create("functionalTesting", FunctionalTestingExtension)
 
+def prepareRepository = tasks.register("prepareRepository", Sync) {
+    from configurations.pluginsUnderTest
+    into file("${buildDir}/aggregatedRepo")
+}
+
 tasks.withType(Test).configureEach { Test test ->
     def repoProvider = objects.newInstance(RepositoryProvider)
-    repoProvider.repositoryDir.from(configurations.pluginsUnderTest)
+    repoProvider.repositoryDir.from(prepareRepository)
     repoProvider.version.set(version)
     test.jvmArgumentProviders.add(repoProvider)
     systemProperties.put("kotlinVersion", libs.versions.kotlin.get())
@@ -61,6 +66,7 @@ abstract class RepositoryProvider implements CommandLineArgumentProvider {
 
     @Override
     Iterable<String> asArguments() {
-        ["-Dinternal.plugin.repo=${repositoryDir.singleFile.toURI().toASCIIString()}", "-Dproject.version=${version.get()}"]
+        String patchedVersion = version.get().replace('-SNAPSHOT', '-DUMMY')
+        ["-Dinternal.plugin.repo=${repositoryDir.singleFile.toURI().toASCIIString()}", "-Dproject.version=${patchedVersion}"]
     }
 }

--- a/buildSrc/src/main/groovy/io.micronaut.internal.build.gradle-plugin.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.internal.build.gradle-plugin.gradle
@@ -31,18 +31,81 @@ configurations {
     }
 }
 
+def projectRepoPath = project.layout.buildDirectory.dir("repo")
+
+def localPublicationsTasks = []
+
 publishing {
     repositories {
         maven {
             name = "build"
             url = "${rootProject.layout.buildDirectory.dir("repo").get().asFile.toURI()}"
         }
+        maven {
+            name = "project"
+            url = "${projectRepoPath.get().asFile.toURI()}"
+        }
+    }
+    publications.all { pub ->
+        if (!pub.name.startsWith('local')) {
+            String pubName = "local${pub.name.capitalize()}"
+            localPublicationsTasks << "publish${pubName.capitalize()}PublicationToProjectRepository".toString()
+            publications.register(pubName, MavenPublication) {
+                project.afterEvaluate {
+                    def component = pub.component
+                    from(component)
+                    alias = true
+                    groupId = pub.groupId
+                    artifactId = pub.artifactId
+                    version = project.version.replace('-SNAPSHOT', '-DUMMY')
+                    if (component == null) {
+                        String pName = project.name
+                        String pGroup = project.group
+                        String pVersion = project.version.toString().replace('-SNAPSHOT', '-DUMMY')
+                        // it is a plugin marker
+                        pom.withXml {
+                            def dependenciesNode = asNode().appendNode('dependencies')
+                            def dep = dependenciesNode.appendNode('dependency')
+                            dep.appendNode('groupId', pGroup)
+                            dep.appendNode('artifactId', pName)
+                            dep.appendNode('version', pVersion)
+                        }
+                    } else {
+                        pom.withXml {
+                            asNode().dependencies.dependency.each { n ->
+                                if (n.groupId[0].text() == 'io.micronaut.gradle') {
+                                    if (n.version[0].text().endsWith('-SNAPSHOT')) {
+                                        n.version[0].value = n.version[0].text().replace('-SNAPSHOT', '-DUMMY')
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+def cleanRepository = tasks.register("cleanRepository", Delete) {
+    delete projectRepoPath
+}
+
+def publishPluginToProjectRepo = tasks.register("publishPluginToProjectRepo") {
+    dependsOn(cleanRepository)
+    dependsOn(localPublicationsTasks)
+}
+
+localPublicationsTasks.each { taskName ->
+    tasks.named(taskName) {
+        mustRunAfter(cleanRepository)
     }
 }
 
 configurations.repository.outgoing {
-    artifact(rootProject.layout.buildDirectory.dir("repo")) {
-        builtBy(tasks.named("publishAllPublicationsToBuildRepository"))
+    artifact(projectRepoPath) {
+        builtBy(publishPluginToProjectRepo)
     }
 }
 
@@ -54,26 +117,20 @@ dependencies {
     }
 }
 
-// This is a quick and dirty workaround for
-// publication tasks which are never up-to-date.
-// The problem is that we rely on a local repository
-// for functional testing, and that every invocation
-// of a test would trigger a publication and therefore
-// never be up-to-date.
-tasks.configureEach {
-    if (it.name.startsWith("generateMetadataFile")
-            || it.name.startsWith("generatePomFile")
-            || it.name.startsWith("publish")) {
-        dependsOn(tasks.named('jar'))
-        onlyIf {
-            !rootProject.layout.buildDirectory.dir("repo").get().asFile.exists() || tasks.getByName("jar").didWork
-        }
-    }
+tasks.withType(Jar).configureEach {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
 }
 
 // There are many violations that we'll need to fix later
 tasks.withType(Checkstyle).configureEach {
     enabled = false
+}
+
+tasks.withType(GenerateModuleMetadata).configureEach {
+    if (it.name.contains('ForLocal')) {
+        enabled = false
+    }
 }
 
 gradlePlugin {

--- a/buildSrc/src/main/groovy/io.micronaut.internal.build.testing.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.internal.build.testing.gradle
@@ -1,23 +1,40 @@
 plugins {
     id 'java'
     id 'pl.droidsonroids.jacoco.testkit'
-}
-
-tasks.withType(Test).configureEach {
-    def graalvmHome = providers.environmentVariable('GRAALVM_HOME')
-            .orElse(providers.environmentVariable("JAVA_HOME"))
-            .getOrElse("")
-    useJUnitPlatform()
-    inputs.property("GRAALVM_HOME", graalvmHome)
-    predictiveSelection {
-        enabled = micronautBuild.environment.isTestSelectionEnabled()
-    }
-    environment "GRAALVM_HOME", graalvmHome
-    systemProperty "micronautVersion", libs.versions.micronaut.asProvider().get()
+    id 'com.adarshr.test-logger'
 }
 
 dependencies {
     testImplementation libs.groovy.core
     testImplementation libs.spock.core
     testImplementation libs.spock.junit4
+}
+
+// We are NOT using the `jvm-test-suite` plugin because
+// it would generate different source sets for each test
+// suite, which is not what we want: we simply need different
+// test tasks, with different includes
+
+tasks.withType(Test).configureEach {
+    dependsOn("generateJacocoTestKitProperties")
+    useJUnitPlatform()
+    def graalvmHome = providers.environmentVariable('GRAALVM_HOME')
+            .orElse(providers.environmentVariable("JAVA_HOME"))
+            .getOrElse("")
+    inputs.property("GRAALVM_HOME", graalvmHome)
+    environment "GRAALVM_HOME", graalvmHome
+    systemProperty "micronautVersion", libs.versions.micronaut.asProvider().get()
+    predictiveSelection {
+        enabled = micronautBuild.environment.isTestSelectionEnabled()
+    }
+    maxParallelForks = Math.max(1, (int) (Runtime.runtime.availableProcessors()/2))
+}
+
+testlogger {
+    theme 'standard-parallel'
+    showFullStackTraces true
+    showStandardStreams true
+    showPassedStandardStreams false
+    showSkippedStandardStreams false
+    showFailedStandardStreams true
 }

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
@@ -76,7 +76,7 @@ class BuildLayersSpec extends AbstractGradleBuildSpec {
                 from sourceSets.main.output
             }
 
-            configurations.runtimeClasspath.dependencies.add(dependencies.create(files(jar1, jar2)))            
+            configurations.runtimeOnly.dependencies.add(dependencies.create(files(jar1, jar2)))            
 
             tasks.withType(io.micronaut.gradle.docker.tasks.BuildLayersTask) {
                 duplicatesStrategy = DuplicatesStrategy.INCLUDE

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -645,7 +645,7 @@ afterEvaluate {
             $repositoriesBlock
 
             micronaut {
-                version "3.4.0"
+                version "$micronautVersion"
             }
 
             mainClassName="example.Application"
@@ -693,7 +693,7 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
 
         then:
         def dockerfileNative = new File(testProjectDir.root, 'build/docker/native-main/DockerfileNative').text
-        dockerfileNative == """FROM ghcr.io/graalvm/native-image:ol7-java11-22.3.0 AS graalvm
+        dockerfileNative == """FROM ghcr.io/graalvm/native-image:ol7-java17-22.3.0 AS graalvm
 WORKDIR /home/app
 COPY layers/libs /home/app/libs
 COPY server.iprof /home/app/server.iprof
@@ -701,6 +701,7 @@ COPY layers/classes /home/app/classes
 COPY layers/resources /home/app/resources
 COPY layers/application.jar /home/app/application.jar
 RUN mkdir /home/app/config-dirs
+RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
 COPY config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
 RUN native-image -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -H:Name=application -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.configure=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jni=ALL-UNNAMED -J--add-exports=org.graalvm.sdk/org.graalvm.nativeimage.impl=ALL-UNNAMED -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile -H:Class=example.Application
 FROM frolvlad/alpine-glibc:alpine-3.12
@@ -725,7 +726,7 @@ ENTRYPOINT ["/app/application"]
             $repositoriesBlock
 
             micronaut {
-                version "3.4.0"
+                version "$micronautVersion"
             }
 
             mainClassName="example.Application"

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/Kotest5FunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/Kotest5FunctionalTest.groovy
@@ -26,19 +26,6 @@ class Kotest5FunctionalTest extends AbstractEagerConfiguringFunctionalTest {
                        |    $plugin
                        |}
                        |
-                       |tasks {
-                       |    compileKotlin {
-                       |        kotlinOptions {
-                       |            jvmTarget = "1.8"
-                       |        }
-                       |    }
-                       |    compileTestKotlin {
-                       |        kotlinOptions {
-                       |            jvmTarget = "1.8"
-                       |        }
-                       |    }
-                       |}
-                       |
                        |micronaut {
                        |    version "$micronautVersion"
                        |    runtime "netty"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.8.10"
-ksp = "1.8.0-1.0.8"
+ksp = "1.8.10-1.0.9"
 docker = "9.2.1"
 diffplug = "3.41.1"
 shadow = "7.1.2"
@@ -8,7 +8,7 @@ groovy = "3.0.16"
 spock = "2.1-groovy-3.0"
 graalvmPlugin = "0.9.20"
 micronaut = "4.0.0-SNAPSHOT"
-micronaut-aot = "1.1.2"
+micronaut-aot = "2.0.0-M1"
 micronaut-testresources = "2.0.0-SNAPSHOT"
 log4j2 = { require = "2.17.1", reject = ["]0, 2.17["] }
 jetbrains-annotations = "23.1.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This commit fixes a number of issues with the build:

1. reworks how the test Maven repository is built, in order to be more reliable and compatible with the configuration cache. The previous implementation didn't accurately capture changes in some cases, forcing to do a `clean` when it shouldn't be necessary
2. upgrades to AOT 2.0.0-M1
3. fixes the crac plugin using a lambda instead of anonymous class
4. fixes test expectations which were broken by recent Micronaut upgrade