### PR TITLE
fix: Updated KaptArguments value from bool -> string to be compatible…

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
@@ -118,7 +118,7 @@ public class MicronautKotlinSupport {
             if (isIncremental) {
 
                 kaptExtension.arguments(options -> {
-                    options.arg("micronaut.processing.incremental", true);
+                    options.arg("micronaut.processing.incremental", "true");
                     final List<String> annotations = processingConfig.getAnnotations().getOrElse(Collections.emptyList());
                     if (!annotations.isEmpty()) {
                         options.arg("micronaut.processing.annotations", String.join(",", annotations));


### PR DESCRIPTION
… with the latest version

The latest KaptArguments interface accepts strings rather than `Any`. As a result, when updating a project to use Kotlin `2.2.0`, we get the following compilation error:

```
* What went wrong:
'void org.jetbrains.kotlin.gradle.dsl.KaptArguments.arg(java.lang.Object, java.lang.Object[])'

* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

* Exception is:
java.lang.NoSuchMethodError: 'void org.jetbrains.kotlin.gradle.dsl.KaptArguments.arg(java.lang.Object, java.lang.Object[])'
        at io.micronaut.gradle.MicronautKotlinSupport.lambda$configureKapt$7(MicronautKotlinSupport.java:121)
        ... REDACTED FOR LENGTH ....
```

---

Issue observed using...
* Kotlin `2.2.0`
* `io.micronaut.application` plugin version `4.5.4`

---

Links:
* Kotlin release notes: [link](https://github.com/JetBrains/kotlin/releases/tag/v2.2.0)
* Kotlin ticket re: changing KaptArguments: [link](https://youtrack.jetbrains.com/issue/KT-61928)