### PR TITLE
Update package names to support Amazon Linux 2023

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -430,7 +430,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
         if (buildStrategy == DockerBuildStrategy.LAMBDA) {
             from(new From(imageResolver.resolve()).withStage("graalvm"));
             environmentVariable("LANG", "en_US.UTF-8");
-            runCommand("yum install -y gcc gcc-c++ libc6-dev zlib1g-dev curl bash zlib zlib-devel zlib-static zip tar gzip");
+            runCommand("yum install -y gcc gcc-c++ curl bash zlib zlib-devel zlib-static zip tar gzip");
             String jdkVersion = getJdkVersion().get();
             String graalArch = getGraalArch().get();
             // https://download.oracle.com/graalvm/17/latest/graalvm-jdk-17_linux-aarch64_bin.tar.gz

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -430,7 +430,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
         if (buildStrategy == DockerBuildStrategy.LAMBDA) {
             from(new From(imageResolver.resolve()).withStage("graalvm"));
             environmentVariable("LANG", "en_US.UTF-8");
-            runCommand("yum install -y gcc gcc-c++ glibc-devel curl bash zlib zlib-devel zlib-static zip tar gzip");
+            runCommand("yum install -y gcc gcc-c++ glibc-devel curl-minimal bash zlib zlib-devel zlib-static zip tar gzip");
             String jdkVersion = getJdkVersion().get();
             String graalArch = getGraalArch().get();
             // https://download.oracle.com/graalvm/17/latest/graalvm-jdk-17_linux-aarch64_bin.tar.gz

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -430,7 +430,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
         if (buildStrategy == DockerBuildStrategy.LAMBDA) {
             from(new From(imageResolver.resolve()).withStage("graalvm"));
             environmentVariable("LANG", "en_US.UTF-8");
-            runCommand("yum install -y gcc gcc-c++ curl bash zlib zlib-devel zlib-static zip tar gzip");
+            runCommand("yum install -y gcc gcc-c++ glibc-devel curl bash zlib zlib-devel zlib-static zip tar gzip");
             String jdkVersion = getJdkVersion().get();
             String graalArch = getGraalArch().get();
             // https://download.oracle.com/graalvm/17/latest/graalvm-jdk-17_linux-aarch64_bin.tar.gz

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -742,7 +742,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
             String baseImage = getBaseImage().getOrNull();
 
             if (strategy == DockerBuildStrategy.LAMBDA && baseImage == null) {
-                baseImage = "amazonlinux:2";
+                baseImage = "amazonlinux:2023";
             } else if (baseImage == null) {
                 baseImage = "cgr.dev/chainguard/wolfi-base:latest";
             }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -104,7 +104,7 @@ micronaut:
         where:
         runtime           | nativeImage
         "netty"           | "FROM ghcr.io/graalvm/native-image-community:17-ol${DefaultVersions.ORACLELINUX}"
-        "lambda_provided" | 'FROM amazonlinux:2 AS graalvm'
+        "lambda_provided" | 'FROM amazonlinux:2023 AS graalvm'
         "jetty"           | "FROM ghcr.io/graalvm/native-image-community:17-ol${DefaultVersions.ORACLELINUX}"
     }
 
@@ -502,7 +502,7 @@ class Application {
         where:
         runtime           | nativeImage
         "netty"           | "FROM ghcr.io/graalvm/native-image-community:17-ol${DefaultVersions.ORACLELINUX}"
-        "lambda_provided" | 'FROM amazonlinux:2 AS graalvm'
+        "lambda_provided" | 'FROM amazonlinux:2023 AS graalvm'
         "jetty"           | "FROM ghcr.io/graalvm/native-image-community:17-ol${DefaultVersions.ORACLELINUX}"
     }
 

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
@@ -236,7 +236,7 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
             }
 
             dockerfileNative {
-                baseImage('internal.proxy.com/amazonlinux:2')
+                baseImage('internal.proxy.com/amazonlinux:2023')
             }
         """
 
@@ -250,7 +250,7 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
         dockerfileNativeTask.outcome == TaskOutcome.SUCCESS
 
         and:
-        dockerFileNative.find() { it.contains('internal.proxy.com/amazonlinux:2') }
+        dockerFileNative.find() { it.contains('internal.proxy.com/amazonlinux:2023') }
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/279")
@@ -298,7 +298,7 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
         dockerfileNativeTask.outcome == TaskOutcome.SUCCESS
 
         and:
-        dockerFileNative.find() { it.contains('amazonlinux:2') }
+        dockerFileNative.find() { it.contains('amazonlinux:2023') }
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/pull/537")

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1071,7 +1071,7 @@ If you wish to switch to using a different base image (for example to use your o
 ----
 dockerfileNative {
     // Use the image from the Amazon ECR Public Gallery
-    baseImage.set("public.ecr.aws/amazonlinux/amazonlinux:2")
+    baseImage.set("public.ecr.aws/amazonlinux/amazonlinux:2023")
 }
 ----
 


### PR DESCRIPTION
Unfortunately, libc6-dev and zlib1g-dev are not available in the Amazon Linux 2023 repository. Instead install the zlib-devel and glibc-devel packages, which are equivalent to zlib1g-dev and libc6-dev, respectively. This should be backwards compatible with Amazon Linux 2 and will also allow for using the amazonlinux:latest tag.
