### PR TITLE
Gradle Configuration Cache fails to caches run task

### DIFF
--- a/functional-tests/src/test/groovy/io/micronaut/gradle/RuntimeDependenciesSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/RuntimeDependenciesSpec.groovy
@@ -23,7 +23,7 @@ class RuntimeDependenciesSpec extends AbstractEagerConfiguringFunctionalTest {
             }
             
             micronaut {
-                version "$shadowVersion"
+                version "$micronautVersion"
                 runtime "$runtime"                
             }
             

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
@@ -114,13 +114,13 @@ public class MicronautMinimalApplicationPlugin implements Plugin<Project> {
                     Map<String, Object> sysProps = new LinkedHashMap<>();
                     sysProps.put("micronaut.io.watch.restart", true);
                     sysProps.put("micronaut.io.watch.enabled", true);
+                    FileCollection sourceDirectories = sourceSet.getAllSource().getSourceDirectories();
                     //noinspection Convert2Lambda
                     javaExec.doFirst(new Action<>() {
                         @Override
                         public void execute(Task workaroundEagerSystemProps) {
-                            String watchPaths = sourceSet
-                                    .getAllSource()
-                                    .getSrcDirs()
+                            String watchPaths = sourceDirectories
+                                    .getFiles()
                                     .stream()
                                     .map(File::getPath)
                                     .collect(Collectors.joining(","));
@@ -205,12 +205,12 @@ public class MicronautMinimalApplicationPlugin implements Plugin<Project> {
                     "--target", "io.micronaut.gcp.function.http.HttpFunction",
                     "--port", 8080
             ));
+            SourceSet sourceSet = PluginsHelper.findSourceSets(p).getByName("main");
+            SourceSetOutput output = sourceSet.getOutput();
+            String runtimeClasspath = project.files(project.getConfigurations().getByName("runtimeClasspath"),
+                    output
+            ).getAsPath();
             run.doFirst(t -> {
-                SourceSet sourceSet = PluginsHelper.findSourceSets(p).getByName("main");
-                SourceSetOutput output = sourceSet.getOutput();
-                String runtimeClasspath = project.files(project.getConfigurations().getByName("runtimeClasspath"),
-                        output
-                ).getAsPath();
                 ((JavaExec) t).args("--classpath",
                         runtimeClasspath
                 );


### PR DESCRIPTION
Fixes #1063 

As the [gradle documentation](https://docs.gradle.org/8.10/userguide/configuration_cache.html#config_cache:requirements:disallowed_types) states:

> Gradle model types (e.g. Gradle, Settings, Project, SourceSet, Configuration etc…​) are usually used to carry some task input that should be explicitly and precisely declared instead.

> For example, if you reference a Project in order to get the project.version at execution time, you should instead directly declare the project version as an input to your task using a Property<String>. Another example would be to reference a SourceSet to later get the source files, the compilation classpath or the outputs of the source set. You should instead declare these as a FileCollection input and reference just that.

I verified the changes by publishing the new version to my local maven registry and following the reproduction steps outlined in the issue. Unfortunately I'm unable to verify the changes to the google cloud function runtime.

Please let me know if any further work is required!