### PR TITLE
Fix index out of bounds if main class is not in a package

### DIFF
--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -112,6 +112,7 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
     ));
     public static final String AOT_APPLICATION_CLASSPATH = "aotApplicationClasspath";
     public static final String OPTIMIZED_RUNTIME_CLASSPATH_CONFIGURATION_NAME = "optimizedRuntimeClasspath";
+    public static final String DEFAULT_GENERATED_PACKAGE = "io.micronaut.aot.generated";
 
     @Inject
     protected abstract ArchiveOperations getArchiveOperations();
@@ -138,8 +139,11 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
         aotExtension.getDeduceEnvironment().convention(false);
         aotExtension.getTargetPackage().convention(providers.provider(() -> {
             JavaApplication javaApplication = project.getExtensions().findByType(JavaApplication.class);
-            String mainClass = javaApplication.getMainClass().get();
-            return mainClass.contains(".") ? mainClass.substring(0, mainClass.lastIndexOf(".")) : "io.micronaut.aot.generated";
+            if (javaApplication != null) {
+                String mainClass = javaApplication.getMainClass().get();
+                return mainClass.contains(".") ? mainClass.substring(0, mainClass.lastIndexOf(".")) : DEFAULT_GENERATED_PACKAGE;
+            }
+            return DEFAULT_GENERATED_PACKAGE;
         }));
         aotExtension.getOptimizeNetty().convention(false);
     }

--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -138,12 +138,8 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
         aotExtension.getDeduceEnvironment().convention(false);
         aotExtension.getTargetPackage().convention(providers.provider(() -> {
             JavaApplication javaApplication = project.getExtensions().findByType(JavaApplication.class);
-            if (javaApplication != null) {
-                String mainClass = javaApplication.getMainClass().get();
-                return mainClass.substring(0, mainClass.lastIndexOf("."));
-            } else {
-                return "io.micronaut.aot.generated";
-            }
+            String mainClass = javaApplication.getMainClass().get();
+            return mainClass.contains(".") ? mainClass.substring(0, mainClass.lastIndexOf(".")) : "io.micronaut.aot.generated";
         }));
         aotExtension.getOptimizeNetty().convention(false);
     }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
@@ -118,6 +118,7 @@ class BasicMicronautAOTSpec extends AbstractAOTPluginSpec {
         'native' | Plugins.MINIMAL_APPLICATION
         'native' | Plugins.APPLICATION
 
+
     }
 
     def "can optimize an application using the minimal application plugin"() {
@@ -169,6 +170,90 @@ class BasicMicronautAOTSpec extends AbstractAOTPluginSpec {
         where:
         task << ["nativeCompile", "nativeOptimizedCompile"]
 
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/803")
+    def "supports main class not in package"() {
+        withSample("aot/basic-app")
+        withPlugins(kind)
+        buildFile << """
+            application {
+                mainClass.set("NioHttpServer")
+            }
+            micronaut {
+                aot {
+                    configurationProperties.putAll([
+                        'known.missing.types.enabled': 'false',
+                        'some.plugin.enabled': 'true'
+                    ])
+                }
+            }
+
+        """
+
+        when:
+        def result = build "prepare${runtime.capitalize()}Optimizations", "-i"
+
+        and: "configuration file is generated"
+        hasAOTConfiguration(runtime) {
+            withProperty('graalvm.config.enabled', 'native' == runtime ? 'true' : 'false')
+            withProperty('logback.xml.to.java.enabled', 'true')
+            withProperty('cached.environment.enabled', 'true')
+            withProperty('serviceloading.jit.enabled', 'true')
+            withProperty('serviceloading.native.enabled', 'true')
+            withProperty('yaml.to.java.config.enabled', 'true')
+            withProperty('scan.reactive.types.enabled', 'true')
+            withProperty('known.missing.types.enabled', 'false')
+            withProperty('sealed.property.source.enabled', 'true')
+            withProperty('precompute.environment.properties.enabled', 'true')
+            withProperty('deduce.environment.enabled', 'true')
+            withProperty('some.plugin.enabled', 'true')
+            withProperty('netty.properties.enabled', 'true')
+            withExtraPropertyKeys 'service.types', 'known.missing.types.list'
+        }
+
+        then: "Context configurer is loaded"
+        result.output.contains 'Java configurer loaded'
+
+        when:
+        interruptApplicationStartup()
+        result = build("optimizedRun")
+
+        then:
+        [
+                'io.micronaut.core.util.EnvironmentProperties',
+                'io.micronaut.core.async.publisher.PublishersOptimizations',
+                'io.micronaut.core.io.service.SoftServiceLoader$Optimizations',
+                'io.micronaut.context.env.ConstantPropertySources'
+        ].each {
+
+
+            def outputDir = new File("$baseDir/build/generated/aot/jit/sources/")
+            def expectedPackage = "io.micronaut.aot.generated"
+            def expectectedTargetDir = expectedPackage.replace(".", "/")
+            assert calculatePossiblePackages(outputDir).contains(expectectedTargetDir)
+
+        }
+
+        where:
+        runtime  | kind
+        'jit'    | Plugins.MINIMAL_APPLICATION
+        'jit'    | Plugins.APPLICATION
+        'native' | Plugins.MINIMAL_APPLICATION
+        'native' | Plugins.APPLICATION
+
+
+    }
+
+    private List<GString> calculatePossiblePackages(File outputDir) {
+        def list = new ArrayList()
+        outputDir.eachDirRecurse { list.add(subpath(it, outputDir)) }
+        return list
+    }
+
+    private String subpath(File fullpath, File basePath) {
+        def path = fullpath.getAbsolutePath()
+        path.substring(basePath.getAbsolutePath().length() + 1, path.size())
     }
 
 }


### PR DESCRIPTION
This PR fixes error mentioned in **Issue #803** by handling `getTargetPackage()` during `configureAotDefaults` setting `"io.micronaut.aot.generated"` as target package when main class is in the default package.