### PR TITLE
Add new service types to AOT optimizations by default

### DIFF
--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -105,7 +105,10 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
             "io.micronaut.inject.BeanDefinitionReference",
             "io.micronaut.http.HttpRequestFactory",
             "io.micronaut.http.HttpResponseFactory",
-            "io.micronaut.core.beans.BeanIntrospectionReference"
+            "io.micronaut.core.beans.BeanIntrospectionReference",
+            "io.micronaut.core.convert.TypeConverterRegistrar",
+            "io.micronaut.context.ApplicationContextConfigurer",
+            "io.micronaut.context.env.PropertyExpressionResolver"
     ));
     public static final String AOT_APPLICATION_CLASSPATH = "aotApplicationClasspath";
     public static final String OPTIMIZED_RUNTIME_CLASSPATH_CONFIGURATION_NAME = "optimizedRuntimeClasspath";


### PR DESCRIPTION
And you would ask: why don't you use the constant available in `io.micronaut.aot.std.sourcegen.AbstractStaticServiceLoaderSourceGenerator`? Good question! That's because Micronaut AOT is a _compile only_ dependency: we have the ability to override the version of AOT which is used at runtime, so the types that we use in the task are limited, and we cannot use any of the AOT types at this point in time.

This means that ideally, we should have an additional AOT module which simply exposes such constants, and use it as a runtime dependency. However, it's a bit overkill for a single constant right now. Worse, this wouldn't improve the situation in case the user overrides the AOT version, since the plugin would only "see" the version it was compiled with. This means a proper fix would be to actually read the constant dynamically, _before_ we invoke AOT. Lots of work for something which would slow down execution and be a bit hackish.