### PR TITLE
Backport fixes from the 4.1.x mainline to 4.0.x

### DIFF
--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCCheckpointDockerfile.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCCheckpointDockerfile.java
@@ -155,7 +155,7 @@ public abstract class CRaCCheckpointDockerfile extends Dockerfile {
 
         String errorMessage = "No CRaC OpenJDK found for Java version " + javaVersion + " and architecture " + arch;
 
-        String url = "https://api.azul.com/metadata/v1/zulu/packages/?java_version=" + javaVersion + "&arch=" + arch + "&crac_supported=true&latest=true&release_status=ga&certifications=tck&page=1&page_size=100";
+        String url = "https://api.azul.com/metadata/v1/zulu/packages/?java_version=" + javaVersion + "&arch=" + arch + "&crac_supported=true&java_package_type=jdk&latest=true&release_status=ga&certifications=tck&page=1&page_size=100";
         task.runCommand("release_id=$(curl -s \"" + url + "\" -H \"accept: application/json\" | jq -r '.[0] | .package_uuid') \\\n" +
                 "    && if [ \"$release_id\" = \"null\" ]; then \\\n" +
                 "           echo \"" + errorMessage + "\"; \\\n" +

--- a/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
+++ b/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
@@ -136,7 +136,7 @@ class CracCustomizationSpec extends BaseCracGradleBuildSpec {
 
         then:
         result.output.contains("BUILD SUCCESSFUL")
-        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains("https://api.azul.com/metadata/v1/zulu/packages/?java_version=$javaVersion&arch=$expectedArch&crac_supported=true&latest=true&release_status=ga&certifications=tck&page=1&page_size=100")
+        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains("https://api.azul.com/metadata/v1/zulu/packages/?java_version=$javaVersion&arch=$expectedArch&crac_supported=true&java_package_type=jdk&latest=true&release_status=ga&certifications=tck&page=1&page_size=100")
     }
 
     void "Azul CRaC JDK and arch can be changed"() {
@@ -153,7 +153,7 @@ class CracCustomizationSpec extends BaseCracGradleBuildSpec {
 
         then:
         result.output.contains("BUILD SUCCESSFUL")
-        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains("https://api.azul.com/metadata/v1/zulu/packages/?java_version=$javaVersion&arch=$MicronautCRaCPlugin.ARM_ARCH&crac_supported=true&latest=true&release_status=ga&certifications=tck&page=1&page_size=100")
+        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains("https://api.azul.com/metadata/v1/zulu/packages/?java_version=$javaVersion&arch=$MicronautCRaCPlugin.ARM_ARCH&crac_supported=true&java_package_type=jdk&latest=true&release_status=ga&certifications=tck&page=1&page_size=100")
     }
 
     void "Weird java versions cause an error"() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.8.22"
 ksp = "1.8.22-1.0.11"
-docker = "9.3.2"
+docker = "9.3.3"
 diffplug = "3.42.2"
 shadow = "8.1.1"
 groovy = "3.0.19"


### PR DESCRIPTION
This backports the CRaC docker fix https://github.com/micronaut-projects/micronaut-gradle-plugin/pull/828
And the upgrade to docker https://github.com/micronaut-projects/micronaut-gradle-plugin/pull/839