### PR TITLE
Upgrade to Native Build Tools 0.10.0

### DIFF
--- a/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -9,13 +9,11 @@ import io.micronaut.gradle.SourceSetConfigurerRegistry;
 import io.micronaut.gradle.internal.AutomaticDependency;
 import org.graalvm.buildtools.gradle.NativeImagePlugin;
 import org.graalvm.buildtools.gradle.dsl.GraalVMExtension;
-import org.graalvm.buildtools.gradle.dsl.GraalVMReachabilityMetadataRepositoryExtension;
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
 import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.DependencySet;
-import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
@@ -69,8 +67,6 @@ public class MicronautGraalPlugin implements Plugin<Project> {
             nativeLambdaExtension.getLambdaRuntimeClassName().convention(nativeLambdaExtension.getLambdaRuntime().map(NativeLambdaRuntime::getMainClassName));
         });
         GraalVMExtension graal = project.getExtensions().findByType(GraalVMExtension.class);
-        GraalVMReachabilityMetadataRepositoryExtension reachability = ((ExtensionAware) graal).getExtensions().getByType(GraalVMReachabilityMetadataRepositoryExtension.class);
-        reachability.getEnabled().convention(true);
         graal.getBinaries().configureEach(options ->
                 {
                     options.resources(rsrc -> rsrc.autodetection(inf -> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,10 +7,10 @@ shadow = "8.1.1"
 groovy = "3.0.20"
 spock = "2.1-groovy-3.0"
 oraclelinux = "9"
-graalvmPlugin = "0.9.28"
+graalvmPlugin = "0.10.0"
 micronaut-platform = "4.2.1" # This is the platform version, used in our tests
 micronaut-aot = "2.2.0"
-micronaut-testresources = "2.3.2"
+micronaut-testresources = "2.3.3"
 micronaut-openapi = "6.5.1"
 mockserver = "5.15.0"
 log4j2 = { require = "2.17.1", reject = ["]0, 2.17["] }


### PR DESCRIPTION
This version enabled the metadata repository by default so we can remove the configuration we had to do this.

In addition this sneaks in a test resources upgrade.