### PR TITLE
Mark kotlinProcessors as unresolvable

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
@@ -72,7 +72,7 @@ public class MicronautKotlinSupport {
         PluginManager pluginManager = project.getPluginManager();
         final TaskContainer tasks = project.getTasks();
         project.getConfigurations().create(KOTLIN_PROCESSORS, conf -> {
-            conf.setCanBeConsumed(false);
+            conf.setCanBeResolved(false);
             conf.setCanBeConsumed(false);
         });
         tasks.withType(KotlinCompile.class).configureEach(kotlinCompile -> {


### PR DESCRIPTION
I believe this is a typo, and instead of setCanBeConsumed twice, one should be setCanBeResolved.

This pattern can be seen in other configurations ie:

https://github.com/micronaut-projects/micronaut-gradle-plugin/blob/2d20a5128c52aa997a36aa5d0a748f71aa6b334a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java#L78-L80

Closes https://github.com/micronaut-projects/micronaut-core/issues/10752