### PR TITLE
Use Chainguard's Wolfi base image by default

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -751,11 +751,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
             if (strategy == DockerBuildStrategy.LAMBDA && baseImage == null) {
                 baseImage = "amazonlinux:2";
             } else if (baseImage == null) {
-                baseImage = getGraalArch()
-                        .map(a -> a.equals(ARM_ARCH)
-                                ? "cgr.dev/chainguard/wolfi-base:latest"
-                                : "frolvlad/alpine-glibc:alpine-" + DefaultVersions.ALPINE)
-                        .getOrElse("frolvlad/alpine-glibc:alpine-" + DefaultVersions.ALPINE);
+                baseImage = "cgr.dev/chainguard/wolfi-base:latest";
             }
 
             return baseImage;

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -521,13 +521,6 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
                 break;
             default:
                 from(baseImageProvider);
-                // mandatory dependency for alpine-glibc docker images
-                runCommand(getProviders().provider(() -> {
-                    if (baseImageProvider.get().getImage().contains("alpine-glibc")) {
-                        return "apk --no-cache update && apk add libstdc++";
-                    }
-                    return null;
-                }));
                 exposePort(getExposedPorts());
                 getInstructions().addAll(additionalInstructions);
                 copyFile(new CopyFile(workDir + "/application", "/app/application").withStage("graalvm"));

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -78,7 +78,6 @@ COPY --link config-dirs/io.netty/netty-common/4.0.0.Final /home/app/config-dirs/
 COPY --link config-dirs/ch.qos.logback/logback-classic/4.0.0 /home/app/config-dirs/ch.qos.logback/logback-classic/4.0.0
 RUN native-image --exclude-config .*/libs/netty-transport-4.0.0.Final.jar ^/META-INF/native-image/.* --exclude-config .*/libs/netty-buffer-4.0.0.Final.jar ^/META-INF/native-image/.* --exclude-config .*/libs/netty-codec-http-4.0.0.Final.jar ^/META-INF/native-image/.* --exclude-config .*/libs/netty-handler-4.0.0.Final.jar ^/META-INF/native-image/.* --exclude-config .*/libs/netty-common-4.0.0.Final.jar ^/META-INF/native-image/.* --exclude-config .*/libs/netty-codec-http2-4.0.0.Final.jar ^/META-INF/native-image/.* -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -o application -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile,/home/app/config-dirs/io.netty/netty-buffer/4.0.0.Final,/home/app/config-dirs/io.netty/netty-common/4.0.0.Final,/home/app/config-dirs/io.netty/netty-codec-http/4.0.0.Final,/home/app/config-dirs/io.netty/netty-transport/4.0.0.Final,/home/app/config-dirs/io.netty/netty-handler/4.0.0.Final,/home/app/config-dirs/io.netty/netty-codec-http2/4.0.0.Final,/home/app/config-dirs/ch.qos.logback/logback-classic/4.0.0 demo.app.Application
 FROM cgr.dev/chainguard/wolfi-base:latest
-RUN apk --no-cache update && apk add libstdc++
 EXPOSE 8080
 COPY --link --from=graalvm /home/app/application /app/application
 ENTRYPOINT ["/app/application"]

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -77,7 +77,7 @@ COPY --link config-dirs/generateResourcesConfigFile /home/app/config-dirs/genera
 COPY --link config-dirs/io.netty/netty-common/4.0.0.Final /home/app/config-dirs/io.netty/netty-common/4.0.0.Final
 COPY --link config-dirs/ch.qos.logback/logback-classic/4.0.0 /home/app/config-dirs/ch.qos.logback/logback-classic/4.0.0
 RUN native-image --exclude-config .*/libs/netty-transport-4.0.0.Final.jar ^/META-INF/native-image/.* --exclude-config .*/libs/netty-buffer-4.0.0.Final.jar ^/META-INF/native-image/.* --exclude-config .*/libs/netty-codec-http-4.0.0.Final.jar ^/META-INF/native-image/.* --exclude-config .*/libs/netty-handler-4.0.0.Final.jar ^/META-INF/native-image/.* --exclude-config .*/libs/netty-common-4.0.0.Final.jar ^/META-INF/native-image/.* --exclude-config .*/libs/netty-codec-http2-4.0.0.Final.jar ^/META-INF/native-image/.* -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -o application -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile,/home/app/config-dirs/io.netty/netty-buffer/4.0.0.Final,/home/app/config-dirs/io.netty/netty-common/4.0.0.Final,/home/app/config-dirs/io.netty/netty-codec-http/4.0.0.Final,/home/app/config-dirs/io.netty/netty-transport/4.0.0.Final,/home/app/config-dirs/io.netty/netty-handler/4.0.0.Final,/home/app/config-dirs/io.netty/netty-codec-http2/4.0.0.Final,/home/app/config-dirs/ch.qos.logback/logback-classic/4.0.0 demo.app.Application
-FROM frolvlad/alpine-glibc:alpine-${DefaultVersions.ALPINE}
+FROM cgr.dev/chainguard/wolfi-base:latest
 RUN apk --no-cache update && apk add libstdc++
 EXPOSE 8080
 COPY --link --from=graalvm /home/app/application /app/application

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -16,7 +16,7 @@ class DockerNativeFunctionalTest extends AbstractEagerConfiguringFunctionalTest 
     String defaultBaseImage = 'cgr.dev/chainguard/wolfi-base:latest'
 
     @Lazy
-    String defaultDockerFrom = { -> "FROM $defaultBaseImage" + (System.properties['os.arch'] == "aarch64" ? '' : '\nRUN apk --no-cache update && apk add libstdc++') }()
+    String defaultDockerFrom = "FROM $defaultBaseImage"
 
     def "test build docker native image for runtime #runtime"() {
         given:
@@ -161,7 +161,7 @@ micronaut:
         runtime << ['netty', 'lambda_provided']
     }
 
-    void 'use alpine-glibc by default and do not build mostly static native images'() {
+    void 'use wolfi-base by default and do not build mostly static native images'() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"
         buildFile << """
@@ -202,7 +202,7 @@ micronaut:
         dockerFileNative.find { s -> !s.contains('-H:+StaticExecutableWithDynamicLibC') }
     }
 
-    void 'do not use alpine-glibc for lambda_provided runtime'() {
+    void 'do not use wolfi-base for lambda_provided runtime'() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"
         buildFile << """

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -13,7 +13,7 @@ import spock.lang.Requires
 class DockerNativeFunctionalTest extends AbstractEagerConfiguringFunctionalTest {
 
     @Lazy
-    String defaultBaseImage = { -> System.properties['os.arch'] == "aarch64" ? 'cgr.dev/chainguard/wolfi-base:latest' : "frolvlad/alpine-glibc:alpine-${DefaultVersions.ALPINE}" }()
+    String defaultBaseImage = 'cgr.dev/chainguard/wolfi-base:latest'
 
     @Lazy
     String defaultDockerFrom = { -> "FROM $defaultBaseImage" + (System.properties['os.arch'] == "aarch64" ? '' : '\nRUN apk --no-cache update && apk add libstdc++') }()
@@ -239,7 +239,7 @@ micronaut:
         dockerfileNativeTask.outcome == TaskOutcome.SUCCESS
 
         and:
-        dockerFileNative.find { s -> !s.contains('FROM frolvlad/alpine-glibc:alpine-') }
+        dockerFileNative.find { s -> !s.contains('FROM cgr.dev/chainguard/wolfi-base:latest') }
         dockerFileNative.find { s -> !s.contains('-H:+StaticExecutableWithDynamicLibC') }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ shadow = "8.1.1"
 groovy = "3.0.19"
 spock = "2.1-groovy-3.0"
 oraclelinux = "9"
-alpine="3.16"
 graalvmPlugin = "0.9.28"
 micronaut-platform = "4.2.1" # This is the platform version, used in our tests
 micronaut-aot = "2.1.1"

--- a/minimal-plugin/build.gradle
+++ b/minimal-plugin/build.gradle
@@ -28,7 +28,6 @@ var writeVersions = tasks.register("writeDefaultVersions", WriteVersions) {
     versions.put('test-resources', libs.versions.micronaut.testresources)
     versions.put('openapi', libs.versions.micronaut.openapi)
     versions.put('oraclelinux', libs.versions.oraclelinux)
-    versions.put('alpine', libs.versions.alpine)
     packageName = 'io.micronaut.gradle'
 }
 

--- a/samples/test-resources/data-mysql/src/main/resources/application.yml
+++ b/samples/test-resources/data-mysql/src/main/resources/application.yml
@@ -16,3 +16,7 @@ datasources:
 #    driverClassName: org.postgresql.Driver
 #    schema-generate: CREATE_DROP
 #    dialect: POSTGRES
+test-resources:
+  containers:
+    mysql:
+      image-name: mysql:8.2

--- a/samples/test-resources/isolated-multiproject/app1/src/main/resources/application.yml
+++ b/samples/test-resources/isolated-multiproject/app1/src/main/resources/application.yml
@@ -11,3 +11,7 @@ datasources:
   default:
     schema-generate: CREATE_DROP
     dialect: MYSQL
+test-resources:
+  containers:
+    mysql:
+      image-name: mysql:8.2

--- a/samples/test-resources/multiproject/app1/src/main/resources/application.yml
+++ b/samples/test-resources/multiproject/app1/src/main/resources/application.yml
@@ -11,3 +11,7 @@ datasources:
   default:
     schema-generate: CREATE_DROP
     dialect: MYSQL
+test-resources:
+  containers:
+    mysql:
+      image-name: mysql:8.2

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1058,7 +1058,7 @@ dockerfileNative {
 }
 ----
 
-The compiled native binary will ultimately be copied into an `alpine-glibc` base image for X86_64, and `cgr.dev/chainguard/wolfi-base` for ARM.
+The compiled native binary will ultimately be copied into an `cgr.dev/chainguard/wolfi-base:latest` base image.
 These base images can be overridden via configuration see <<_base_image_and_pull_limits>> and <<_build_mostly_static_native_executables>>.
 
 [#_base_image_and_pull_limits]


### PR DESCRIPTION
This PR uses `cgr.dev/chainguard/wolfi-base:latest` as the default base image for all CPU architectures, not only for ARM, since it is multi-platform and a bit smaller than `frolvlad/alpine-glibc`