### PR TITLE
Remove micronaut-docs-asciidoc-extensions

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,7 +8,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.micronaut.docs:micronaut-docs-asciidoc-extensions:1.0.25'
     implementation 'org.asciidoctor:asciidoctor-gradle-jvm:4.0.2'
     implementation 'com.gradle.publish:plugin-publish-plugin:1.2.1'
     implementation 'pl.droidsonroids.gradle.jacoco:pl.droidsonroids.gradle.jacoco:1.0.12'


### PR DESCRIPTION
This dependency is no longer available on the Gradle plugin portal and makes the build fail.

See https://blog.gradle.org/portal-jcenter-impact for context.

I removed the dependency and tested docs generation as well as a user application, and I noticed no difference, so I guess it was simply redundant.