### PR TITLE
Fix compatibility with Shadow plugin 9.0.1+

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -93,7 +93,7 @@ public class MicronautComponentPlugin implements Plugin<Project> {
 
         ShadowPluginSupport.withShadowPlugin(project, () -> {
             configureTesting(project, micronautExtension, inspectRuntimeClasspath);
-            ShadowPluginSupport.mergeServiceFiles(project);
+            ShadowPluginSupport.configureDefaults(project);
         });
         PluginsHelper.registerVersionExtensions(PluginsHelper.KNOWN_VERSION_PROPERTIES, project);
 

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
@@ -186,7 +186,7 @@ public class MicronautMinimalApplicationPlugin implements Plugin<Project> {
             if (micronautRuntime == MicronautRuntime.GOOGLE_FUNCTION) {
                 configureGoogleCloudFunctionRuntime(project, p, dependencyHandler);
             }
-            ShadowPluginSupport.withShadowPlugin(project, () -> ShadowPluginSupport.mergeServiceFiles(project));
+            ShadowPluginSupport.withShadowPlugin(project, () -> ShadowPluginSupport.configureDefaults(project));
 
         });
     }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/ShadowPluginSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/ShadowPluginSupport.java
@@ -17,6 +17,7 @@ package io.micronaut.gradle;
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar;
 import org.gradle.api.Project;
+import org.gradle.api.file.DuplicatesStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,8 +59,15 @@ public class ShadowPluginSupport {
      * <a href="https://imperceptiblethoughts.com/shadow/configuration/merging/#merging-service-descriptor-files">Shadow: Merging Server Descriptor Files</a>
      * @param project Gradle Project
      */
-    public static void mergeServiceFiles(Project project) {
+    private static void mergeServiceFiles(Project project) {
         project.getTasks().withType(ShadowJar.class).configureEach(ShadowPluginSupport::mergeServiceFiles);
+    }
+
+    public static void configureDefaults(Project project) {
+        project.getTasks().withType(ShadowJar.class).configureEach(jar -> {
+            jar.setDuplicatesStrategy(DuplicatesStrategy.WARN);
+            mergeServiceFiles(jar);
+        });
     }
 
     // This method calls `mergeServiceFiles` reflectively, because the Shadow Plugin v9


### PR DESCRIPTION
The behavior of the Shadow plugin in 9.0.1 was changed to use EXCLUDE as the default duplicates strategy. This causes several issues, including missing service files. This commit fixes it by switching the default to WARN.

Fixes #1176