### PR TITLE
Restore "resources" layer

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
@@ -71,6 +71,11 @@ public class MicronautDockerPlugin implements Plugin<Project> {
                 layer.getLayerKind().set(LayerKind.APP);
                 layer.getFiles().from(runnerJar);
             });
+            image.addLayer(layer -> {
+                layer.getLayerKind().set(LayerKind.EXPANDED_RESOURCES);
+                layer.getFiles().from(project.getExtensions().getByType(SourceSetContainer.class)
+                    .getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput().getResourcesDir());
+            });
         });
     }
 

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/model/LayerKind.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/model/LayerKind.java
@@ -19,7 +19,8 @@ public enum LayerKind {
     PROJECT_LIBS("project_libs", "libs"),
     SNAPSHOT_LIBS("snapshot_libs", "libs"),
     LIBS("libs", "libs"),
-    APP("app", "");
+    APP("app", ""),
+    EXPANDED_RESOURCES("resources", "resources");
 
     private final String sourceDirName;
     private final String targetDirName;

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
@@ -198,6 +198,7 @@ class Application {
 WORKDIR /home/alternate
 COPY --link layers/libs /home/alternate/libs
 COPY --link layers/app /home/alternate/
+COPY --link layers/resources /home/alternate/resources
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/home/alternate/application.jar"]
 """
@@ -252,6 +253,7 @@ class Application {
 WORKDIR /home/app
 COPY layers/libs /home/app/libs
 COPY layers/app /home/app/
+COPY layers/resources /home/app/resources
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
 """

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -585,6 +585,7 @@ FROM ghcr.io/graalvm/native-image-community:17-ol${DefaultVersions.ORACLELINUX} 
 WORKDIR /home/alternate
 COPY --link layers/libs /home/alternate/libs
 COPY --link layers/app /home/alternate/
+COPY --link layers/resources /home/alternate/resources
 RUN mkdir /home/alternate/config-dirs
 RUN mkdir -p /home/alternate/config-dirs/generateResourcesConfigFile
 RUN mkdir -p /home/alternate/config-dirs/io.netty/netty-common/4.0.0.Final
@@ -692,6 +693,7 @@ WORKDIR /home/app
 COPY --link layers/libs /home/app/libs
 COPY --link server.iprof /home/app/server.iprof
 COPY --link layers/app /home/app/
+COPY --link layers/resources /home/app/resources
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
 """
@@ -706,6 +708,7 @@ WORKDIR /home/app
 COPY --link layers/libs /home/app/libs
 COPY --link server.iprof /home/app/server.iprof
 COPY --link layers/app /home/app/
+COPY --link layers/resources /home/app/resources
 RUN mkdir /home/app/config-dirs
 RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
 COPY --link config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
@@ -768,6 +771,7 @@ WORKDIR /home/app
 COPY --link layers/libs /home/app/libs
 COPY --link server.iprof /home/app/server.iprof
 COPY --link layers/app /home/app/
+COPY --link layers/resources /home/app/resources
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
 """


### PR DESCRIPTION
This layer is actually required for regular docker images (no optimized/AOT) since the jars which are included are not the regular jars.

Fixes #938