### PR TITLE
Add Official CRaC JDK support to the Gradle Plugin.

### DIFF
--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCConfiguration.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCConfiguration.java
@@ -3,6 +3,7 @@ package io.micronaut.gradle.crac;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -22,9 +23,24 @@ public interface CRaCConfiguration {
     Property<String> getBaseImage();
 
     /**
+     * The architecture to use for building the CRaC enabled images. Defaults to the current architecture.
+     * Currently only {@value MicronautCRaCPlugin#X86_64_ARCH} and {@value MicronautCRaCPlugin#ARM_ARCH} are supported.
+     * @return the architecture
+     */
+    Property<String> getArch();
+
+    /**
+     * The java version to use for building the CRaC enabled images. Currently only '17' is supported.
+     * @return the java version
+     */
+    Property<String> getJavaVersion();
+
+    /**
      * The platform to specify in the FROM instruction defaults to {@value MicronautCRaCPlugin#CRAC_DEFAULT_BASE_IMAGE_PLATFORM}.
      * @return the platform (can be removed with {@code platform.convention(null)} in the {@link CRaCConfiguration} extension)
+     * @deprecated use {@link #getArch()} instead
      */
+    @Deprecated
     Property<String> getPlatform();
 
     /**

--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
@@ -17,6 +17,7 @@ import io.micronaut.gradle.docker.DockerBuildStrategy;
 import io.micronaut.gradle.docker.model.MicronautDockerImage;
 import io.micronaut.gradle.docker.tasks.BuildLayersTask;
 import org.gradle.api.GradleException;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -39,6 +40,8 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
 
     public static final String CRAC_DEFAULT_BASE_IMAGE = "ubuntu:22.04";
     public static final String CRAC_DEFAULT_BASE_IMAGE_PLATFORM = "linux/amd64";
+    public static final String ARM_ARCH = "aarch64";
+    public static final String X86_64_ARCH = "amd64";
     public static final String CRAC_DEFAULT_READINESS_COMMAND = "curl --output /dev/null --silent --head http://localhost:8080";
     private static final String CRAC_TASK_GROUP = "CRaC";
     public static final String BUILD_DOCKER_DIRECTORY = "docker/";
@@ -63,8 +66,15 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
         CRaCConfiguration crac = micronautExtension.getExtensions().create("crac", CRaCConfiguration.class);
         crac.getEnabled().convention(true);
         crac.getBaseImage().convention(CRAC_DEFAULT_BASE_IMAGE);
-        crac.getPlatform().convention(CRAC_DEFAULT_BASE_IMAGE_PLATFORM);
         crac.getPreCheckpointReadinessCommand().convention(CRAC_DEFAULT_READINESS_COMMAND);
+
+        // Default to current architecture
+        String osArch = System.getProperty("os.arch");
+        crac.getArch().convention(ARM_ARCH.equals(osArch) ? ARM_ARCH : X86_64_ARCH);
+
+        // Default to Java 17
+        crac.getJavaVersion().convention(JavaVersion.VERSION_17.getMajorVersion());
+
         return crac;
     }
 
@@ -133,6 +143,8 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
             task.getDestFile().set(targetCheckpointDockerFile);
             task.getBaseImage().set(configuration.getBaseImage());
             task.getPlatform().set(configuration.getPlatform());
+            task.getArch().set(configuration.getArch());
+            task.getJavaVersion().set(configuration.getJavaVersion());
             task.setupDockerfileInstructions();
         });
 

--- a/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/BaseCracGradleBuildSpec.groovy
+++ b/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/BaseCracGradleBuildSpec.groovy
@@ -48,7 +48,7 @@ abstract class BaseCracGradleBuildSpec extends AbstractGradleBuildSpec {
                 id "io.micronaut.crac"
                 id "io.micronaut.minimal.application"
                 id "io.micronaut.docker"
-            }"""
+            }""".stripIndent()
     }
 
     String getRepositoriesBlock(boolean allowSnapshots = true) {
@@ -59,7 +59,7 @@ abstract class BaseCracGradleBuildSpec extends AbstractGradleBuildSpec {
             }""".stripIndent()
     }
 
-    String getDependenciesBlock(String cracVersion = '1.0.0-SNAPSHOT') {
+    String getDependenciesBlock(String cracVersion = '1.2.3') {
         """
             dependencies {
                 implementation("io.micronaut.crac:micronaut-crac:$cracVersion")

--- a/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracBuildTaskSpec.groovy
+++ b/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracBuildTaskSpec.groovy
@@ -4,6 +4,7 @@ import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.IgnoreIf
 
 @IgnoreIf({ os.windows })
+@IgnoreIf(value = { os.macOs && System.properties['os.arch'] == 'aarch64' }, reason = "Java 11 compatible Docker not supported on OSX M1 architecture")
 class CracBuildTaskSpec extends BaseCracGradleBuildSpec {
 
     def "test build docker image when #desc"() {

--- a/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
+++ b/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
@@ -87,31 +87,14 @@ class CracCustomizationSpec extends BaseCracGradleBuildSpec {
 
         then:
         result.output.contains("BUILD SUCCESSFUL")
-        fileTextContents("build/docker/main/Dockerfile").readLines().head() == "FROM --platform=linux/amd64 $MicronautCRaCPlugin.CRAC_DEFAULT_BASE_IMAGE"
-        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").readLines().head() == "FROM --platform=linux/amd64 $MicronautCRaCPlugin.CRAC_DEFAULT_BASE_IMAGE"
+        fileTextContents("build/docker/main/Dockerfile").readLines().head() == "FROM $MicronautCRaCPlugin.CRAC_DEFAULT_BASE_IMAGE"
+        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").readLines().head() == "FROM $MicronautCRaCPlugin.CRAC_DEFAULT_BASE_IMAGE"
     }
 
     void "base image is customizable"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"
         buildFile << getBuildFileBlockWithMicronautConfig(getMicronautConfigBlock("""crac {
-    baseImage.set("timyates:latest")
-}"""))
-
-        when:
-        def result = build('dockerfileCrac', 'checkpointDockerfile', '-s')
-
-        then:
-        result.output.contains("BUILD SUCCESSFUL")
-        fileTextContents("build/docker/main/Dockerfile").readLines().head() == "FROM --platform=linux/amd64 timyates:latest"
-        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").readLines().head() == "FROM --platform=linux/amd64 timyates:latest"
-    }
-
-    void "platform can be removed"() {
-        given:
-        settingsFile << "rootProject.name = 'hello-world'"
-        buildFile << getBuildFileBlockWithMicronautConfig(getMicronautConfigBlock("""crac {
-    platform.convention(null)
     baseImage.set("timyates:latest")
 }"""))
 
@@ -139,6 +122,38 @@ class CracCustomizationSpec extends BaseCracGradleBuildSpec {
         result.output.contains("BUILD SUCCESSFUL")
         fileTextContents("build/docker/main/Dockerfile").readLines().head() == "FROM --platform=raspberry-pi/arm64 timyates:latest"
         fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").readLines().head() == "FROM --platform=raspberry-pi/arm64 timyates:latest"
+    }
+
+    void "Arch defaults to OS arch, and java version defaults to 17"() {
+        given:
+        def javaVersion = "17"
+        def expectedArch = System.properties['os.arch'] == MicronautCRaCPlugin.ARM_ARCH ? MicronautCRaCPlugin.ARM_ARCH : MicronautCRaCPlugin.X86_64_ARCH
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << getBuildFileBlockWithMicronautConfig(getMicronautConfigBlock())
+
+        when:
+        def result = build('dockerfileCrac', 'checkpointDockerfile', '-s')
+
+        then:
+        result.output.contains("BUILD SUCCESSFUL")
+        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains("https://api.azul.com/metadata/v1/zulu/packages/?java_version=$javaVersion&arch=$expectedArch&crac_supported=true&latest=true&release_status=ga&certifications=tck&page=1&page_size=100")
+    }
+
+    void "Azul CRaC JDK and arch can be changed"() {
+        given:
+        def javaVersion = "21"
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << getBuildFileBlockWithMicronautConfig(getMicronautConfigBlock("""crac {
+    javaVersion.set("$javaVersion")
+    arch.set('$MicronautCRaCPlugin.ARM_ARCH')
+}"""))
+
+        when:
+        def result = build('dockerfileCrac', 'checkpointDockerfile', '-s')
+
+        then:
+        result.output.contains("BUILD SUCCESSFUL")
+        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains("https://api.azul.com/metadata/v1/zulu/packages/?java_version=$javaVersion&arch=$MicronautCRaCPlugin.ARM_ARCH&crac_supported=true&latest=true&release_status=ga&certifications=tck&page=1&page_size=100")
     }
 
     void "dockerfiles can be customized"() {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1625,8 +1625,15 @@ micronaut {
         // the base docker image to use for the Checkpoint and final images
         baseImage = "ubuntu:22.04"
 
-        // The platform to build the image for (currently must be linux/amd64)
+        // The platform to use pulling the base image. Defaults to none specified. Deprecated, use arch instead.
         platform = "linux/amd64"
+
+        // The architecture of the CRaC JDK to use. Defaults to the architecture of the machine.
+        // (currently only 'aarch64' or 'amd64' are supported)
+        arch = "aarch64"
+
+        // The version of the Azul CRaC JDK to use in the image (currently only 17 is supported)
+        javaVersion = "17"
 
         // A command to run that will be successful when the application is ready to be checkpointed.
         preCheckpointReadinessCheck = "curl --output /dev/null --silent --head http://localhost:8080"
@@ -1653,8 +1660,15 @@ micronaut {
         // the base docker image to use for the Checkpoint and final images
         baseImage.set("ubuntu:22.04")
 
-        // The platform to build the image for (currently must be linux/amd64)
+        // The platform to build the image for (currently must be linux/amd64). Deprecated, use arch instead.
         platform.set("linux/amd64")
+
+        // The architecture of the CRaC JDK to use. Defaults to the architecture of the machine.
+        // (currently only 'aarch64' or 'amd64' are supported)
+        arch.set("aarch64")
+
+        // The version of the Azul CRaC JDK to use in the image (currently only 17 is supported)
+        javaVersion.set("17")
 
         // A command to run that will be successful when the application is ready to be checkpointed.
         preCheckpointReadinessCheck.set("curl --output /dev/null --silent --head http://localhost:8080")


### PR DESCRIPTION
Azul has officially released their CRaC JDK.

This PR switches to find and download the official JDK when building with `dockerBuildCrac`.

They have also silently released the ARM version of the CRaC enabled JDK.

This PR also adds support for this, using the current system architecture as the default.

New configuration has been added to allow changing from the defaults.

The old "platform" configuration has been deprecated for removal in 4.0.0.