### PR TITLE
Offer the option to generate only APIs/models

### DIFF
--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiSpec.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiSpec.java
@@ -118,4 +118,8 @@ public interface OpenApiSpec {
     Property<Boolean> getAllowUnicodeIdentifiers();
 
     Property<Boolean> getPrependFormOrBodyParameters();
+
+    Property<Boolean> getGenerateApis();
+
+    Property<Boolean> getGenerateModels();
 }

--- a/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiServerGeneratorSpec.groovy
+++ b/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiServerGeneratorSpec.groovy
@@ -50,6 +50,97 @@ class OpenApiServerGeneratorSpec extends AbstractOpenApiGeneratorSpec {
         file("build/classes/java/main/io/micronaut/openapi/model/Pet.class").exists()
     }
 
+    def "can generate an java OpenAPI server (API only)"() {
+        given:
+        settingsFile << "rootProject.name = 'openapi-server'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.openapi"
+            }
+            
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+                testRuntime "junit5"
+                openapi {
+                    server(file("petstore.json")) {
+                        generateModels = false
+                    }
+                }
+            }
+            
+            $repositoriesBlock
+            mainClassName="example.Application"
+
+            dependencies {
+                implementation "io.micronaut.security:micronaut-security"
+                implementation "io.micronaut.serde:micronaut-serde-jackson"
+            }
+        """
+
+        withPetstore()
+
+        when:
+        def result = build('test')
+
+        then:
+        result.task(":generateServerOpenApiApis").outcome == TaskOutcome.SUCCESS
+        result.task(":generateServerOpenApiModels").outcome == TaskOutcome.SKIPPED
+        result.task(":compileJava").outcome == TaskOutcome.FAILED
+
+        and:
+        file("build/generated/openapi/generateServerOpenApiApis/src/main/java/io/micronaut/openapi/api/PetApi.java").exists()
+        !file("build/generated/openapi/generateServerOpenApiModels/src/main/java/io/micronaut/openapi/model/Pet.java").exists()
+        !file("build/classes/java/main/io/micronaut/openapi/model/Pet.class").exists()
+    }
+
+    def "can generate an java OpenAPI server (models only)"() {
+        given:
+        settingsFile << "rootProject.name = 'openapi-server'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.openapi"
+            }
+            
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+                testRuntime "junit5"
+                openapi {
+                    server(file("petstore.json")) {
+                        generateApis = false
+                    }
+                }
+            }
+            
+            $repositoriesBlock
+            mainClassName="example.Application"
+
+            dependencies {
+                implementation "io.micronaut.security:micronaut-security"
+                implementation "io.micronaut.serde:micronaut-serde-jackson"
+            }
+        """
+
+        withPetstore()
+
+        when:
+        def result = build('test')
+
+        then:
+        result.task(":generateServerOpenApiApis").outcome == TaskOutcome.SKIPPED
+        result.task(":generateServerOpenApiModels").outcome == TaskOutcome.SUCCESS
+        result.task(":compileJava").outcome == TaskOutcome.SUCCESS
+
+        and:
+        !file("build/generated/openapi/generateServerOpenApiApis/src/main/java/io/micronaut/openapi/api/PetApi.java").exists()
+        file("build/generated/openapi/generateServerOpenApiModels/src/main/java/io/micronaut/openapi/model/Pet.java").exists()
+        !file("build/classes/java/main/io/micronaut/openapi/api/PetApi.class").exists()
+        file("build/classes/java/main/io/micronaut/openapi/model/Pet.class").exists()
+    }
+
     def "can generate an java OpenAPI server implementation with properties"() {
         given:
         settingsFile << "rootProject.name = 'openapi-server'"


### PR DESCRIPTION
Note the calls to `task.setEnabled()` which have to be done because of a side effect in Gradle. Basically we use:

javaMain.srcDir(clientSpec.getGenerateApis().zip(client.flatMap(DefaultOpenApiExtension::mainSrcDir), this::ifEnabled));

which will create a task dependency on the `client` generation task independently of the result of the `enabled` flag.

Fixes #1055