### PR TITLE
Use `src/main/java` subdirectory for source directory

### DIFF
--- a/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiClientGeneratorSpec.groovy
+++ b/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiClientGeneratorSpec.groovy
@@ -42,7 +42,7 @@ class OpenApiClientGeneratorSpec extends AbstractOpenApiGeneratorSpec {
         result.task(":compileJava").outcome == TaskOutcome.SUCCESS
 
         and:
-        file("build/generated/openapi/client/src/main/java/io/micronaut/openapi/model/Pet.java").exists()
+        file("build/generated/openapi/generateClientOpenApiModels/src/main/java/io/micronaut/openapi/model/Pet.java").exists()
 
     }
 

--- a/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiServerGeneratorSpec.groovy
+++ b/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiServerGeneratorSpec.groovy
@@ -45,8 +45,8 @@ class OpenApiServerGeneratorSpec extends AbstractOpenApiGeneratorSpec {
         result.task(":compileJava").outcome == TaskOutcome.SUCCESS
 
         and:
-        file("build/generated/openapi/server/src/main/java/io/micronaut/openapi/api/PetApi.java").exists()
-        file("build/generated/openapi/server/src/main/java/io/micronaut/openapi/model/Pet.java").exists()
+        file("build/generated/openapi/generateServerOpenApiApis/src/main/java/io/micronaut/openapi/api/PetApi.java").exists()
+        file("build/generated/openapi/generateServerOpenApiModels/src/main/java/io/micronaut/openapi/model/Pet.java").exists()
         file("build/classes/java/main/io/micronaut/openapi/api/PetApi.class").exists()
         file("build/classes/java/main/io/micronaut/openapi/model/Pet.class").exists()
 


### PR DESCRIPTION
While the previous implementation worked, it had a couple issues:

- we were generating the api and models in the same directory, although it was distinct classes, which breaks caching/up-to-date checking
- it compiles fine, but the IDE doesn't find the sources properly