### PR TITLE
Add an option to not automatically add BOM

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
@@ -25,6 +25,8 @@ public abstract class MicronautExtension implements ExtensionAware {
     private final Property<MicronautRuntime> runtime;
     private final Property<MicronautTestRuntime> testRuntime;
 
+    public abstract Property<Boolean> getImportMicronautPlatform();
+
     @Inject
     public MicronautExtension(ObjectFactory objectFactory) {
         this.processing = objectFactory.newInstance(AnnotationProcessing.class);
@@ -35,6 +37,7 @@ public abstract class MicronautExtension implements ExtensionAware {
                                     .convention(MicronautRuntime.NONE);
         this.testRuntime = objectFactory.property(MicronautTestRuntime.class)
                                         .convention(MicronautTestRuntime.NONE);
+        getImportMicronautPlatform().convention(true);
     }
 
     /**

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
@@ -25,6 +25,13 @@ public abstract class MicronautExtension implements ExtensionAware {
     private final Property<MicronautRuntime> runtime;
     private final Property<MicronautTestRuntime> testRuntime;
 
+    /**
+     * If set to false, then the Micronaut Gradle plugins will not automatically
+     * add the Micronaut Platform BOM to your dependencies. It becomes your
+     * responsibility to add it directly, or to provide explicit versions for
+     * Micronaut modules.
+     * @return the import platform flag. Defaults to true.
+     */
     public abstract Property<Boolean> getImportMicronautPlatform();
 
     @Inject

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
-import static io.micronaut.gradle.MicronautComponentPlugin.resolveMicronautPlatform;
+import static io.micronaut.gradle.PluginsHelper.resolveMicronautPlatform;
 import static io.micronaut.gradle.PluginsHelper.configureAnnotationProcessors;
 
 /**

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -312,6 +312,10 @@ Complete example with the default settings:
 ----
 micronaut {
     version "{micronaut-version}"
+    // If set to false, then the `io.micronaut.platform:micronaut-platform` BOM
+    // will not be automatically applied, and you will have to add it yourself
+    // to your dependencies, or specify versions of Micronaut modules explicitly
+    importMicronautPlatform = true
     processing {
         // Sets whether incremental annotation processing is enabled
         incremental true
@@ -340,7 +344,11 @@ micronaut {
 ----
 micronaut {
     version.set("{micronaut-version}")
-    processing {
+    // If set to false, then the `io.micronaut.platform:micronaut-platform` BOM
+    // will not be automatically applied, and you will have to add it yourself
+    // to your dependencies, or specify versions of Micronaut modules explicitly
+   importMicronautPlatform.set(true)
+   processing {
         // Sets whether incremental annotation processing is enabled
         incremental.set(true)
         // Sets the module name.

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesConsumerPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesConsumerPlugin.java
@@ -23,13 +23,11 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.plugins.PluginManager;
 
 import static io.micronaut.gradle.MicronautComponentPlugin.MICRONAUT_BOMS_CONFIGURATION;
-import static io.micronaut.gradle.MicronautComponentPlugin.resolveMicronautPlatform;
 
 /**
  * A lightweight test resources plugin, which requires
@@ -52,10 +50,7 @@ public class MicronautTestResourcesConsumerPlugin implements Plugin<Project> {
     private Configuration createTestResourcesExtension(Project project) {
         ConfigurationContainer configurations = project.getConfigurations();
         Configuration boms = configurations.findByName(MICRONAUT_BOMS_CONFIGURATION);
-        DependencyHandler dependencyHandler = project.getDependencies();
-        dependencyHandler.addProvider(MICRONAUT_BOMS_CONFIGURATION, PluginsHelper.findMicronautVersion(project).map(micronautVersion ->
-                resolveMicronautPlatform(dependencyHandler, micronautVersion)
-        ));
+        PluginsHelper.maybeAddMicronautPlaformBom(project, boms);
         return project.getConfigurations().create(MicronautTestResourcesPlugin.TESTRESOURCES_CONFIGURATION, conf -> {
             conf.extendsFrom(boms);
             conf.setCanBeConsumed(false);

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -64,7 +64,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.micronaut.gradle.MicronautComponentPlugin.MICRONAUT_BOMS_CONFIGURATION;
-import static io.micronaut.gradle.MicronautComponentPlugin.resolveMicronautPlatform;
 import static java.util.stream.Stream.concat;
 
 /**
@@ -273,11 +272,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
         MicronautExtension micronautExtension = PluginsHelper.findMicronautExtension(project);
         TestResourcesConfiguration testResources = micronautExtension.getExtensions().create("testResources", TestResourcesConfiguration.class);
         ProviderFactory providers = project.getProviders();
-        testResources.getEnabled().convention(
-                micronautExtension.getVersion()
-                        .orElse(providers.gradleProperty("micronautVersion"))
-                        .map(MicronautTestResourcesPlugin::isAtLeastMicronaut3dot5)
-        );
+        testResources.getEnabled().convention(true);
         testResources.getVersion().convention(VersionInfo.getVersion());
         testResources.getExplicitPort().convention(explicitPort);
         testResources.getInferClasspath().convention(true);
@@ -401,10 +396,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
     private static Configuration createTestResourcesServerConfiguration(Project project) {
         ConfigurationContainer configurations = project.getConfigurations();
         Configuration boms = configurations.findByName(MICRONAUT_BOMS_CONFIGURATION);
-        DependencyHandler dependencyHandler = project.getDependencies();
-        dependencyHandler.addProvider(MICRONAUT_BOMS_CONFIGURATION, PluginsHelper.findMicronautVersion(project).map(micronautVersion ->
-                resolveMicronautPlatform(dependencyHandler, micronautVersion)
-        ));
+        PluginsHelper.maybeAddMicronautPlaformBom(project, boms);
         return configurations.create(TESTRESOURCES_CONFIGURATION, conf -> {
             conf.extendsFrom(boms);
             conf.setDescription("Dependencies for the Micronaut test resources service");


### PR DESCRIPTION
This option has (at least) a couple use cases:

1. the issue described in #681, when a user wants to drive the Micronaut version from a catalog, or directly in their dependencies (although this is probably redundant with #694)

2. we use the Gradle plugins in our module builds, where it's going to look for the platform BOM, which is not necessarily what we want, since we want to use local versions of projects and possibly override transitive versions

Closes #681