### PR TITLE
Micronaut 4.0.1 `buildNativeLambda` task breaks under Windows with `StringIndexOutOfBoundsException`

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -614,8 +614,8 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
      */
     private List<String> remapExcludeConfigArgs(List<String> args) {
         return args.stream().map(arg -> {
-            if (arg.startsWith("\\Q") && arg.contains(".jar")) {
-                int index = arg.lastIndexOf(java.io.File.separatorChar);
+            if (arg.startsWith("\\Q") && arg.contains(".jar") && arg.endsWith("\\E")) {
+                int index = arg.substring(0, arg.length() - 2).lastIndexOf(java.io.File.separatorChar);
                 if (index > 0) {
                     // Why aren't we using `\Q` and `\E` here?
                     // Because for some reason, it doesn't when we build under

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
@@ -3,12 +3,10 @@ package io.micronaut.gradle.lambda
 import io.micronaut.gradle.AbstractGradleBuildSpec
 import io.micronaut.gradle.fixtures.AbstractFunctionalTest
 import org.gradle.testkit.runner.TaskOutcome
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Requires
 
 @Requires({ AbstractGradleBuildSpec.graalVmAvailable })
-@IgnoreIf({ os.windows })
 class LambdaNativeImageSpec extends AbstractFunctionalTest {
 
     void 'mainclass is set correctly for an application deployed as GraalVM and Lambda'() {


### PR DESCRIPTION
This PR fixes a bug introduced in #654 that affects only Windows.

The exclude-config arguments were being monkey-patched incorrectly: the last part of the regular expression `\Q ... \E` was being interpreted as a path separator on Windows. This PR makes `lastIndexOf` ignore that part.

No additional tests are needed, because `LambdaNativeImageSpec` was already failing on Windows due to this issue. I removed `@IgnoreIf({ os.windows })` and it works fine after the bugfix.