### PR TITLE
bug: Fix the Azul API url again

### DIFF
--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCCheckpointDockerfile.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCCheckpointDockerfile.java
@@ -226,6 +226,7 @@ public abstract class CRaCCheckpointDockerfile extends Dockerfile {
             &latest=true\
             &release_status=ga\
             &certifications=tck\
+            &archive_type=tar.gz\
             &page=1\
             &page_size=100""".formatted(javaVersion, os, arch);
     }

--- a/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
+++ b/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
@@ -136,7 +136,7 @@ class CracCustomizationSpec extends BaseCracGradleBuildSpec {
         def result = build('dockerfileCrac', 'checkpointDockerfile', '-s')
         then:
         result.output.contains("BUILD SUCCESSFUL")
-        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains("https://api.azul.com/metadata/v1/zulu/packages/?java_version=$javaVersion&os=$MicronautCRaCPlugin.DEFAULT_OS&arch=$expectedArch&crac_supported=true&java_package_type=jdk&latest=true&release_status=ga&certifications=tck&page=1&page_size=100")
+        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains("https://api.azul.com/metadata/v1/zulu/packages/?java_version=$javaVersion&os=$MicronautCRaCPlugin.DEFAULT_OS&arch=$expectedArch&crac_supported=true&java_package_type=jdk&latest=true&release_status=ga&certifications=tck&archive_type=tar.gz&page=1&page_size=100")
     }
 
     void "default CRaC URL returns a single JDK"() {
@@ -165,7 +165,7 @@ class CracCustomizationSpec extends BaseCracGradleBuildSpec {
 
         then:
         result.output.contains("BUILD SUCCESSFUL")
-        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains("https://api.azul.com/metadata/v1/zulu/packages/?java_version=$javaVersion&os=$configuredOs&arch=$MicronautCRaCPlugin.ARM_ARCH&crac_supported=true&java_package_type=jdk&latest=true&release_status=ga&certifications=tck&page=1&page_size=100")
+        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains("https://api.azul.com/metadata/v1/zulu/packages/?java_version=$javaVersion&os=$configuredOs&arch=$MicronautCRaCPlugin.ARM_ARCH&crac_supported=true&java_package_type=jdk&latest=true&release_status=ga&certifications=tck&archive_type=tar.gz&page=1&page_size=100")
     }
 
     void "Weird java versions cause an error"() {


### PR DESCRIPTION
Azul have introduced different packages for their CRaC JDK.

The first one in the list is a .deb package which we then try to unpack (and fail as it's not a tgz)

The fix here is to supply the new archive_type argument to the API to go back to a single result