### PR TITLE
Rename testresources to testResourcesService in doc

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1637,7 +1637,7 @@ plugins {
 }
 
 dependencies {
-    testresources(project(":shared-testresources"))           // <2>
+    testResourcesService(project(":shared-testresources"))           // <2>
 }
 ----
 <1> Use the test resources consumer plugin instead


### PR DESCRIPTION
Per https://github.com/micronaut-projects/micronaut-gradle-plugin/pull/508:

> This PR also renames the `testresources` configuration to `testResourcesService` for clarity (in a backwards compatible way). T