### PR TITLE
Use an automatic dependency for graal

### DIFF
--- a/functional-tests/src/test/groovy/io/micronaut/gradle/graalvm/MicronautGraalPluginSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/graalvm/MicronautGraalPluginSpec.groovy
@@ -54,6 +54,7 @@ class MicronautGraalPluginSpec extends AbstractEagerConfiguringFunctionalTest {
     void 'native-image is called with the generated JSON file directory (Micronaut Application)'() {
         given:
         withSwaggerMicronautApplication()
+        withNativeImageDryRun()
 
         when:
         def result = build('nativeCompile', '-i', '--stacktrace')
@@ -76,6 +77,7 @@ class MicronautGraalPluginSpec extends AbstractEagerConfiguringFunctionalTest {
     void 'native-image is called with the generated JSON file directory (regular Application)'() {
         given:
         withSwaggerApplication()
+        withNativeImageDryRun()
 
         when:
         def result = build('nativeCompile', '-i', '--stacktrace')

--- a/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -3,6 +3,7 @@ package io.micronaut.gradle.graalvm;
 import io.micronaut.gradle.MicronautExtension;
 import io.micronaut.gradle.MicronautRuntime;
 import io.micronaut.gradle.PluginsHelper;
+import io.micronaut.gradle.internal.AutomaticDependency;
 import org.graalvm.buildtools.gradle.NativeImagePlugin;
 import org.graalvm.buildtools.gradle.dsl.GraalVMExtension;
 import org.graalvm.buildtools.gradle.dsl.GraalVMReachabilityMetadataRepositoryExtension;
@@ -24,7 +25,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+
+import static io.micronaut.gradle.PluginsHelper.CORE_VERSION_PROPERTY;
 
 /**
  * Support for building GraalVM native images.
@@ -127,10 +131,9 @@ public class MicronautGraalPlugin implements Plugin<Project> {
 
     private static void addGraalVMAnnotationProcessorDependency(Project project, Iterable<SourceSet> sourceSets) {
         for (SourceSet sourceSet : sourceSets) {
-            project.getDependencies().add(
-                    sourceSet.getAnnotationProcessorConfigurationName(),
-                    "io.micronaut:micronaut-graal"
-            );
+            new AutomaticDependency(sourceSet.getAnnotationProcessorConfigurationName(),
+                    "io.micronaut:micronaut-graal",
+                    Optional.of(CORE_VERSION_PROPERTY)).applyTo(project);
         }
     }
 

--- a/graalvm-plugin/src/test/groovy/io/micronaut/gradle/NativeImageTaskSpec.groovy
+++ b/graalvm-plugin/src/test/groovy/io/micronaut/gradle/NativeImageTaskSpec.groovy
@@ -29,6 +29,8 @@ class NativeImageTaskSpec extends AbstractGradleBuildSpec {
             mainClassName="example.Application"
             
         """
+        withNativeImageDryRun()
+
         testProjectDir.newFolder("src", "main", "java", "example")
         def javaFile = testProjectDir.newFile("src/main/java/example/Application.java")
         javaFile.parentFile.mkdirs()
@@ -82,6 +84,7 @@ class Application {
                 }
             }            
         """
+        withNativeImageDryRun()
         testProjectDir.newFolder("src", "main", "java", "example")
         def javaFile = testProjectDir.newFile("src/main/java/example/Application.java")
         javaFile.parentFile.mkdirs()
@@ -103,7 +106,6 @@ class Application {
         def task = result.task(":nativeCompile")
         then:
         result.output.contains("Native Image written to")
-        result.output.contains("Generating 'basic-app'")
         argFileContentsOf(result).contains('-Dfoo=bar')
         task.outcome == TaskOutcome.SUCCESS
     }

--- a/minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
+++ b/minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
@@ -144,6 +144,14 @@ abstract class AbstractGradleBuildSpec extends Specification {
         }
     }
 
+    void withNativeImageDryRun() {
+        buildFile << """
+            graalvmNative.binaries.all {
+                buildArgs.add("--dry-run")
+            }
+        """
+    }
+
     private void prepareBuild() {
         if (postSettingsStatements) {
             postSettingsStatements.each {


### PR DESCRIPTION
This commit changes how the `micronaut-graal` dependency is added in order to use the `AutomaticDependency` mechanism. This makes it possible to override the version of the Micronaut Graal dependency by changing the `coreVersion` in the DSL.