### PR TITLE
Add glibc-langpack-en to Native Lambda image

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -430,7 +430,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
         if (buildStrategy == DockerBuildStrategy.LAMBDA) {
             from(new From(imageResolver.resolve()).withStage("graalvm"));
             environmentVariable("LANG", "en_US.UTF-8");
-            runCommand("yum install -y gcc gcc-c++ glibc-devel curl-minimal bash zlib zlib-devel zlib-static zip tar gzip");
+            runCommand("yum install -y gcc gcc-c++ glibc-devel glibc-langpack-en curl-minimal bash zlib zlib-devel zlib-static zip tar gzip");
             String jdkVersion = getJdkVersion().get();
             String graalArch = getGraalArch().get();
             // https://download.oracle.com/graalvm/17/latest/graalvm-jdk-17_linux-aarch64_bin.tar.gz


### PR DESCRIPTION
We reached out to Amazon to check that we are installing the correct yum packages after the move to amazonlinux:2023

They came back with;

> I also recommend installing glibc-langpack-en package to AmazonLinux2023, as java can’t read Unicode filenames without it.

This PR does just that