### PR TITLE
Micronaut openapi 6.13.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ tomlj = "1.1.1"
 micronaut-platform = "4.6.3" # This is the platform version, used in our tests
 micronaut-aot = "2.5.0"
 micronaut-testresources = "2.6.2"
-micronaut-openapi = "6.13.0"
+micronaut-openapi = "6.13.1"
 
 [libraries]
 # Core

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/DefaultOpenApiExtension.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/DefaultOpenApiExtension.java
@@ -123,7 +123,7 @@ public abstract class DefaultOpenApiExtension implements OpenApiExtension {
         spec.getFluxForArrays().convention(false);
         spec.getSerializationFramework().convention(DEFAULT_SERIALIZATION_FRAMEWORK);
         spec.getAlwaysUseGenerateHttpResponse().convention(false);
-        spec.getGenerateHttpResponseWhereRequired().convention(false);
+        spec.getGenerateHttpResponseWhereRequired().convention(true);
         spec.getDateTimeFormat().convention("ZONED_DATETIME");
         spec.getLang().convention("java");
         spec.getGenerateSwaggerAnnotations().convention(false);


### PR DESCRIPTION
Fix `generateHttpResponseWhereRequired` property default value