### PR TITLE
Add experimental support for incremental native builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=4.5.6-SNAPSHOT
+projectVersion=4.6.0-SNAPSHOT
 projectGroup=io.micronaut.gradle
 
 title=Micronaut Gradle plugin

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
@@ -166,6 +166,12 @@ public abstract class MicronautExtension implements ExtensionAware {
     }
 
     /**
+     * Property which drives if incremental native builds should be enabled.
+     * @return the incremental property
+     */
+    public abstract Property<Boolean> getIncrementalNativeBuild();
+
+    /**
      * Allows configuring processing.
      * @param processingAction The processing action
      * @return This extension


### PR DESCRIPTION
This commit introduces a new flag on the `micronautBuild`:

- `incrementalNativeBuild = true`

When set, this triggers the creation of a base layer with all external dependencies, adds options specific to Micronaut to build the base layer, and configures the application layer to use the base layer.

The flag can also be enabled from command-line using:

`-Dgraalvm.native.incremental=true`

As of now, this feature is EXPERIMENTAL.