### PR TITLE
Add ability to pass system properties/env vars to test resources service

### DIFF
--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -264,6 +264,9 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
             task.getStandalone().set(isStandalone);
             task.getClassDataSharingDir().convention(cdsDir);
             task.getUseClassDataSharing().convention(JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17));
+            task.getSystemProperties().convention(config.getServerSystemProperties());
+            task.getEnvironment().convention(config.getServerEnvironment());
+            task.getDebugServer().convention(config.getDebugServer());
         });
     }
 

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -23,6 +23,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
@@ -173,6 +174,12 @@ public abstract class StartTestResourcesService extends DefaultTask {
     @Internal
     public abstract DirectoryProperty getClassDataSharingDir();
 
+    @Input
+    public abstract MapProperty<String, String> getSystemProperties();
+
+    @Input
+    public abstract MapProperty<String, String> getEnvironment();
+
     @Inject
     protected abstract ExecOperations getExecOperations();
 
@@ -219,6 +226,8 @@ public abstract class StartTestResourcesService extends DefaultTask {
                         spec.setClasspath(getObjects().fileCollection().from(classpath));
                         spec.setJvmArgs(processParameters.getJvmArguments());
                         processParameters.getSystemProperties().forEach(spec::systemProperty);
+                        getSystemProperties().get().forEach(spec::systemProperty);
+                        getEnvironment().get().forEach(spec::environment);
                         processParameters.getArguments().forEach(spec::args);
                     });
                 } catch (GradleException e) {

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/TestResourcesConfiguration.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/TestResourcesConfiguration.java
@@ -17,6 +17,7 @@ package io.micronaut.gradle.testresources;
 
 import io.micronaut.testresources.buildtools.KnownModules;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 
 /**
@@ -110,4 +111,23 @@ public interface TestResourcesConfiguration extends KnownModules {
      * @return the server idle timeout
      */
     Property<Integer> getServerIdleTimeoutMinutes();
+
+    /**
+     * System properties to be set on the test resources service JVM.
+     * @return the system properties
+     */
+    MapProperty<String, String> getServerSystemProperties();
+
+    /**
+     * Environment variables to be set on the test resources service JVM.
+     * @return the environment variables
+     */
+    MapProperty<String, String> getServerEnvironment();
+
+    /**
+     * Set this property to true if you want to start the test resources service
+     * with a debugger attached.
+     * @return the debug property
+     */
+    Property<Boolean> getDebugServer();
 }


### PR DESCRIPTION
This commit adds 2 configuration properties for the test resources service, making it possible to pass either system properties or environment variables at startup.

This will be useful in order to configure the logging level of the server. For example, one can add:

```
micronaut {
   testResources {
      serverSystemProperties.put("logger.levels.io.micronaut", "TRACE")
   }
}
```