### PR TITLE
Disable caching classpath inspector

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/ApplicationClasspathInspector.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/ApplicationClasspathInspector.java
@@ -18,7 +18,6 @@ package io.micronaut.gradle;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -26,6 +25,7 @@ import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -34,7 +34,7 @@ import java.io.PrintWriter;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@CacheableTask
+@DisableCachingByDefault(because = "Not worth caching")
 public abstract class ApplicationClasspathInspector extends DefaultTask {
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)


### PR DESCRIPTION
Disabled caching for the inspectClasspath task, as it's not worth caching