### PR TITLE
Add missing annotation processors for micronaut modules.

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/PluginsHelper.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/PluginsHelper.java
@@ -51,13 +51,25 @@ public abstract class PluginsHelper {
     public static final ConfigurableVersionProperty CORE_VERSION_PROPERTY = ConfigurableVersionProperty.of("core");
     public static final ConfigurableVersionProperty DATA_VERSION_PROPERTY = ConfigurableVersionProperty.of("data");
     public static final ConfigurableVersionProperty JAXRS_VERSION_PROPERTY = ConfigurableVersionProperty.of("jaxrs");
+    public static final ConfigurableVersionProperty MICROMETER_VERSION_PROPERTY = ConfigurableVersionProperty.of("micrometer");
+    public static final ConfigurableVersionProperty MICROSTREAM_VERSION_PROPERTY = ConfigurableVersionProperty.of("microstream");
+    public static final ConfigurableVersionProperty OPENAPI_VERSION_PROPERTY = ConfigurableVersionProperty.of("openapi");
     public static final ConfigurableVersionProperty SECURITY_VERSION_PROPERTY = ConfigurableVersionProperty.of("security");
+    public static final ConfigurableVersionProperty SERDE_VERSION_PROPERTY = ConfigurableVersionProperty.of("serde");
+    public static final ConfigurableVersionProperty SPRING_VERSION_PROPERTY = ConfigurableVersionProperty.of("spring");
+    public static final ConfigurableVersionProperty TRACING_VERSION_PROPERTY = ConfigurableVersionProperty.of("tracing");
     public static final ConfigurableVersionProperty VALIDATION_VERSION_PROPERTY = ConfigurableVersionProperty.of("validation");
 
     private static final Map<String, AutomaticDependency> GROUP_TO_PROCESSOR_MAP = Map.of(
             "io.micronaut.data", new AutomaticDependency(null, "io.micronaut.data:micronaut-data-processor", Optional.of(DATA_VERSION_PROPERTY)),
             "io.micronaut.jaxrs", new AutomaticDependency(null, "io.micronaut.jaxrs:micronaut-jaxrs-processor", Optional.of(JAXRS_VERSION_PROPERTY)),
+            "io.micronaut.micrometer", new AutomaticDependency(null, "io.micronaut.micrometer:micronaut-micrometer-annotation", Optional.of(MICROMETER_VERSION_PROPERTY)),
+            "io.micronaut.microstream", new AutomaticDependency(null, "io.micronaut.microstream:micronaut-microstream-annotations", Optional.of(MICROSTREAM_VERSION_PROPERTY)),
+            "io.micronaut.openapi", new AutomaticDependency(null, "io.micronaut.openapi:micronaut-openapi", Optional.of(OPENAPI_VERSION_PROPERTY)),
             "io.micronaut.security", new AutomaticDependency(null, "io.micronaut.security:micronaut-security-annotations", Optional.of(SECURITY_VERSION_PROPERTY)),
+            "io.micronaut.serde", new AutomaticDependency(null, "io.micronaut.serde:micronaut-serde-processor", Optional.of(SERDE_VERSION_PROPERTY)),
+            "io.micronaut.spring", new AutomaticDependency(null, "io.micronaut.spring:micronaut-spring-annotation", Optional.of(SPRING_VERSION_PROPERTY)),
+            "io.micronaut.tracing", new AutomaticDependency(null, "io.micronaut.tracing:micronaut-tracing-annotation", Optional.of(TRACING_VERSION_PROPERTY)),
             "io.micronaut.validation", new AutomaticDependency(null, "io.micronaut.validation:micronaut-validation-processor", Optional.of(VALIDATION_VERSION_PROPERTY))
     );
     public static final String MICRONAUT_VERSION_PROPERTY = "micronautVersion";
@@ -68,7 +80,13 @@ public abstract class PluginsHelper {
             CORE_VERSION_PROPERTY,
             DATA_VERSION_PROPERTY,
             JAXRS_VERSION_PROPERTY,
+            MICROMETER_VERSION_PROPERTY,
+            MICROSTREAM_VERSION_PROPERTY,
+            OPENAPI_VERSION_PROPERTY,
             SECURITY_VERSION_PROPERTY,
+            SERDE_VERSION_PROPERTY,
+            SPRING_VERSION_PROPERTY,
+            TRACING_VERSION_PROPERTY,
             VALIDATION_VERSION_PROPERTY
     );
 

--- a/minimal-plugin/src/test/groovy/io/micronaut/gradle/AutomaticDependencySpec.groovy
+++ b/minimal-plugin/src/test/groovy/io/micronaut/gradle/AutomaticDependencySpec.groovy
@@ -1,0 +1,41 @@
+package io.micronaut.gradle
+
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class AutomaticDependencySpec extends Specification {
+    def "automatically adds annotation processor dependency for #group"() {
+        def project = ProjectBuilder.builder().build()
+        project.extensions.add('micronautVersion', 'any')
+        project.pluginManager.apply(MicronautMinimalLibraryPlugin)
+
+        when:
+        project.configurations.implementation.dependencies.add(project.dependencies.create("$group:micronaut-any"))
+        project.evaluate()
+
+        // this variable is used to make sure other automatic dependencies are not used
+        // when a particular dependency is found
+        def shouldNotHave = "io.micronaut.validation:micronaut-validation-processor"
+        if (group == "io.micronaut.validation") {
+            shouldNotHave = "io.micronaut.data:micronaut-data-processor"
+        }
+
+        then:
+        project.configurations.annotationProcessor.incoming.dependencies.find { "${it.group}:${it.name}" == processor }
+        !project.configurations.annotationProcessor.incoming.dependencies.find { "${it.group}:${it.name}" == shouldNotHave }
+
+        where:
+        group                      | processor
+        "io.micronaut.data"        | "io.micronaut.data:micronaut-data-processor"
+        "io.micronaut.jaxrs"       | "io.micronaut.jaxrs:micronaut-jaxrs-processor"
+        "io.micronaut.micrometer"  | "io.micronaut.micrometer:micronaut-micrometer-annotation"
+        "io.micronaut.microstream" | "io.micronaut.microstream:micronaut-microstream-annotations"
+        "io.micronaut.openapi"     | "io.micronaut.openapi:micronaut-openapi"
+        "io.micronaut.security"    | "io.micronaut.security:micronaut-security-annotations"
+        "io.micronaut.serde"       | "io.micronaut.serde:micronaut-serde-processor"
+        "io.micronaut.spring"      | "io.micronaut.spring:micronaut-spring-annotation"
+        "io.micronaut.tracing"     | "io.micronaut.tracing:micronaut-tracing-annotation"
+        "io.micronaut.validation"  | "io.micronaut.validation:micronaut-validation-processor"
+    }
+}


### PR DESCRIPTION
closes #871

@melix @sdelamo 
micronaut-tracing and micronaut-spring have multiple possible annotation processors. I included the primary ones. Do we need to add the others? If so then the implementation needs to be changed because it's based on a map with groupIds for keys.

These are the ones I didn't add:
- io.micronaut.tracing:micronaut-tracing-opentelemetry-annotation
- io.micronaut.spring:micronaut-spring-boot-annotation
- io.micronaut.spring:micronaut-spring-web-annotation

@melix Also, I didn't see an obvious way this is tested, so I didn't change anything for the new ones either. Happy for any guidance.