### PR TITLE
Add the Micronaut GraalVM dependency consistently

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
@@ -1,7 +1,6 @@
 package io.micronaut.gradle;
 
 import com.google.devtools.ksp.gradle.KspExtension;
-import io.micronaut.gradle.graalvm.GraalUtil;
 import io.micronaut.gradle.internal.AutomaticDependency;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -199,21 +198,21 @@ public class MicronautKotlinSupport {
         configureAnnotationProcessors(p,
                 implementationConfigurationName,
                 annotationProcessorConfigurationName);
-        if (GraalUtil.isGraalJVM()) {
-            new AutomaticDependency(annotationProcessorConfigurationName,
-                    "io.micronaut:micronaut-graal",
-                    Optional.of(CORE_VERSION_PROPERTY)).applyTo(p);
-        }
+        p.getPluginManager().withPlugin("io.micronaut.graalvm", unused ->
+                new AutomaticDependency(annotationProcessorConfigurationName,
+                "io.micronaut:micronaut-graal",
+                Optional.of(CORE_VERSION_PROPERTY)).applyTo(p)
+        );
     }
 
     private static void addGraalVmDependencies(String[] compilerConfigurations, Project project) {
-        if (GraalUtil.isGraalJVM()) {
+        project.getPluginManager().withPlugin("io.micronaut.graalvm", unused -> {
             for (String configuration : compilerConfigurations) {
                 new AutomaticDependency(configuration,
                         "io.micronaut:micronaut-graal",
                         Optional.of(CORE_VERSION_PROPERTY)).applyTo(project);
             }
-        }
+        });
     }
 
     private static void configureAllOpen(Project project) {


### PR DESCRIPTION
In previous releases of the plugin, there was an inconsistency in how the `micronaut-graal` processor was added. In particular, the dependency was only added if the JVM _running the build_ was GraalVM, but only for Kotlin. For Java and Groovy, the dependency was added in any case.

In fact, the behavior for Kotlin was wrong, since there's no reason that the toolchain used to compile the app is the same as the one running the build. Therefore, this commit changes the behavior so that as soon as the `io.micronaut.graalvm` plugin is applied, then the dependency is added.

It is a slight behavioral change for users who do _not_ use GraalVM but who would still apply the `io.micronaut.application` plugin. Before this change, they wouldn't have a `micronaut-graalvm` annotation processor on classpath. After this change, they will, because the `application` plugin applies the `graalvm` plugin. It is however significantly easier to reason about and more correct.