### PR TITLE
Copy the customized CRaC dockerfiles if they exist in the root

### DIFF
--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCFinalDockerfile.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCFinalDockerfile.java
@@ -3,11 +3,19 @@ package io.micronaut.gradle.crac;
 import io.micronaut.gradle.docker.DockerBuildStrategy;
 import io.micronaut.gradle.docker.MicronautDockerfile;
 import org.gradle.api.GradleException;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,11 +28,36 @@ public abstract class CRaCFinalDockerfile extends MicronautDockerfile {
     @Optional
     public abstract Property<String> getPlatform();
 
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    @Optional
+    public abstract RegularFileProperty getCustomFinalDockerfile();
+
     public static final String DEFAULT_WORKING_DIR = "/home/app";
 
     @SuppressWarnings("java:S5993") // Gradle API
     public CRaCFinalDockerfile() {
         setDescription("Builds a Docker File for a CRaC checkpointed Micronaut application");
+    }
+
+    @TaskAction
+    @Override
+    public void create() {
+        if (getCustomFinalDockerfile().isPresent()) {
+            Path source = getCustomFinalDockerfile().get().getAsFile().toPath();
+            try {
+                Files.copy(
+                        source,
+                        getDestFile().get().getAsFile().toPath()
+                );
+                getProject().getLogger().lifecycle("Dockerfile copied from {} to {}", source, getDestFile().get().getAsFile().getAbsolutePath());
+                return;
+            } catch (IOException e) {
+                throw new GradleException("Error copying custom final Dockerfile", e);
+            }
+        }
+        super.create();
+        getProject().getLogger().lifecycle("Dockerfile written to: {}", getDestFile().get().getAsFile().getAbsolutePath());
     }
 
     @Override

--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
@@ -127,6 +127,9 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
         TaskProvider<CRaCCheckpointDockerfile> dockerFileTask = tasks.register(dockerFileTaskName, CRaCCheckpointDockerfile.class, task -> {
             task.setGroup(CRAC_TASK_GROUP);
             task.setDescription("Builds a Checkpoint Docker File for image " + imageName);
+            if (f.exists()) {
+                task.getCustomCheckpointDockerfile().set(f);
+            }
             task.getDestFile().set(targetCheckpointDockerFile);
             task.getBaseImage().set(configuration.getBaseImage());
             task.getPlatform().set(configuration.getPlatform());
@@ -226,6 +229,9 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
             task.setGroup(CRAC_TASK_GROUP);
             task.mustRunAfter(start);
             task.setDescription("Builds a Docker File for CRaC checkpointed image " + imageName);
+            if (f.exists()) {
+                task.getCustomFinalDockerfile().set(f);
+            }
             task.getDestFile().set(targetCheckpointDockerFile);
             task.getBaseImage().set(configuration.getBaseImage());
             task.getPlatform().set(configuration.getPlatform());
@@ -258,5 +264,4 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
         }
         return Optional.empty();
     }
-
 }

--- a/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
+++ b/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
@@ -140,4 +140,21 @@ class CracCustomizationSpec extends BaseCracGradleBuildSpec {
         fileTextContents("build/docker/main/Dockerfile").readLines().head() == "FROM --platform=raspberry-pi/arm64 timyates:latest"
         fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").readLines().head() == "FROM --platform=raspberry-pi/arm64 timyates:latest"
     }
+
+    void "dockerfiles can be customized"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << buildFileBlock
+
+        baseDir.resolve("DockerfileCracCheckpoint").write("I am checkpoint dockerfile")
+        baseDir.resolve("Dockerfile").write("I am the main dockerfile")
+
+        when:
+        def result = build('dockerfileCrac', 'checkpointDockerfile', '-s')
+
+        then:
+        result.output.contains("BUILD SUCCESSFUL")
+        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").readLines().head() == "I am checkpoint dockerfile"
+        fileTextContents("build/docker/main/Dockerfile").readLines().head() == "I am the main dockerfile"
+    }
 }


### PR DESCRIPTION
Previously, we allowed users to create `Dockerfile` and/or `DockerfileCracCheckpoint` in the root of their project and we then would attempt to use these for the image generation.

This doesn't work.  The Docker plugin requires all Docker content to be in the same file tree.

This PR copies checks for the existence of these files, and copies them to the correct location instead of building the dockerfiles.

Fixes #678