### PR TITLE
Fix for kotlin 2

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.internal.build.functional-testing.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.internal.build.functional-testing.gradle
@@ -41,7 +41,9 @@ tasks.withType(Test).configureEach { Test test ->
     repoProvider.version.set(version)
     test.jvmArgumentProviders.add(repoProvider)
     systemProperties.put("kotlinVersion", libs.versions.kotlin.get())
+    systemProperties.put("kotlin2Version", libs.versions.kotlin2.get())
     systemProperties.put("kspVersion", libs.versions.ksp.get())
+    systemProperties.put("ksp2Version", libs.versions.ksp2.get())
     systemProperties.put("shadowVersion", libs.versions.shadow.get())
 }
 

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
@@ -8,19 +8,23 @@ class KotlinLibraryFunctionalTest extends AbstractEagerConfiguringFunctionalTest
 
     @Shared
     private final String kotlinVersion = System.getProperty("kotlinVersion")
+    @Shared
+    private final String kotlin2Version = System.getProperty("kotlin2Version")
 
     @Shared
     private final String kspVersion = System.getProperty("kspVersion")
+    @Shared
+    private final String ksp2Version = System.getProperty("ksp2Version")
 
 
-    def "test apply defaults for micronaut-library and KSP with kotlin DSL for #plugin"() {
+    def "test apply defaults for micronaut-library and KSP with kotlin DSL for #plugin (Kotlin #kotlin, KSP #ksp)"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"
         buildFile.delete()
         kotlinBuildFile << """
             plugins {
-                id("org.jetbrains.kotlin.jvm") version("$kotlinVersion")
-                id("com.google.devtools.ksp") version "$kspVersion"
+                id("org.jetbrains.kotlin.jvm") version("$kotlin")
+                id("com.google.devtools.ksp") version "$ksp"
                 id("io.micronaut.$plugin")
             }
             
@@ -52,21 +56,23 @@ class Foo {}
         result.task(":assemble").outcome == TaskOutcome.SUCCESS
         new File(testProjectDir.root, "build/generated/ksp/main/classes/example")
                 .listFiles()
-                ?.find { it.name.endsWith(".class") && it.name.contains('$Definition')}
+                ?.find { it.name.endsWith(".class") && it.name.contains('$Definition') }
 
         where:
-        plugin << ['library', 'minimal.library']
+        plugin            | kotlin         | ksp
+        'library'         | kotlinVersion  | kspVersion
+        'minimal.library' | kotlin2Version | ksp2Version
     }
 
-    def "test apply defaults for micronaut-library and kotlin with kotlin DSL for #plugin"() {
+    def "test apply defaults for micronaut-library and kotlin with kotlin DSL for #plugin (Kotlin #kotlin)"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"
         buildFile.delete()
         kotlinBuildFile << """
             plugins {
-                id("org.jetbrains.kotlin.jvm") version("$kotlinVersion")
-                id("org.jetbrains.kotlin.kapt") version("$kotlinVersion")
-                id("org.jetbrains.kotlin.plugin.allopen") version("$kotlinVersion")
+                id("org.jetbrains.kotlin.jvm") version("$kotlin")
+                id("org.jetbrains.kotlin.kapt") version("$kotlin")
+                id("org.jetbrains.kotlin.plugin.allopen") version("$kotlin")
                 id("io.micronaut.$plugin")
             }
             
@@ -100,18 +106,20 @@ class Foo {}
                 .resolve('build/tmp/kapt3/classes/main/example/$Foo$Definition.class').toFile().exists()
 
         where:
-        plugin << ['library', 'minimal.library']
+        plugin            | kotlin
+        'library'         | kotlinVersion
+        'minimal.library' | kotlin2Version
     }
 
-    def "test custom sourceSet for micronaut-library and kotlin with kotlin DSL for #plugin"() {
+    def "test custom sourceSet for micronaut-library and kotlin with kotlin DSL for #plugin (Kotlin #kotlin)"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"
         buildFile.delete()
         kotlinBuildFile << """
             plugins {
-                id("org.jetbrains.kotlin.jvm") version("$kotlinVersion")
-                id("org.jetbrains.kotlin.kapt") version("$kotlinVersion")
-                id("org.jetbrains.kotlin.plugin.allopen") version("$kotlinVersion")
+                id("org.jetbrains.kotlin.jvm") version("$kotlin")
+                id("org.jetbrains.kotlin.kapt") version("$kotlin")
+                id("org.jetbrains.kotlin.plugin.allopen") version("$kotlin")
                 id("io.micronaut.$plugin")
             }
             
@@ -154,6 +162,8 @@ class Foo {}
                 .resolve('build/tmp/kapt3/classes/custom/example/$Foo$Definition.class').toFile().exists()
 
         where:
-        plugin << ['library', 'minimal.library']
+        plugin            | kotlin
+        'library'         | kotlinVersion
+        'minimal.library' | kotlin2Version
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
 kotlin = "1.9.25"
+kotlin2 = "2.2.10"
 ksp = "1.9.25-1.0.20"
+ksp2 = "2.2.10-2.0.2"
 docker = "9.4.0"
 diffplug = "4.3.0"
 shadow = "8.3.6"
@@ -30,7 +32,9 @@ graalvmPlugin = { module = "org.graalvm.buildtools:native-gradle-plugin", versio
 
 kotlin-allopen = { module = "org.jetbrains.kotlin:kotlin-allopen", version.ref = "kotlin" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin2-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin2" }
 ksp-gradlePlugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
+ksp2-gradlePlugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp2" }
 
 groovy-core = { module = "org.codehaus.groovy:groovy", version.ref = "groovy" }
 spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }


### PR DESCRIPTION
Not micronaut gradle plugin is incompatible with `kapt` plugin with version `2.2.10` because DSL was changed and now you can't use KaptArguments with non-string values.

KAPT 1.9.25:
<img width="516" height="194" alt="{624F2AED-FDDF-4EBC-815E-E0685E6A4B7B}" src="https://github.com/user-attachments/assets/08e0cd1d-4356-411d-85a5-4128aa5b5036" />


KAPT 2.2.10:

<img width="433" height="196" alt="{E255C809-6D83-4290-81FA-9743887B2D1A}" src="https://github.com/user-attachments/assets/0f743434-f9ad-4b66-904c-df89d00a2546" />

This is crittical error, because now you can't use micronaut gradle plugin with gradle 9.0 + kotlin 2 + kapt