### PR TITLE
Add OS configuration for CRaC JDK

### DIFF
--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCConfiguration.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCConfiguration.java
@@ -30,6 +30,12 @@ public interface CRaCConfiguration {
     Property<String> getArch();
 
     /**
+     * Filters the jdk result by the operating system the package is targeting. Defaults to {@value MicronautCRaCPlugin#DEFAULT_OS}.
+     * @return the operating system
+     */
+    Property<String> getOs();
+
+    /**
      * The java version to use for building the CRaC enabled images. Currently only '17' is supported.
      * @return the java version
      */

--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
@@ -48,6 +48,7 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
     public static final String CRAC_DEFAULT_BASE_IMAGE_PLATFORM = "linux/amd64";
     public static final String ARM_ARCH = "aarch64";
     public static final String X86_64_ARCH = "amd64";
+    public static final String DEFAULT_OS = "linux-glibc";
     public static final String CRAC_DEFAULT_READINESS_COMMAND = "curl --output /dev/null --silent --head http://localhost:8080";
     private static final String CRAC_TASK_GROUP = "CRaC";
     public static final String BUILD_DOCKER_DIRECTORY = "docker/";
@@ -77,6 +78,9 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
         // Default to current architecture
         String osArch = System.getProperty("os.arch");
         crac.getArch().convention(ARM_ARCH.equals(osArch) ? ARM_ARCH : X86_64_ARCH);
+
+        // Default to linux-glibc
+        crac.getOs().convention(DEFAULT_OS);
 
         // Default to Java 17
         crac.getJavaVersion().convention(JavaLanguageVersion.of(17));
@@ -150,6 +154,7 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
             task.getBaseImage().set(configuration.getBaseImage());
             task.getPlatform().set(configuration.getPlatform());
             task.getArch().set(configuration.getArch());
+            task.getOs().set(configuration.getOs());
             task.getJavaVersion().set(configuration.getJavaVersion());
             task.setupDockerfileInstructions();
             task.getLayers().convention(buildLayersTask.flatMap(BuildLayersTask::getLayers));

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1711,7 +1711,7 @@ Micronaut CRaC is a module which adds support for https://openjdk.org/projects/c
 
 It is capable of generating a docker image containing a CRaC enabled JDK and a pre-warmed, checkpointed application via a new task `dockerBuildCrac`.
 
-IMPORTANT: Currently, CRaC support has only been tested on Ubuntu 18.04, 20.04 and 22.04.  It also requires an x86 machine architecture.
+IMPORTANT: Currently, CRaC support has only been tested on Ubuntu 18.04, 20.04 and 22.04.
 
 When executed, this task will:
 
@@ -1774,6 +1774,9 @@ micronaut {
         // (currently only 'aarch64' or 'amd64' are supported)
         arch = "aarch64"
 
+        // The OS of the Azul CRaC JDK to use. Defaults to linux-glibc for the default base image.
+        os = "linux-glibc"
+
         // The version of the Azul CRaC JDK to use in the image (currently only 17 is supported)
         javaVersion = JavaLanguageVersion.of(17)
 
@@ -1808,6 +1811,9 @@ micronaut {
         // The architecture of the CRaC JDK to use. Defaults to the architecture of the machine.
         // (currently only 'aarch64' or 'amd64' are supported)
         arch.set("aarch64")
+
+        // The OS of the Azul CRaC JDK to use. Defaults to linux-glibc for the default base image.
+        os.set("linux-glibc")
 
         // The version of the Azul CRaC JDK to use in the image (currently only 17 is supported)
         javaVersion.set(JavaLanguageVersion.of(17))


### PR DESCRIPTION
The Azul API has started to differentiate between linux-musl and linux-glibc.

Without us passing the option to use linux-glibc we get 2 JDKs returned, and the musl one doesn't work for building images on OSX with DockerDesktop.

This PR allows configuration of the OS when making the request to the Azul API