### PR TITLE
Automatically add `junit-platform-launcher`

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
@@ -19,7 +19,7 @@ public enum MicronautTestRuntime {
      */
     JUNIT_5(MicronautExtension.mapOf(
             JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, List.of("org.junit.jupiter:junit-jupiter-api", "io.micronaut.test:micronaut-test-junit5"),
-            JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME, List.of("org.junit.jupiter:junit-jupiter-engine", "org.junit.jupiter:junit-platform-launcher")
+            JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME, List.of("org.junit.jupiter:junit-jupiter-engine", "org.junit.platform:junit-platform-launcher")
     ), true),
     /**
      * Spock 2.

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
@@ -1,11 +1,11 @@
 package io.micronaut.gradle;
 
+import org.gradle.api.plugins.JavaPlugin;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-
-import org.gradle.api.plugins.JavaPlugin;
 
 /**
  * An enum with the different supported test runtimes.
@@ -18,10 +18,8 @@ public enum MicronautTestRuntime {
      * JUnit 5.
      */
     JUNIT_5(MicronautExtension.mapOf(
-            JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME,
-            List.of("org.junit.jupiter:junit-jupiter-api", "io.micronaut.test:micronaut-test-junit5"),
-            JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME,
-            Collections.singletonList("org.junit.jupiter:junit-jupiter-engine")
+            JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, List.of("org.junit.jupiter:junit-jupiter-api", "io.micronaut.test:micronaut-test-junit5"),
+            JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME, List.of("org.junit.jupiter:junit-jupiter-engine", "org.junit.jupiter:junit-platform-launcher")
     ), true),
     /**
      * Spock 2.


### PR DESCRIPTION
Older Gradle releases used to add this dependency automatically. Since Gradle 8, this is no longer the case (see https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#manually_declaring_dependencies).

However, Native Build Tools used to leak this dependency, which caused other issues like duplicate entries on classpath. Since we upgraded to 0.11.1, this is no longer the case.

Therefore, users who upgrade may see an error if they don't add this dependency explicitly. To workaround this and make transition smoother, we're adding the dependency back implicitly.