### PR TITLE
Fix error when AOT + test resources are applied with library plugin

### DIFF
--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/internal/TestResourcesAOT.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/internal/TestResourcesAOT.java
@@ -37,9 +37,11 @@ public final class TestResourcesAOT {
         AOTExtension aot = PluginsHelper.findMicronautExtension(project).getExtensions().getByType(AOTExtension.class);
         ConfigurationContainer configurations = project.getConfigurations();
         Configuration aotAppClasspath = configurations.getByName(MicronautAotPlugin.AOT_APPLICATION_CLASSPATH);
-        Configuration optimizedRuntimeClasspath = configurations.getByName(MicronautAotPlugin.OPTIMIZED_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
         aotAppClasspath.extendsFrom(client);
-        optimizedRuntimeClasspath.extendsFrom(client);
+        project.getPluginManager().withPlugin("io.micronaut.minimal.application", unused -> {
+            Configuration optimizedRuntimeClasspath = configurations.getByName(MicronautAotPlugin.OPTIMIZED_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+            optimizedRuntimeClasspath.extendsFrom(client);
+        });
         project.afterEvaluate(p -> {
             MapProperty<String, String> props = aot.getConfigurationProperties();
             if (props.get().containsKey("service.types")) {


### PR DESCRIPTION
The Micronaut AOT plugin is expected to be applied with the application plugin. Therefore, the test resources plugin was assuming that the application plugin was applied, but in practice a user may apply AOT with the library plugin. It wouldn't do anything, but it causes build errors.

This commit makes sure to wrap the relevant code in a `withPlugin` block to avoid the error.

Fixes #815