### PR TITLE
Fix CRaC JDK download in docker container

### DIFF
--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCCheckpointDockerfile.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCCheckpointDockerfile.java
@@ -154,7 +154,7 @@ public abstract class CRaCCheckpointDockerfile extends Dockerfile {
 
         String errorMessage = "No CRaC OpenJDK found for Java version " + javaVersion + " and architecture " + arch;
 
-        String url = "https://api.azul.com/metadata/v1/zulu/packages/?java_version=" + javaVersion + "&arch=" + arch + "&crac_supported=true&latest=true&release_status=ga&certifications=tck&page=1&page_size=100";
+        String url = "https://api.azul.com/metadata/v1/zulu/packages/?java_version=" + javaVersion + "&arch=" + arch + "&crac_supported=true&java_package_type=jdk&latest=true&release_status=ga&certifications=tck&page=1&page_size=100";
         task.runCommand("release_id=$(curl -s \"" + url + "\" -H \"accept: application/json\" | jq -r '.[0] | .package_uuid') \\\n" +
                 "    && if [ \"$release_id\" = \"null\" ]; then \\\n" +
                 "           echo \"" + errorMessage + "\"; \\\n" +

--- a/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
+++ b/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
@@ -136,7 +136,7 @@ class CracCustomizationSpec extends BaseCracGradleBuildSpec {
 
         then:
         result.output.contains("BUILD SUCCESSFUL")
-        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains("https://api.azul.com/metadata/v1/zulu/packages/?java_version=$javaVersion&arch=$expectedArch&crac_supported=true&latest=true&release_status=ga&certifications=tck&page=1&page_size=100")
+        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains("https://api.azul.com/metadata/v1/zulu/packages/?java_version=$javaVersion&arch=$expectedArch&crac_supported=true&java_package_type=jdk&latest=true&release_status=ga&certifications=tck&page=1&page_size=100")
     }
 
     void "Azul CRaC JDK and arch can be changed"() {
@@ -153,7 +153,7 @@ class CracCustomizationSpec extends BaseCracGradleBuildSpec {
 
         then:
         result.output.contains("BUILD SUCCESSFUL")
-        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains("https://api.azul.com/metadata/v1/zulu/packages/?java_version=$javaVersion&arch=$MicronautCRaCPlugin.ARM_ARCH&crac_supported=true&latest=true&release_status=ga&certifications=tck&page=1&page_size=100")
+        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains("https://api.azul.com/metadata/v1/zulu/packages/?java_version=$javaVersion&arch=$MicronautCRaCPlugin.ARM_ARCH&crac_supported=true&java_package_type=jdk&latest=true&release_status=ga&certifications=tck&page=1&page_size=100")
     }
 
     void "Weird java versions cause an error"() {


### PR DESCRIPTION
Azul added a JRE to their CRaC java deliverables.

The query wasn't specific enough to say we want a JDK, so we end up pulling the JRE if it comes back first in the response. The JRE doesn't include the JCmd command which we use for snapshotting...

This change adds `java_package_type=jdk` to the request URL so we just get the JDK.

### Done on the 3.7.x branch, to allow fixing Micronaut 3.x