### PR TITLE
build: Micronaut Build Quality checks plugin to 5.4.9

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,5 +12,5 @@ dependencies {
     implementation 'org.asciidoctor:asciidoctor-gradle-jvm:3.3.2'
     implementation 'com.gradle.publish:plugin-publish-plugin:1.1.0'
     implementation 'gradle.plugin.pl.droidsonroids.gradle.jacoco:jacoco-gradle-testkit-plugin:1.0.9'
-    implementation 'io.micronaut.build.internal.quality-checks:io.micronaut.build.internal.quality-checks.gradle.plugin:5.3.14'
+    implementation 'io.micronaut.build.internal.quality-checks:io.micronaut.build.internal.quality-checks.gradle.plugin:5.4.9'
 }


### PR DESCRIPTION
3.7.9 release failed https://github.com/micronaut-projects/micronaut-gradle-plugin/actions/runs/4829605123/jobs/8604838345

I guess this may be the culprit