### PR TITLE
Fix Gradle 9 deprecations

### DIFF
--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -46,7 +46,6 @@ import org.gradle.api.file.RelativePath;
 import org.gradle.api.java.archives.Attributes;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.ApplicationPlugin;
-import org.gradle.api.plugins.ApplicationPluginConvention;
 import org.gradle.api.plugins.JavaApplication;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Provider;
@@ -183,7 +182,7 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
     private void registerOptimizedDistribution(Project project,
                                                TaskProvider<Jar> optimizedJar) {
         DistributionContainer distributions = project.getExtensions().getByType(DistributionContainer.class);
-        ApplicationPluginConvention appConvention = project.getConvention().getPlugin(ApplicationPluginConvention.class);
+        JavaApplication appConvention = project.getExtensions().getByType(JavaApplication.class);
         ConfigurableFileCollection classpath = project.getObjects().fileCollection();
         classpath.from(optimizedJar);
         classpath.from(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
@@ -29,9 +29,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.ApplicationPlugin;
-import org.gradle.api.plugins.JavaApplication;
 import org.gradle.api.plugins.PluginManager;
-import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -191,17 +189,7 @@ public class MicronautMinimalApplicationPlugin implements Plugin<Project> {
             if (micronautRuntime == MicronautRuntime.GOOGLE_FUNCTION) {
                 configureGoogleCloudFunctionRuntime(project, p, dependencyHandler);
             }
-            ShadowPluginSupport.withShadowPlugin(project, () -> {
-                JavaApplication javaApplication = project
-                        .getExtensions().findByType(JavaApplication.class);
-                if (javaApplication != null) {
-                    Property<String> mainClass = javaApplication.getMainClass();
-                    if (mainClass.isPresent()) {
-                        project.setProperty("mainClassName", mainClass.get());
-                    }
-                }
-                ShadowPluginSupport.mergeServiceFiles(project);
-            });
+            ShadowPluginSupport.withShadowPlugin(project, () -> ShadowPluginSupport.mergeServiceFiles(project));
 
         });
     }


### PR DESCRIPTION
Note : in order to fix all deprecations, we'll have to wait for the NBT 0.9.28 release.