### PR TITLE
Add missing configuration parameter

### DIFF
--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -244,6 +244,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
             task.getAccessToken().convention(accessToken);
             task.getExplicitPort().convention(config.getExplicitPort());
             task.getClientTimeout().convention(config.getClientTimeout());
+            task.getServerIdleTimeoutMinutes().convention(config.getServerIdleTimeoutMinutes());
             task.getClasspath().from(server);
             task.getForeground().convention(false);
             task.getStopFile().set(stopFile.toFile());

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/TestResourcesConfiguration.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/TestResourcesConfiguration.java
@@ -18,6 +18,7 @@ package io.micronaut.gradle.testresources;
 import io.micronaut.testresources.buildtools.KnownModules;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 
 /**
  * Configuration for the test resources plugin.
@@ -101,4 +102,13 @@ public interface TestResourcesConfiguration extends KnownModules {
      * @return the namespace
      */
     Property<String> getSharedServerNamespace();
+
+    /**
+     * Server idle timeout, in minutes. If the server
+     * doesn't receive any request for this amount of
+     * time, it will stop itself.
+     *
+     * @return the server idle timeout
+     */
+    Provider<Integer> getServerIdleTimeoutMinutes();
 }


### PR DESCRIPTION
This was left over when upgrading to test resources 2.3.0.

Fixes #875