### PR TITLE
Fix test resources version check

### DIFF
--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -354,8 +354,13 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
         }
     }
 
-    private static ArrayList<Integer> parseVersion(String testedVersion) {
-        return Arrays.stream(testedVersion.split("\\."))
+    static ArrayList<Integer> parseVersion(String testedVersion) {
+        String version = testedVersion;
+        var index = version.indexOf("-");
+        if (index > 0) {
+            version = version.substring(0, index);
+        }
+        return Arrays.stream(version.split("\\."))
                 .map(String::trim)
                 .map(s -> s.replaceAll("[^0-9]", ""))
                 .map(Integer::parseInt)

--- a/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/MicronautTestResourcesPluginTest.groovy
+++ b/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/MicronautTestResourcesPluginTest.groovy
@@ -1,0 +1,17 @@
+package io.micronaut.gradle.testresources
+
+import spock.lang.Specification
+
+class MicronautTestResourcesPluginTest extends Specification {
+    def "ignores appendix when testing versions"() {
+        expect:
+        MicronautTestResourcesPlugin.parseVersion(version) == expected
+
+        where:
+        version        | expected
+        '1.0'          | [1, 0]
+        '1.1.0'        | [1, 1, 0]
+        '1.1-SNAPSHOT' | [1, 1]
+        '1.1-M3'       | [1, 1]
+    }
+}


### PR DESCRIPTION
It wasn't possible to replace `2.0.0-M3` with another version because we parsed it as [2,0,3] instead, so `2.0.1` was typically considered lower.