### PR TITLE
Let the user ignore automatic dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=4.1.3-SNAPSHOT
+projectVersion=4.2.0-SNAPSHOT
 projectGroup=io.micronaut.gradle
 githubBranch=master
 org.gradle.caching=true

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
@@ -4,6 +4,7 @@ import org.gradle.api.Action;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 import java.util.LinkedHashMap;
@@ -33,6 +34,16 @@ public abstract class MicronautExtension implements ExtensionAware {
      * @return the import platform flag. Defaults to true.
      */
     public abstract Property<Boolean> getImportMicronautPlatform();
+
+    /**
+     * The Micronaut plugins can automatically add dependencies to your project.
+     * If, for some reason, a dependency shouldn't be automatically added, you can
+     * add its coordinates to this set. The format is "group:name". It must not include
+     * the version.
+     *
+     * @return the set of ignored automatic dependencies, as group:name strings.
+     */
+    public abstract SetProperty<String> getIgnoredAutomaticDependencies();
 
     @Inject
     public MicronautExtension(ObjectFactory objectFactory, SourceSetConfigurer sourceSetConfigurer) {

--- a/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMinimalApplicationPluginSpec.groovy
+++ b/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMinimalApplicationPluginSpec.groovy
@@ -331,4 +331,36 @@ public class ExampleTest {
         result.output.contains('Could not find io.micronaut:micronaut-http-server-netty:2048')
 
     }
+
+    def "can ignore an automatic dependency"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+            }
+            
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+                testRuntime "junit5"
+                ignoredAutomaticDependencies.add("io.micronaut:micronaut-inject-java")
+            }
+            
+            $repositoriesBlock
+            mainClassName="example.Application"
+        """
+        testProjectDir.newFolder("src", "test", "java", "example")
+        def javaFile = writeExampleClass()
+        when:
+        def result = build('test')
+
+        def task = result.task(":test")
+        println result.output
+
+        then:
+        !result.output.contains('Creating bean classes for 1 type elements')
+        task.outcome == TaskOutcome.FAILED
+
+    }
 }


### PR DESCRIPTION
In some circumstances, automatic dependencies can get in the way. This should be rare but there was no built-in mechanism to ignore such dependencies. It is now possible to list these using the `micronaut` extension, for example:

```
micronaut {
    ignoredAutomaticDependencies.add("io.micronaut.data:micronaut-data-processor")
}
```

The responsibility of adding these is then shifted to the user.

Fixes https://github.com/micronaut-projects/micronaut-sql/issues/1157