### PR TITLE
Fix micronaut.processing.group option

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
@@ -95,7 +95,7 @@ public class MicronautKotlinSupport {
             if (isIncremental) {
                 kspExtension.arg("micronaut.processing.incremental", "true");
                 if (group.length() > 0) {
-                    kspExtension.arg("micronaut.processing.group,", group);
+                    kspExtension.arg("micronaut.processing.group", group);
                 }
                 kspExtension.arg("micronaut.processing.module", module);
             }
@@ -126,7 +126,7 @@ public class MicronautKotlinSupport {
                     }
 
                     if (group.length() > 0) {
-                        options.arg("micronaut.processing.group,", group);
+                        options.arg("micronaut.processing.group", group);
                     }
                     options.arg("micronaut.processing.module", module);
 


### PR DESCRIPTION
The option was incorrectly passed to the Kotlin compiler with a trailing comma in the option name. This was obviously wrong, generating wrong compiler options, and in particular something like this `micronaut.processing.group,=data-parent.doc-examples` which causes a parsing error in latest KSP plugin builds:

Wrong plugin option format: null, should be plugin:<pluginId>:<optionName>=