### PR TITLE
Improve the openapi generator plugin

### DIFF
--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/DefaultOpenApiExtension.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/DefaultOpenApiExtension.java
@@ -137,6 +137,7 @@ public abstract class DefaultOpenApiExtension implements OpenApiExtension {
         task.getAlwaysUseGenerateHttpResponse().convention(openApiSpec.getAlwaysUseGenerateHttpResponse());
         task.getGenerateHttpResponseWhereRequired().convention(openApiSpec.getGenerateHttpResponseWhereRequired());
         task.getDateTimeFormat().convention(openApiSpec.getDateTimeFormat());
+        task.getParameterMappings().convention(openApiSpec.getParameterMappings());
         task.getResponseBodyMappings().convention(openApiSpec.getResponseBodyMappings());
     }
 

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiSpec.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiSpec.java
@@ -39,5 +39,7 @@ public interface OpenApiSpec {
 
     Property<String> getDateTimeFormat();
 
+    ListProperty<ParameterMappingModel> getParameterMappings();
+
     ListProperty<ResponseBodyMappingModel> getResponseBodyMappings();
 }

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/ParameterMappingModel.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/ParameterMappingModel.java
@@ -49,12 +49,12 @@ public final class ParameterMappingModel implements Serializable {
      * The unique name of the parameter to be used as method parameter name.
      * By default, a name deduced from the parameter type will be used.
      */
-    private String mappedName;
+    private final String mappedName;
 
     /**
      * Whether the mapped parameter requires validation.
      */
-    private boolean isValidated;
+    private final boolean isValidated;
 
     /**
      * Create a prameter mapping
@@ -68,31 +68,66 @@ public final class ParameterMappingModel implements Serializable {
      *                   the package name if required.
      */
     public ParameterMappingModel(String name, ParameterLocation location, String mappedType) {
+        this(name, location, mappedType, null, false);
+    }
+
+    private ParameterMappingModel(String name, ParameterLocation location, String mappedType, String mappedName, boolean isValidated) {
         this.name = name;
         this.location = location;
         this.mappedType = mappedType;
+        this.mappedName = mappedName;
+        this.isValidated = isValidated;
+    }
+
+    /**
+     * Specify the name of the parameter to trigger the mapping.
+     * The name should correspond to a field name in the OpenAPI specification.
+     *
+     * @param name the name
+     * @return new instance with the updated name
+     */
+    public ParameterMappingModel withName(String name) {
+        return new ParameterMappingModel(name, location, mappedType, mappedName, isValidated);
+    }
+
+    /**
+     * Specify the location of the parameter that triggers the mapping.
+     *
+     * @param location the name
+     * @return new instance with the updated location
+     */
+    public ParameterMappingModel withLocation(ParameterLocation location) {
+        return new ParameterMappingModel(name, location, mappedType, mappedName, isValidated);
+    }
+
+    /**
+     * Specify the fully-qualified type to which the parameter will be mapped .
+     *
+     * @param mappedType the type
+     * @return new instance with the updated mapped type
+     */
+    public ParameterMappingModel withMappedType(String mappedType) {
+        return new ParameterMappingModel(name, location, mappedType, mappedName, isValidated);
     }
 
     /**
      * Specify the unique name of the parameter to be used as method parameter name.
      *
      * @param mappedName the name
-     * @return this instance
+     * @return new instance with the name specified
      */
     public ParameterMappingModel withMappedName(String mappedName) {
-        this.mappedName = mappedName;
-        return this;
+        return new ParameterMappingModel(name, location, mappedType, mappedName, isValidated);
     }
 
     /**
      * Specify whether the parameter requires validation.
      *
      * @param isValidated the value
-     * @return this instance
+     * @return new instance with the validation requirement specified
      */
     public ParameterMappingModel withValidated(boolean isValidated) {
-        this.isValidated = isValidated;
-        return this;
+        return new ParameterMappingModel(name, location, mappedType, mappedName, isValidated);
     }
 
     public String getName() {

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/ParameterMappingModel.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/ParameterMappingModel.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle.openapi;
+
+import java.io.Serializable;
+
+/**
+ * A model that can be used to specify parameter mappings during the OpenAPI gneration
+ *
+ * <p>An equivalent to Micronaut OpenAPI's ParameterMapping but
+ * without using classes from that dependency so that we can isolate
+ * execution in workers.</p>
+ */
+public final class ParameterMappingModel implements Serializable {
+
+    /**
+     * The name of the parameter as described by the name field in specification.
+     */
+    private final String name;
+
+    /**
+     * The location of parameter. Path parameters cannot be mapped, as this
+     * behavior should not be used.
+     */
+    private final ParameterLocation location;
+
+    /**
+     * The type to which the parameter should be mapped. If multiple parameters
+     * have the same mapping, only one parameter will be present. If set to null,
+     * the original parameter will simply be deleted. The type should contain
+     * the package name if required.
+     */
+    private final String mappedType;
+
+    /**
+     * The unique name of the parameter to be used as method parameter name.
+     * By default, a name deduced from the parameter type will be used.
+     */
+    private String mappedName;
+
+    /**
+     * Whether the mapped parameter requires validation.
+     */
+    private boolean isValidated;
+
+    /**
+     * Create a prameter mapping
+     *
+     * @param name The name of the parameter as described by the name field in specification.
+     * @param location The location of parameter. Path parameters cannot be mapped, as this
+     *                 behavior should not be used.
+     * @param mappedType The type to which the parameter should be mapped. If multiple parameters
+     *                   have the same mapping, only one parameter will be present. If set to null,
+     *                   the original parameter will simply be deleted. The type should contain
+     *                   the package name if required.
+     */
+    public ParameterMappingModel(String name, ParameterLocation location, String mappedType) {
+        this.name = name;
+        this.location = location;
+        this.mappedType = mappedType;
+    }
+
+    /**
+     * Specify the unique name of the parameter to be used as method parameter name.
+     *
+     * @param mappedName the name
+     * @return this instance
+     */
+    public ParameterMappingModel withMappedName(String mappedName) {
+        this.mappedName = mappedName;
+        return this;
+    }
+
+    /**
+     * Specify whether the parameter requires validation.
+     *
+     * @param isValidated the value
+     * @return this instance
+     */
+    public ParameterMappingModel withValidated(boolean isValidated) {
+        this.isValidated = isValidated;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ParameterLocation getLocation() {
+        return location;
+    }
+
+    public String getMappedType() {
+        return mappedType;
+    }
+
+    public String getMappedName() {
+        return mappedName;
+    }
+
+    public boolean isValidated() {
+        return isValidated;
+    }
+
+    /**
+     * Enum used to describe the location of a parameter.
+     */
+    public enum ParameterLocation {
+        HEADER,
+        QUERY,
+        FORM,
+        COOKIE,
+        BODY
+    }
+
+}

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/ResponseBodyMappingModel.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/ResponseBodyMappingModel.java
@@ -15,17 +15,88 @@
  */
 package io.micronaut.gradle.openapi;
 
+import java.io.Serializable;
+
 /**
- * An equivalent to Micronaut OpenAPI's ResponseBodyMapping but
+ * A model that can be used to specify body mappings during OpenAPI generation.
+ *
+ * <p>An equivalent to Micronaut OpenAPI's ResponseBodyMapping but
  * without using classes from that dependency so that we can isolate
- * execution in workers.
- * @param headerName the header name
- * @param mappedBodyType the mapped body type
- * @param isListWrapper if it's a list wrapper
- * @param isValidated if it's validated
+ * execution in workers.</p>
  */
-public record ResponseBodyMappingModel(String headerName,
-                                       String mappedBodyType,
-                                       boolean isListWrapper,
-                                       boolean isValidated) {
+public final class ResponseBodyMappingModel implements Serializable {
+
+    /**
+     * The response header name that triggers the change of response type.
+     */
+    private final String headerName;
+
+    /**
+     * The type in which will be used as the response type. The type must take
+     * a single type parameter, which will be the original body.
+     */
+    private final String mappedBodyType;
+
+    /**
+     * Whether the mapped body type needs to be supplied list items as property.
+     */
+    boolean isListWrapper;
+
+    /**
+     * Whether the mapped response body type required validation.
+     */
+    boolean isValidated;
+
+    /**
+     * Create a response body mapping.
+     *
+     * @param headerName The response header name that triggers the change of response type.
+     * @param mappedBodyType The type in which will be used as the response type. The type must take
+     *                       a single type parameter, which will be the original body. If the value is null,
+     *                       the header will be removed and body not changed.
+     */
+    public ResponseBodyMappingModel(String headerName, String mappedBodyType) {
+        this.headerName = headerName;
+        this.mappedBodyType = mappedBodyType;
+    }
+
+    /**
+     * Specify whether the mapped body is a list wrapper.
+     * Then the mapped body type needs to be supplied list items as property
+     *
+     * @param isListWrapper whether it is a list wrapper
+     * @return this instance
+     */
+    public ResponseBodyMappingModel withListWrapper(boolean isListWrapper) {
+        this.isListWrapper = isListWrapper;
+        return this;
+    }
+
+    /**
+     * Specify whether the mapped response body type required validation.
+     *
+     * @param isValidated whether it should be validated
+     * @return this instance
+     */
+    public ResponseBodyMappingModel withValidated(boolean isValidated) {
+        this.isValidated = isValidated;
+        return this;
+    }
+
+    public String getHeaderName() {
+        return headerName;
+    }
+
+    public String getMappedBodyType() {
+        return mappedBodyType;
+    }
+
+    public boolean isListWrapper() {
+        return isListWrapper;
+    }
+
+    public boolean isValidated() {
+        return isValidated;
+    }
+
 }

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/ResponseBodyMappingModel.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/ResponseBodyMappingModel.java
@@ -40,12 +40,12 @@ public final class ResponseBodyMappingModel implements Serializable {
     /**
      * Whether the mapped body type needs to be supplied list items as property.
      */
-    boolean isListWrapper;
+    private final boolean isListWrapper;
 
     /**
      * Whether the mapped response body type required validation.
      */
-    boolean isValidated;
+    private final boolean isValidated;
 
     /**
      * Create a response body mapping.
@@ -56,8 +56,35 @@ public final class ResponseBodyMappingModel implements Serializable {
      *                       the header will be removed and body not changed.
      */
     public ResponseBodyMappingModel(String headerName, String mappedBodyType) {
+        this(headerName, mappedBodyType, false, false);
+    }
+
+    private ResponseBodyMappingModel(String headerName, String mappedBodyType, boolean isListWrapper, boolean isValidated) {
         this.headerName = headerName;
         this.mappedBodyType = mappedBodyType;
+        this.isListWrapper = isListWrapper;
+        this.isValidated = isValidated;
+    }
+
+    /**
+     * Specify the name of the response header that triggers mapping.
+     *
+     * @param headerName the name
+     * @return new instance with the updated header name
+     */
+    public ResponseBodyMappingModel withHeaderName(String headerName) {
+        return new ResponseBodyMappingModel(headerName, mappedBodyType, isListWrapper, isValidated);
+    }
+
+    /**
+     * Specify the fully-qualified name of the body type that will be generated
+     * as the response return type in case mapping is triggered.
+     *
+     * @param mappedBodyType the type
+     * @return new instance with the updated mapped body type
+     */
+    public ResponseBodyMappingModel withMappedBodyType(String mappedBodyType) {
+        return new ResponseBodyMappingModel(headerName, mappedBodyType, isListWrapper, isValidated);
     }
 
     /**
@@ -65,22 +92,20 @@ public final class ResponseBodyMappingModel implements Serializable {
      * Then the mapped body type needs to be supplied list items as property
      *
      * @param isListWrapper whether it is a list wrapper
-     * @return this instance
+     * @return new instance with the isListWrapper property specified
      */
     public ResponseBodyMappingModel withListWrapper(boolean isListWrapper) {
-        this.isListWrapper = isListWrapper;
-        return this;
+        return new ResponseBodyMappingModel(headerName, mappedBodyType, isListWrapper, isValidated);
     }
 
     /**
      * Specify whether the mapped response body type required validation.
      *
      * @param isValidated whether it should be validated
-     * @return this instance
+     * @return new instance with validation requirement set
      */
     public ResponseBodyMappingModel withValidated(boolean isValidated) {
-        this.isValidated = isValidated;
-        return this;
+        return new ResponseBodyMappingModel(headerName, mappedBodyType, isListWrapper, isValidated);
     }
 
     public String getHeaderName() {

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/AbstractOpenApiGenerator.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/AbstractOpenApiGenerator.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.gradle.openapi.tasks;
 
+import io.micronaut.gradle.openapi.ParameterMappingModel;
 import io.micronaut.gradle.openapi.ResponseBodyMappingModel;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -75,6 +76,9 @@ public abstract class AbstractOpenApiGenerator<W extends AbstractOpenApiWorkActi
 
     @Input
     public abstract Property<String> getDateTimeFormat();
+
+    @Input
+    public abstract ListProperty<ParameterMappingModel> getParameterMappings();
 
     @Input
     public abstract ListProperty<ResponseBodyMappingModel> getResponseBodyMappings();

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/AbstractOpenApiGenerator.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/AbstractOpenApiGenerator.java
@@ -111,6 +111,7 @@ public abstract class AbstractOpenApiGenerator<W extends AbstractOpenApiWorkActi
                     params.getAlwaysUseGenerateHttpResponse().set(getAlwaysUseGenerateHttpResponse());
                     params.getGenerateHttpResponseWhereRequired().set(getGenerateHttpResponseWhereRequired());
                     params.getDateTimeFormat().set(getDateTimeFormat());
+                    params.getParameterMappings().set(getParameterMappings());
                     params.getResponseBodyMappings().set(getResponseBodyMappings());
                     configureWorkerParameters(params);
                 });

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/AbstractOpenApiWorkAction.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/AbstractOpenApiWorkAction.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.gradle.openapi.tasks;
 
+import io.micronaut.gradle.openapi.ParameterMappingModel;
 import io.micronaut.gradle.openapi.ResponseBodyMappingModel;
 import io.micronaut.openapi.generator.AbstractMicronautJavaCodegen;
 import io.micronaut.openapi.generator.MicronautCodeGeneratorBuilder;
@@ -58,6 +59,8 @@ public abstract class AbstractOpenApiWorkAction<T extends AbstractOpenApiWorkAct
 
         Property<String> getDateTimeFormat();
 
+        ListProperty<ParameterMappingModel> getParameterMappings();
+
         ListProperty<ResponseBodyMappingModel> getResponseBodyMappings();
     }
 
@@ -86,10 +89,22 @@ public abstract class AbstractOpenApiWorkAction<T extends AbstractOpenApiWorkAct
                     options.withGenerateHttpResponseAlways(parameters.getAlwaysUseGenerateHttpResponse().get());
                     options.withGenerateHttpResponseWhereRequired(parameters.getGenerateHttpResponseWhereRequired().get());
                     options.withDateTimeFormat(MicronautCodeGeneratorOptionsBuilder.DateTimeFormat.valueOf(parameters.getDateTimeFormat().get().toUpperCase(Locale.US)));
+                    options.withParameterMappings(parameters.getParameterMappings()
+                            .get()
+                            .stream()
+                            .map(mapping -> new AbstractMicronautJavaCodegen.ParameterMapping(
+                                    mapping.getName(),
+                                    AbstractMicronautJavaCodegen.ParameterMapping.ParameterLocation.valueOf(mapping.getLocation().name()),
+                                    mapping.getMappedType(),
+                                    mapping.getMappedName(),
+                                    mapping.isValidated())
+                            )
+                            .toList()
+                    );
                     options.withResponseBodyMappings(parameters.getResponseBodyMappings()
                             .get()
                             .stream()
-                            .map(mapping -> new AbstractMicronautJavaCodegen.ResponseBodyMapping(mapping.headerName(), mapping.mappedBodyType(), mapping.isListWrapper(), mapping.isValidated()))
+                            .map(mapping -> new AbstractMicronautJavaCodegen.ResponseBodyMapping(mapping.getHeaderName(), mapping.getMappedBodyType(), mapping.isListWrapper(), mapping.isValidated()))
                             .toList()
                     );
                 });


### PR DESCRIPTION
- Add a parameter mapping model to support parameter mappings.
- Improve documentation of parameter and response body mappings and improve the api by not requiring all the properties in constructor as records did.
- Make the models serializable, as otherwise a gradle error is thrown during build.
- Rename the getUseGenerateAlwaysHttpResponse to getGenerateHttpResponseAlways