### PR TITLE
Remove snapshot repos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,9 @@ plugins {
 repositories {
     mavenCentral()
     gradlePluginPortal()
-    maven {
-        url "https://s01.oss.sonatype.org/content/repositories/snapshots"
-    }
+//    maven {
+//        url "https://s01.oss.sonatype.org/content/repositories/snapshots"
+//    }
 }
 
 dependencies {

--- a/buildSrc/src/main/groovy/io.micronaut.internal.build.gradle-plugin.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.internal.build.gradle-plugin.gradle
@@ -14,7 +14,7 @@ pluginManager.apply(io.micronaut.build.MicronautQualityChecksParticipantPlugin)
 repositories {
     mavenCentral()
     gradlePluginPortal()
-    maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/") }
+//    maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/") }
 }
 
 project.extensions.create("micronautPlugins", MicronautPluginExtension, gradlePlugin)

--- a/minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
+++ b/minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
@@ -30,7 +30,7 @@ abstract class AbstractGradleBuildSpec extends Specification {
         return false
     }
 
-    boolean allowSnapshots = true
+    boolean allowSnapshots = false
     // This flag is only for local tests, do not push with this flag set to true
     boolean allowMavenLocal = false
 


### PR DESCRIPTION
Now that we have milestones for everything, snapshots are no longer required. Kept as comments for the next major changes.