### PR TITLE
Fix shadow plugin warning

### DIFF
--- a/functional-tests/src/test/groovy/io/micronaut/gradle/shadow/ShadowJarSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/shadow/ShadowJarSpec.groovy
@@ -82,6 +82,7 @@ public class Application implements Runnable {
         result.task(":shadowRun").outcome == TaskOutcome.SUCCESS
         shadowJar.exists()
         result.output.contains("Hello, all!")
+        result.output.contains("Please use the Gradle Shadow plugin instead")
 
         where:
         runtime           | micronautGradlePlugin
@@ -160,6 +161,7 @@ public class Application implements Runnable {
         result.task(":shadowRun").outcome == TaskOutcome.SUCCESS
         shadowJar.exists()
         result.output.contains("Hello, all!")
+        !result.output.contains("Please use the Gradle Shadow plugin instead")
 
         where:
         runtime           | micronautGradlePlugin

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/ShadowPluginSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/ShadowPluginSupport.java
@@ -33,12 +33,18 @@ public class ShadowPluginSupport {
 
     public static void withShadowPlugin(Project p, Runnable action) {
         var applied = new AtomicBoolean(false);
+        var hasNew = new AtomicBoolean(false);
         p.getPluginManager().withPlugin(OLD_SHADOW_PLUGIN, unused -> {
-            LOGGER.warn("The legacy Shadow plugin (id '{}') is deprecated. Please use the Gradle Shadow plugin instead (id = '{}')", OLD_SHADOW_PLUGIN, SHADOW_PLUGIN);
+            p.afterEvaluate(project -> {
+                if (!hasNew.get()) {
+                    LOGGER.warn("The legacy Shadow plugin (id '{}') is deprecated. Please use the Gradle Shadow plugin instead (id = '{}')", OLD_SHADOW_PLUGIN, SHADOW_PLUGIN);
+                }
+            });
             applied.set(true);
             action.run();
         });
         p.getPluginManager().withPlugin(SHADOW_PLUGIN, unused -> {
+            hasNew.set(true);
             if (applied.get()) {
                 return;
             }


### PR DESCRIPTION
The plugin warning was displayed even if the new plugin was applied, because the new plugin also uses the old shadow id for backwards compatibility. The fix is to check if the new shadow plugin is also applied, but it comes with a catch: if both are applied, then there can be a conflict, but it's likely to break with duplicate tasks anyway, so no big deal.