### PR TITLE
Fix test resources client on optimizer classpath

### DIFF
--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -50,7 +50,6 @@ import org.gradle.api.plugins.JavaApplication;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
@@ -447,48 +446,6 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
         private static String normalizePath(String path) {
             return path.replace('\\', '/');
         }
-    }
-
-    private static class ExclusionSpec implements Spec<File> {
-        private final Provider<RegularFile> filterFile;
-        private final Set<String> prefixes;
-        private final Logger logger;
-        private Set<String> excludes;
-
-        private ExclusionSpec(Provider<RegularFile> filterFile,
-                                 Set<String> prefixes,
-                                 Logger logger) {
-            this.filterFile = filterFile;
-            this.prefixes = prefixes;
-            this.logger = logger;
-        }
-
-        @Override
-        public boolean isSatisfiedBy(File file) {
-            if (excludes == null) {
-                File resourceFilter = filterFile.get().getAsFile();
-                try {
-                    excludes = new HashSet<>();
-                    Files.readAllLines(resourceFilter.toPath())
-                            .stream()
-                            .map(JarExclusionSpec::normalizePath)
-                            .forEach(excludes::add);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-                logger.debug("Excluded resources: {} ", excludes);
-            }
-            var relativePath = file.toString();
-            if (excludes.contains(normalizePath(relativePath)) || prefixes.stream().anyMatch(p -> normalizePath(relativePath).startsWith(p))) {
-                return false;
-            }
-            return true;
-        }
-
-        private static String normalizePath(String path) {
-            return path.replace('\\', '/');
-        }
-
     }
 
     private static final class Configurations {

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/internal/TestResourcesAOT.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/internal/TestResourcesAOT.java
@@ -36,8 +36,6 @@ public final class TestResourcesAOT {
     public static void configure(Project project, Configuration client) {
         AOTExtension aot = PluginsHelper.findMicronautExtension(project).getExtensions().getByType(AOTExtension.class);
         ConfigurationContainer configurations = project.getConfigurations();
-        Configuration aotAppClasspath = configurations.getByName(MicronautAotPlugin.AOT_APPLICATION_CLASSPATH);
-        aotAppClasspath.extendsFrom(client);
         project.getPluginManager().withPlugin("io.micronaut.minimal.application", unused -> {
             Configuration optimizedRuntimeClasspath = configurations.getByName(MicronautAotPlugin.OPTIMIZED_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
             optimizedRuntimeClasspath.extendsFrom(client);


### PR DESCRIPTION
The AOT process should optimize applications for the production environment. As such it doesn't make sense to have the test resources client on the classpath of the application being scanned during the AOT optimization process.

This bugfix has the potential to break builds of people who run `./gradlew build` and had builds passing because the AOT optimizer was using test resources.

Fixes #852