### PR TITLE
Fix duplicate entries on classpath

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
@@ -258,8 +258,8 @@ public class MicronautDockerPlugin implements Plugin<Project> {
             // Because docker requires all files to be found in the build context we need to
             // copy the configuration file directories into the build context
             context.getOutputDirectory().set(project.getLayout().getBuildDirectory().dir("docker/native-" + imageName + "/config-dirs"));
-            context.getInputDirectories().from(dockerFileTask.flatMap(t -> t.getNativeImageOptions()
-                    .map(NativeImageOptions::getConfigurationFileDirectories)
+            context.getInputDirectories().from(dockerFileTask.map(t -> t.getNativeImageOptions()
+                    .map(NativeImageOptions::getConfigurationFileDirectories).get() // drop dependency on building image
             ));
         });
         TaskProvider<DockerBuildImage> dockerBuildTask = tasks.register(adaptTaskName("dockerBuildNative", imageName), DockerBuildImage.class, task -> {

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -63,7 +63,7 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
         withSample("aot/basic-app")
 
         when:
-        def result = build "optimizedDockerBuildNative", "-i"
+        def result = build "optimizedDockerBuildNative"
 
         then:
         result.task(":prepareNativeOptimizations").outcome == TaskOutcome.SUCCESS
@@ -73,6 +73,7 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
         result.task(":optimizedBuildNativeLayersTask").outcome == TaskOutcome.SUCCESS
         result.task(":optimizedDockerfileNative").outcome == TaskOutcome.SUCCESS
         result.task(":optimizedDockerBuildNative").outcome == TaskOutcome.SUCCESS
+        result.tasks.stream().noneMatch { it.path == ":nativeCompile" }
 
         def dockerFile = normalizeLineEndings(file("build/docker/native-optimized/DockerfileNative").text)
         dockerFile == """FROM ghcr.io/graalvm/native-image:ol7-java17-22.3.0 AS graalvm

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithAotAndGraalVMSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithAotAndGraalVMSpec.groovy
@@ -32,7 +32,7 @@ micronaut {
 """)
 
         when:
-        def result = build 'nativeOptimizedRun', '-i'
+        def result = build 'nativeOptimizedRun',  "-Dtestresources.native"
 
         then:
         result.task(':nativeOptimizedRun').outcome == TaskOutcome.SUCCESS

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithGraalVMSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithGraalVMSpec.groovy
@@ -56,7 +56,7 @@ graalvmNative.binaries.all {
 """)
 
         when:
-        def result = build 'nativeRun'
+        def result = build 'nativeRun', "-Dtestresources.native"
 
         then:
         result.task(':nativeRun').outcome == TaskOutcome.SUCCESS

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/AttributeUtils.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/AttributeUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
+
+import java.util.Set;
+
+/**
+ * Utilities to deal with Gradle configuration attributes.
+ */
+public abstract class AttributeUtils {
+    private AttributeUtils() {
+
+    }
+
+    /**
+     * Copies attributes from a source configuration to a target configuration
+     * @param from the source configuration
+     * @param to the target configuration
+     */
+    public static void copyAttributes(Configuration from, Configuration to) {
+        from.attributes(attrs -> {
+            AttributeContainer runtimeClasspathAttributes = to.getAttributes();
+            Set<Attribute<?>> keySet = runtimeClasspathAttributes.keySet();
+            for (Attribute<?> attribute : keySet) {
+                //noinspection unchecked,DataFlowIssue
+                attrs.attribute((Attribute<Object>) attribute, runtimeClasspathAttributes.getAttribute(attribute));
+            }
+        });
+    }
+}

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1365,6 +1365,28 @@ dependencies {
 ----
 ====
 
+[[src:test-resources-native]]
+=== Using test resources with native binaries
+
+By default, native binaries are considered production code.
+This implies that the test resources client will _not_ be included in the generated native binaries and therefore, by default, native applications will not make use of test resources.
+
+In order to produce a native binary which is capable of using test resources, you must explicitly pass a system property to the build:
+
+[source,bash]
+----
+./gradlew nativeCompile -Dtestresources.native=true
+----
+
+or, if you want to run the binary directly:
+
+[source,bash]
+----
+./gradlew nativeRun -Dtestresources.native=true
+----
+
+Note that you don't need to do this for the `nativeTest` task, which is automatically configured to use test resources.
+
 [[sec:standalone-test-resources]]
 === Standalone test resources service
 

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/internal/TestResourcesGraalVM.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/internal/TestResourcesGraalVM.java
@@ -20,6 +20,7 @@ import io.micronaut.gradle.testresources.StartTestResourcesService;
 import org.graalvm.buildtools.gradle.dsl.GraalVMExtension;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.TaskProvider;
 
 /**
@@ -28,16 +29,35 @@ import org.gradle.api.tasks.TaskProvider;
  * issues.
  */
 public final class TestResourcesGraalVM {
+    public static final String ENABLED_PROPERTY_NAME = "testresources.native";
+
     public static void configure(Project project,
-                                 Configuration testResourcesClasspathConfig,
+                                 Configuration client,
                                  TaskProvider<StartTestResourcesService> internalStart) {
         GraalVMExtension graalVMExtension = project.getExtensions().findByType(GraalVMExtension.class);
         graalVMExtension.getBinaries().all(b -> {
-            b.getClasspath().from(testResourcesClasspathConfig);
             b.getRuntimeArgs().addAll(internalStart.map(task -> {
                 MicronautTestResourcesPlugin.ServerConnectionParametersProvider provider = new MicronautTestResourcesPlugin.ServerConnectionParametersProvider(internalStart);
                 return provider.asArguments();
             }));
         });
+        ProviderFactory providers = project.getProviders();
+        boolean includeClient = Boolean.TRUE.equals(providers
+                .systemProperty(ENABLED_PROPERTY_NAME)
+                .orElse(providers.gradleProperty(ENABLED_PROPERTY_NAME))
+                .map(s -> {
+                    if (s.equals("")) {
+                        // if the property is set without value, consider it's true
+                        return "true";
+                    }
+                    return "false";
+                })
+                .orElse("false")
+                .map(Boolean::parseBoolean)
+                .getOrElse(false));
+        if (includeClient) {
+            Configuration runtimeClasspath = project.getConfigurations().getByName("runtimeOnly");
+            runtimeClasspath.extendsFrom(client);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the broken builds.

This commit significantly reworks how configurations are setup, in order to fix a problem which appears independently in 2 locations: if using test resources or the developmentOnly configuration, it was possible that dependencies were duplicated, in different versions, on classpath.

For example, the test resources client was previously resolved independently into its own dependency graph, which was then added to the run task classpath. Similarly, the `developmentOnly` configuration was resolved independently and added to the runtime classpath.

The problem is that by appending to the classpath, we have 2 independent dependency graphs, which _may_, or may not, include the same dependencies. In practice, it was easy to get a mismatch. For example, even if we made sure to use the same Micronaut version for the client than the one the user declares, it was possible for transitive dependencies like Netty to have different versions.

The solution is to always use _single_ dependency graphs for the runtime/build/native image/... classpaths. Then Gradle will properly perform dependency conflict resolution as expected, and we won't get any duplicate.

In addition, we changed how the `nativeRun` (and `nativeCompile`) task interact with test resources: the previous implementation didn't properly detect if the client should be injected or not.