### PR TITLE
Fix AOT application classpath

### DIFF
--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/AotShadowSupport.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/AotShadowSupport.java
@@ -42,7 +42,8 @@ class AotShadowSupport {
                                   TaskProvider<Jar> optimizedJar) {
         project.afterEvaluate(unused -> {
             JavaApplication javaApplication = project.getExtensions().findByType(JavaApplication.class);
-            TaskProvider<ShadowJar> shadowProvider = tasks.register(optimizedJar.getName() + "All", ShadowJar.class, shadow -> {
+            var taskName = optimizedJar.getName() + "All";
+            TaskProvider<ShadowJar> shadowProvider = tasks.register(taskName, ShadowJar.class, shadow -> {
                 shadow.setGroup(SHADOW_GROUP);
                 shadow.setDescription("Creates a fat jar including the Micronaut AOT optimizations");
                 shadow.getArchiveClassifier().convention("all-optimized");

--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -377,7 +377,6 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
             c.setCanBeResolved(false);
             c.setCanBeConsumed(false);
         });
-        aotOptimizerRuntimeClasspath.extendsFrom(aotPlugins);
         Configuration aotApplication = configurations.create("aotApplication", c -> {
             c.setCanBeResolved(false);
             c.setCanBeConsumed(false);
@@ -389,6 +388,7 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
             c.extendsFrom(aotApplication);
             c.getDependencies().add(project.getDependencies().create(project));
         });
+        aotApplicationClasspath.extendsFrom(aotPlugins);
         return new Configurations(
                 aotOptimizerRuntimeClasspath,
                 aotApplication,

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/ShadowPluginSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/ShadowPluginSupport.java
@@ -17,8 +17,14 @@ package io.micronaut.gradle;
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar;
 import org.gradle.api.Project;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ShadowPluginSupport {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShadowPluginSupport.class);
+
     public static final String OLD_SHADOW_PLUGIN = "com.github.johnrengelman.shadow";
     public static final String SHADOW_PLUGIN = "com.gradleup.shadow";
 
@@ -26,8 +32,18 @@ public class ShadowPluginSupport {
     }
 
     public static void withShadowPlugin(Project p, Runnable action) {
-        p.getPluginManager().withPlugin(OLD_SHADOW_PLUGIN, unused -> action.run());
-        p.getPluginManager().withPlugin(SHADOW_PLUGIN, unused -> action.run());
+        var applied = new AtomicBoolean(false);
+        p.getPluginManager().withPlugin(OLD_SHADOW_PLUGIN, unused -> {
+            LOGGER.warn("The legacy Shadow plugin (id '{}') is deprecated. Please use the Gradle Shadow plugin instead (id = '{}')", OLD_SHADOW_PLUGIN, SHADOW_PLUGIN);
+            applied.set(true);
+            action.run();
+        });
+        p.getPluginManager().withPlugin(SHADOW_PLUGIN, unused -> {
+            if (applied.get()) {
+                return;
+            }
+            action.run();
+        });
     }
 
     /**

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/ShadowPluginSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/ShadowPluginSupport.java
@@ -19,12 +19,14 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar;
 import org.gradle.api.Project;
 
 public class ShadowPluginSupport {
+    public static final String OLD_SHADOW_PLUGIN = "com.github.johnrengelman.shadow";
     public static final String SHADOW_PLUGIN = "com.gradleup.shadow";
 
     private ShadowPluginSupport() {
     }
 
     public static void withShadowPlugin(Project p, Runnable action) {
+        p.getPluginManager().withPlugin(OLD_SHADOW_PLUGIN, unused -> action.run());
         p.getPluginManager().withPlugin(SHADOW_PLUGIN, unused -> action.run());
     }
 


### PR DESCRIPTION
The AOT application classpath didn't extend from `aotPlugins`, which could cause strange errors during classloading of the AOT plugins.

I have been able to test the fix on a local project, but testing in the build plugins themselves proves difficult (requires a big setup).

Without the change, running a build with a custom plugin yields:

```
Caused by: java.util.ServiceConfigurationError: io.micronaut.aot.core.AOTCodeGenerator: com.foo.MyInstropspector not a subtype
        at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:593)
        at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1244)
        at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1273)
        at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1309)
        at java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1393)
```

with this change, it passes.
