### PR TITLE
Switch to eclipse-temurin:17-jre-focal by default

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 public abstract class MicronautDockerfile extends Dockerfile implements DockerBuildOptions {
     public static final String DEFAULT_WORKING_DIR = "/home/app";
+    public static final String DEFAULT_BASE_IMAGE = "eclipse-temurin:17-jre-focal";
 
     @Input
     private final Property<String> baseImage;
@@ -109,7 +110,7 @@ public abstract class MicronautDockerfile extends Dockerfile implements DockerBu
             case LAMBDA:
                 javaApplication.getMainClass().set("io.micronaut.function.aws.runtime.MicronautLambdaRuntime");
             default:
-                from(new Dockerfile.From(from != null ? from : "openjdk:17-alpine"));
+                from(new Dockerfile.From(from != null ? from : DEFAULT_BASE_IMAGE));
                 setupResources(this);
                 exposePort(exposedPorts);
                 getInstructions().addAll(additionalInstructions);

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
@@ -80,7 +80,7 @@ class Application {
 """
 
         testProjectDir.newFile("Dockerfile") << """
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-jre-focal
 WORKDIR /home/alternate
 COPY layers/libs /home/alternate/libs
 COPY layers/classes /home/alternate/classes
@@ -189,7 +189,7 @@ class Application {
 
         and:
         def dockerfile = new File(testProjectDir.root, 'build/docker/main/Dockerfile').text
-        dockerfile == """FROM openjdk:17-alpine
+        dockerfile == """FROM eclipse-temurin:17-jre-focal
 WORKDIR /home/alternate
 COPY layers/libs /home/alternate/libs
 COPY layers/classes /home/alternate/classes

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -20,7 +20,7 @@ class MicronautAOTDockerSpec extends AbstractAOTPluginSpec {
         result.task(":optimizedDockerfile").outcome != TaskOutcome.FAILED
 
         def dockerFile = normalizeLineEndings(file("build/docker/optimized/Dockerfile").text)
-        dockerFile == """FROM openjdk:17-alpine
+        dockerFile == """FROM eclipse-temurin:17-jre-focal
 WORKDIR /home/app
 COPY layers/libs /home/app/libs
 COPY layers/classes /home/app/classes
@@ -47,7 +47,7 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
         result.task(":optimizedDockerBuild").outcome != TaskOutcome.FAILED
 
         def dockerFile = normalizeLineEndings(file("build/docker/optimized/Dockerfile").text)
-        dockerFile == """FROM openjdk:17-alpine
+        dockerFile == """FROM eclipse-temurin:17-jre-focal
 WORKDIR /home/app
 COPY layers/libs /home/app/libs
 COPY layers/classes /home/app/classes

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -689,7 +689,7 @@ class Application {
 
         then:
         def dockerfile = new File(testProjectDir.root, 'build/docker/main/Dockerfile').text
-        dockerfile == """FROM openjdk:17-alpine
+        dockerfile == """FROM eclipse-temurin:17-jre-focal
 WORKDIR /home/app
 COPY layers/libs /home/app/libs
 COPY server.iprof /home/app/server.iprof
@@ -769,7 +769,7 @@ class Application {
 
         then:
         def dockerfile = new File(testProjectDir.root, 'build/docker/main/Dockerfile').text
-        dockerfile == """FROM openjdk:17-alpine
+        dockerfile == """FROM eclipse-temurin:17-jre-focal
 WORKDIR /home/app
 COPY layers/libs /home/app/libs
 COPY server.iprof /home/app/server.iprof

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -2,7 +2,7 @@
 :native-gradle-plugin: https://graalvm.github.io/native-build-tools/{native-build-tools-version}/gradle-plugin.html
 :gradle-docs: https://docs.gradle.org/{gradle-version}/userguide
 :gradle-toolchains: {gradle-docs}/toolchains.html
-:default-docker-image: openjdk:17-alpine
+:default-docker-image: eclipse-temurin:17-jre-focal
 :docker-plugin: https://github.com/bmuschko/gradle-docker-plugin
 :aws-docs: https://micronaut-projects.github.io/micronaut-aws/latest/guide/index.html#customRuntimes
 :testresources-guide: https://micronaut-projects.github.io/micronaut-test-resources/latest/guide


### PR DESCRIPTION
This is to fix Docker builds on Apple Silicon.

Fixes #794