### PR TITLE
Create multi-layer docker files

### DIFF
--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -238,15 +238,11 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
             });
         } else {
             dockerImages.create("optimized", image -> {
+                MicronautDockerPlugin.createDependencyLayers(image, project.getConfigurations().getByName(RUNTIME_CLASSPATH_CONFIGURATION_NAME));
                 image.addLayer(layer -> {
                     layer.getLayerKind().set(LayerKind.APP);
                     layer.getRuntimeKind().set(runtime == OptimizerIO.TargetRuntime.JIT ? RuntimeKind.JIT : RuntimeKind.NATIVE);
                     layer.getFiles().from(optimizedRunnerJar);
-                });
-                image.addLayer(layer -> {
-                    layer.getLayerKind().set(LayerKind.LIBS);
-                    layer.getFiles().from(layer.getFiles().from(project.getConfigurations().getByName(RUNTIME_CLASSPATH_CONFIGURATION_NAME))
-                    );
                 });
             });
         }

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/editor/DefaultEditor.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/editor/DefaultEditor.java
@@ -108,6 +108,17 @@ public class DefaultEditor implements Editor {
     }
 
     @Override
+    public void replaceRegex(String regex, String replacement) {
+        Boundaries boundaries = getBoundaries();
+        int startIndex = boundaries.getStart().orElse(0);
+        int endIndex = boundaries.getEnd().orElse(lines.size());
+        for (int idx = startIndex; idx < endIndex; idx++) {
+            var line = lines.get(idx);
+            lines.set(idx, line.replaceAll(regex, replacement));
+        }
+    }
+
+    @Override
     public void insert(String... lines) {
         int startIndex = getBoundaries().getStart().orElse(0);
         this.lines.addAll(startIndex, Arrays.asList(lines));

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/editor/Editor.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/editor/Editor.java
@@ -53,6 +53,15 @@ public interface Editor {
     void replace(String line, String replacement);
 
     /**
+     * Replaces strings matching the current lower and upper bounds with the
+     * replacement, if they match the line pattern.
+     *
+     * @param regex the regex to look for
+     * @param replacement the replacement
+     */
+    void replaceRegex(String regex, String replacement);
+
+    /**
      * Inserts the provided lines after the current lower bound.
      * @param lines the lines to be inserted
      */

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/editor/FingerprintingEditor.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/editor/FingerprintingEditor.java
@@ -71,6 +71,13 @@ public class FingerprintingEditor implements Editor {
     }
 
     @Override
+    public void replaceRegex(String regex, String replacement) {
+        fingerprint.add("REPLACE_REGEX");
+        fingerprint.add(regex);
+        fingerprint.add(replacement);
+    }
+
+    @Override
     public void insert(String... lines) {
         fingerprint.add("INSERT");
         Collections.addAll(fingerprint, lines);

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/model/LayerKind.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/model/LayerKind.java
@@ -16,8 +16,24 @@
 package io.micronaut.gradle.docker.model;
 
 public enum LayerKind {
-    LIBS,
-    APP,
-    EXPANDED_CLASSES,
-    EXPANDED_RESOURCES
+    PROJECT_LIBS("project_libs", "libs"),
+    SNAPSHOT_LIBS("snapshot_libs", "libs"),
+    LIBS("libs", "libs"),
+    APP("app", "");
+
+    private final String sourceDirName;
+    private final String targetDirName;
+
+    LayerKind(String sourceDirName, String targetDirName) {
+        this.sourceDirName = sourceDirName;
+        this.targetDirName = targetDirName;
+    }
+
+    public String targetDirName() {
+        return targetDirName;
+    }
+
+    public String sourceDirName() {
+        return sourceDirName;
+    }
 }

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
@@ -83,9 +83,7 @@ class Application {
 FROM eclipse-temurin:17-jre-focal
 WORKDIR /home/alternate
 COPY layers/libs /home/alternate/libs
-COPY layers/classes /home/alternate/classes
-COPY layers/resources /home/alternate/resources
-COPY layers/application.jar /home/alternate/application.jar
+COPY layers/app/application.jar /home/alternate/application.jar
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/home/alternate/application.jar"]
 """
@@ -191,10 +189,10 @@ class Application {
         def dockerfile = new File(testProjectDir.root, 'build/docker/main/Dockerfile').text
         dockerfile == """FROM eclipse-temurin:17-jre-focal
 WORKDIR /home/alternate
-COPY layers/libs /home/alternate/libs
-COPY layers/classes /home/alternate/classes
-COPY layers/resources /home/alternate/resources
-COPY layers/application.jar /home/alternate/application.jar
+COPY --link layers/libs /home/alternate/libs
+COPY --link layers/snapshot_libs /home/alternate/libs
+COPY --link layers/project_libs /home/alternate/libs
+COPY --link layers/app /home/alternate/
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/home/alternate/application.jar"]
 """

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
@@ -250,6 +250,13 @@ class BasicMicronautAOTSpec extends AbstractAOTPluginSpec {
         withSample("aot/basic-app")
         withPlugins(Plugins.MINIMAL_APPLICATION)
         file("gradle.properties") << "org.gradle.caching=true"
+        // Add a random seed to the build.gradle file so that the task is not from cache
+        // when a previous test execution has already cached the result
+        file("build.gradle") << """
+            tasks.named("prepareJitOptimizations") {
+                inputs.property("seed", "${System.currentTimeMillis()}")
+            }
+        """
 
         when:
         def result = build "prepareJitOptimizations"

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -22,10 +22,10 @@ class MicronautAOTDockerSpec extends AbstractAOTPluginSpec {
         def dockerFile = normalizeLineEndings(file("build/docker/optimized/Dockerfile").text)
         dockerFile == """FROM eclipse-temurin:17-jre-focal
 WORKDIR /home/app
-COPY layers/libs /home/app/libs
-COPY layers/classes /home/app/classes
-COPY layers/resources /home/app/resources
-COPY layers/application.jar /home/app/application.jar
+COPY --link layers/libs /home/app/libs
+COPY --link layers/snapshot_libs /home/app/libs
+COPY --link layers/project_libs /home/app/libs
+COPY --link layers/app /home/app/
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
 """
@@ -49,10 +49,10 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
         def dockerFile = normalizeLineEndings(file("build/docker/optimized/Dockerfile").text)
         dockerFile == """FROM eclipse-temurin:17-jre-focal
 WORKDIR /home/app
-COPY layers/libs /home/app/libs
-COPY layers/classes /home/app/classes
-COPY layers/resources /home/app/resources
-COPY layers/application.jar /home/app/application.jar
+COPY --link layers/libs /home/app/libs
+COPY --link layers/snapshot_libs /home/app/libs
+COPY --link layers/project_libs /home/app/libs
+COPY --link layers/app /home/app/
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
 """
@@ -71,10 +71,10 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
         then:
         dockerFile == """FROM ghcr.io/graalvm/native-image-community:17-ol${DefaultVersions.ORACLELINUX} AS graalvm
 WORKDIR /home/app
-COPY layers/libs /home/app/libs
-COPY layers/classes /home/app/classes
-COPY layers/resources /home/app/resources
-COPY layers/application.jar /home/app/application.jar
+COPY --link layers/libs /home/app/libs
+COPY --link layers/snapshot_libs /home/app/libs
+COPY --link layers/project_libs /home/app/libs
+COPY --link layers/app /home/app/
 RUN mkdir /home/app/config-dirs
 RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
 RUN mkdir -p /home/app/config-dirs/io.netty/netty-common/4.0.0.Final

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -583,10 +583,10 @@ micronaut:
         dockerFile == """
 FROM ghcr.io/graalvm/native-image-community:17-ol${DefaultVersions.ORACLELINUX} AS graalvm
 WORKDIR /home/alternate
-COPY layers/libs /home/alternate/libs
-COPY layers/classes /home/alternate/classes
-COPY layers/resources /home/alternate/resources
-COPY layers/application.jar /home/alternate/application.jar
+COPY --link layers/libs /home/alternate/libs
+COPY --link layers/snapshot_libs /home/alternate/libs
+COPY --link layers/project_libs /home/alternate/libs
+COPY --link layers/app /home/alternate/
 RUN mkdir /home/alternate/config-dirs
 RUN mkdir -p /home/alternate/config-dirs/generateResourcesConfigFile
 RUN mkdir -p /home/alternate/config-dirs/io.netty/netty-common/4.0.0.Final
@@ -664,8 +664,8 @@ afterEvaluate {
 
             tasks.withType(io.micronaut.gradle.docker.DockerBuildOptions).configureEach {
                 editDockerfile {
-                    after('COPY layers/libs /home/app/libs') {
-                        insert('COPY server.iprof /home/app/server.iprof')
+                    after('COPY --link layers/libs /home/app/libs') {
+                        insert('COPY --link server.iprof /home/app/server.iprof')
                     } 
                 }
             }
@@ -691,11 +691,11 @@ class Application {
         def dockerfile = new File(testProjectDir.root, 'build/docker/main/Dockerfile').text
         dockerfile == """FROM eclipse-temurin:17-jre-focal
 WORKDIR /home/app
-COPY layers/libs /home/app/libs
-COPY server.iprof /home/app/server.iprof
-COPY layers/classes /home/app/classes
-COPY layers/resources /home/app/resources
-COPY layers/application.jar /home/app/application.jar
+COPY --link layers/libs /home/app/libs
+COPY --link server.iprof /home/app/server.iprof
+COPY --link layers/snapshot_libs /home/app/libs
+COPY --link layers/project_libs /home/app/libs
+COPY --link layers/app /home/app/
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
 """
@@ -707,11 +707,11 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
         def dockerfileNative = new File(testProjectDir.root, 'build/docker/native-main/DockerfileNative').text
         dockerfileNative == """FROM ghcr.io/graalvm/native-image-community:17-ol${DefaultVersions.ORACLELINUX} AS graalvm
 WORKDIR /home/app
-COPY layers/libs /home/app/libs
-COPY server.iprof /home/app/server.iprof
-COPY layers/classes /home/app/classes
-COPY layers/resources /home/app/resources
-COPY layers/application.jar /home/app/application.jar
+COPY --link layers/libs /home/app/libs
+COPY --link server.iprof /home/app/server.iprof
+COPY --link layers/snapshot_libs /home/app/libs
+COPY --link layers/project_libs /home/app/libs
+COPY --link layers/app /home/app/
 RUN mkdir /home/app/config-dirs
 RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
 COPY config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
@@ -744,8 +744,8 @@ ENTRYPOINT ["/app/application"]
 
             tasks.withType(io.micronaut.gradle.docker.DockerBuildOptions).configureEach {
                 editDockerfile {
-                    after('COPY layers/libs /home/app/libs') {
-                        insert('COPY server.iprof /home/app/server.iprof')
+                    after('COPY --link layers/libs /home/app/libs') {
+                        insert('COPY --link server.iprof /home/app/server.iprof')
                     } 
                 }
             }
@@ -771,11 +771,11 @@ class Application {
         def dockerfile = new File(testProjectDir.root, 'build/docker/main/Dockerfile').text
         dockerfile == """FROM eclipse-temurin:17-jre-focal
 WORKDIR /home/app
-COPY layers/libs /home/app/libs
-COPY server.iprof /home/app/server.iprof
-COPY layers/classes /home/app/classes
-COPY layers/resources /home/app/resources
-COPY layers/application.jar /home/app/application.jar
+COPY --link layers/libs /home/app/libs
+COPY --link server.iprof /home/app/server.iprof
+COPY --link layers/snapshot_libs /home/app/libs
+COPY --link layers/project_libs /home/app/libs
+COPY --link layers/app /home/app/
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
 """
@@ -790,7 +790,7 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
         buildFile << """
             tasks.withType(io.micronaut.gradle.docker.DockerBuildOptions).configureEach {
                 editDockerfile {
-                    after('COPY server.iprof /home/app/server.iprof') {
+                    after('COPY --link server.iprof /home/app/server.iprof') {
                         insert('COPY README.TXT /home/app/README.TXT')
                     } 
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=4.2.2-SNAPSHOT
+projectVersion=4.3.0-SNAPSHOT
 projectGroup=io.micronaut.gradle
 githubBranch=master
 org.gradle.caching=true


### PR DESCRIPTION
This commit improves our docker file generation in order to use multiple layers for dependencies. Instead of having a single libs directory, we now have 3 layers which are copied to the `libs` directory:

- one for the transitive dependencies which are not snapshot
- one for the snapshot dependencies
- one for the project dependencies

In addition to the layer which contains the application jar. Moreover, the dockerfile creation now makes use of the `--link` option for COPY, which makes it even more efficient.

Fixes #735