### PR TITLE
Make configurable fields public

### DIFF
--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/AbstractMicronautAotCliTask.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/AbstractMicronautAotCliTask.java
@@ -52,18 +52,18 @@ abstract class AbstractMicronautAotCliTask extends DefaultTask implements Optimi
     protected abstract ExecOperations getExecOperations();
 
     @Input
-    protected abstract Property<Boolean> getDebug();
+    public abstract Property<Boolean> getDebug();
 
     @Input
-    protected abstract Property<String> getAotVersion();
-
-    @Input
-    @Optional
-    protected abstract MapProperty<String, String> getEnvironmentVariables();
+    public abstract Property<String> getAotVersion();
 
     @Input
     @Optional
-    protected abstract ListProperty<String> getJvmArgs();
+    public abstract MapProperty<String, String> getEnvironmentVariables();
+
+    @Input
+    @Optional
+    public abstract ListProperty<String> getJvmArgs();
 
     protected AbstractMicronautAotCliTask() {
         getDebug().convention(false);

--- a/buildSrc/src/main/groovy/io/micronaut/internal/build/sourcegen/SimpleSourceProcessor.java
+++ b/buildSrc/src/main/groovy/io/micronaut/internal/build/sourcegen/SimpleSourceProcessor.java
@@ -38,13 +38,13 @@ import java.util.stream.Stream;
 public abstract class SimpleSourceProcessor extends DefaultTask {
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
-    abstract DirectoryProperty getTemplates();
+    public abstract DirectoryProperty getTemplates();
 
     @OutputDirectory
-    abstract DirectoryProperty getOutputDirectory();
+    public abstract DirectoryProperty getOutputDirectory();
 
     @Input
-    abstract MapProperty<String, String> getReplacements();
+    public abstract MapProperty<String, String> getReplacements();
 
     @TaskAction
     public void process() throws IOException {

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/ApplicationClasspathInspector.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/ApplicationClasspathInspector.java
@@ -35,7 +35,7 @@ import java.util.Set;
 public abstract class ApplicationClasspathInspector extends DefaultTask {
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
-    abstract ConfigurableFileCollection getResources();
+    public abstract ConfigurableFileCollection getResources();
 
     /**
      * The runtime classpath. Curently we only care about the file names,
@@ -44,10 +44,10 @@ public abstract class ApplicationClasspathInspector extends DefaultTask {
      */
     @InputFiles
     @PathSensitive(PathSensitivity.NAME_ONLY)
-    abstract ConfigurableFileCollection getRuntimeClasspath();
+    public abstract ConfigurableFileCollection getRuntimeClasspath();
 
     @OutputFile
-    abstract RegularFileProperty getReportFile();
+    public abstract RegularFileProperty getReportFile();
 
     @TaskAction
     void inspect() throws IOException {

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -62,7 +62,7 @@ public abstract class StartTestResourcesService extends DefaultTask {
     @InputFiles
     @Classpath
     @Incremental
-    abstract ConfigurableFileCollection getClasspath();
+    public abstract ConfigurableFileCollection getClasspath();
 
     /**
      * The directory where the settings to connect to

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StopTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StopTestResourcesService.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  */
 public abstract class StopTestResourcesService extends DefaultTask {
     @Destroys
-    abstract DirectoryProperty getSettingsDirectory();
+    public abstract DirectoryProperty getSettingsDirectory();
 
     @Inject
     protected abstract FileOperations getFileOperations();


### PR DESCRIPTION
Some plugins tasks properties were _protected_, which prevents the user from configuring them using the Kotlin DSL. There were accessible in Groovy scripts, which we use in tests, so these were unnoticed.

Revealed by comment in #785

Fixes #785