### PR TITLE
graalvm native-image docker replace ol7 with ol8

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -373,7 +373,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
     }
 
     private static String toGraalVMBaseImageName(String graalVersion, String jdkVersion) {
-        return "ghcr.io/graalvm/native-image:ol7-" + jdkVersion + '-' + graalVersion;
+        return "ghcr.io/graalvm/native-image:ol8-" + jdkVersion + '-' + graalVersion;
     }
 
     private static int toSupportedJavaVersion(int version) {

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -76,7 +76,7 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
         result.tasks.stream().noneMatch { it.path == ":nativeCompile" }
 
         def dockerFile = normalizeLineEndings(file("build/docker/native-optimized/DockerfileNative").text)
-        dockerFile == """FROM ghcr.io/graalvm/native-image:ol7-java17-22.3.2 AS graalvm
+        dockerFile == """FROM ghcr.io/graalvm/native-image:ol8-java17-22.3.2 AS graalvm
 WORKDIR /home/app
 COPY layers/libs /home/app/libs
 COPY layers/classes /home/app/classes

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -96,9 +96,9 @@ micronaut:
 
         where:
         runtime  | nativeImage
-        "netty"  | 'FROM ghcr.io/graalvm/native-image:ol7-java'
+        "netty"  | 'FROM ghcr.io/graalvm/native-image:ol8-java'
         "lambda" | 'FROM amazonlinux:2 AS graalvm'
-        "jetty"  | 'FROM ghcr.io/graalvm/native-image:ol7-java'
+        "jetty"  | 'FROM ghcr.io/graalvm/native-image:ol8-java'
     }
 
     void 'build mostly static native images when using distroless docker image for runtime=#runtime'() {
@@ -494,9 +494,9 @@ class Application {
 
         where:
         runtime  | nativeImage
-        "netty"  | 'FROM ghcr.io/graalvm/native-image:ol7-java'
+        "netty"  | 'FROM ghcr.io/graalvm/native-image:ol8-java'
         "lambda" | 'FROM amazonlinux:2 AS graalvm'
-        "jetty"  | 'FROM ghcr.io/graalvm/native-image:ol7-java'
+        "jetty"  | 'FROM ghcr.io/graalvm/native-image:ol8-java'
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/402")
@@ -575,7 +575,7 @@ micronaut:
         expect:
         task.outcome == TaskOutcome.SUCCESS
         dockerFile == """
-FROM ghcr.io/graalvm/native-image:ol7-java17-22.3.2 AS graalvm
+FROM ghcr.io/graalvm/native-image:ol8-java17-22.3.2 AS graalvm
 WORKDIR /home/alternate
 COPY layers/libs /home/alternate/libs
 COPY layers/classes /home/alternate/classes
@@ -693,7 +693,7 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
 
         then:
         def dockerfileNative = new File(testProjectDir.root, 'build/docker/native-main/DockerfileNative').text
-        dockerfileNative == """FROM ghcr.io/graalvm/native-image:ol7-java17-22.3.2 AS graalvm
+        dockerfileNative == """FROM ghcr.io/graalvm/native-image:ol8-java17-22.3.2 AS graalvm
 WORKDIR /home/app
 COPY layers/libs /home/app/libs
 COPY server.iprof /home/app/server.iprof


### PR DESCRIPTION
Should we use `ol7` instead of `ol8` ? see:
https://github.com/micronaut-projects/micronaut-starter/pull/1807