### PR TITLE
Fix test resources flag ignored when true

### DIFF
--- a/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithGraalVMSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/testresources/TestResourcesWithGraalVMSpec.groovy
@@ -56,12 +56,15 @@ graalvmNative.binaries.all {
 """)
 
         when:
-        def result = build 'nativeRun', "-Dtestresources.native"
+        def result = build 'nativeRun', "-Dtestresources.native$suffix"
 
         then:
         result.task(':nativeRun').outcome == TaskOutcome.SUCCESS
         result.output.contains "Loaded 2 test resources resolvers"
         result.output.contains "io.micronaut.testresources.mysql.MySQLTestResourceProvider"
         result.output.contains "io.micronaut.testresources.testcontainers.GenericTestContainerProvider"
+
+        where:
+        suffix << ["", "=true"]
     }
 }

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/internal/TestResourcesGraalVM.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/internal/TestResourcesGraalVM.java
@@ -46,7 +46,7 @@ public final class TestResourcesGraalVM {
                 .systemProperty(ENABLED_PROPERTY_NAME)
                 .orElse(providers.gradleProperty(ENABLED_PROPERTY_NAME))
                 .map(s -> {
-                    if (s.equals("")) {
+                    if (s.isEmpty() || "true".equalsIgnoreCase(s)) {
                         // if the property is set without value, consider it's true
                         return "true";
                     }


### PR DESCRIPTION
If the value of the `testresources.native` flag was explicitly set to `true`, then counter-intuitively, the native test resources support was disabled. This commit therefore fixes a bug in the parsing logic, when the value `true` was effectively considered `false.