### PR TITLE
Support Java Launcher for test resources service

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1524,6 +1524,8 @@ micronaut {
         serverIdleTimeoutMinutes = 60 // if the server doesn't receive any request for this amount of time, it will be shut down
         sharedServer = true // false by default
         sharedServerNamespace = 'custom' // unset by default
+        javaLauncher = javaToolchainSpec // uses the project's toolchain if available, otherwise uses the same Java executable as Gradle
+        javaExecutable = '/usr/bin/java' // an alternative to javaLauncher, allows specifying the full path to the Java executable
     }
 }
 ----
@@ -1540,6 +1542,8 @@ micronaut {
         clientTimeout.set(60) // in seconds, maximum time to wait for resources to be available, 60s by default
         sharedServer.set(true) // false by default
         sharedServerNamespace.set("custom") // unset by default
+        javaLauncher.set(javaToolchainSpec) // uses the project's toolchain if available, otherwise uses the same Java executable as Gradle
+        javaExecutable.set("/usr/bin/java") // an alternative to javaLauncher, allows specifying the full path to the Java executable
     }
 }
 ----

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/TestResourcesConfiguration.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/TestResourcesConfiguration.java
@@ -19,6 +19,7 @@ import io.micronaut.testresources.buildtools.KnownModules;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.jvm.toolchain.JavaLauncher;
 
 /**
  * Configuration for the test resources plugin.
@@ -130,4 +131,22 @@ public interface TestResourcesConfiguration extends KnownModules {
      * @return the debug property
      */
     Property<Boolean> getDebugServer();
+
+    /**
+     * Sets the Java launcher for the test resources service.
+     * If the project sets a Java toolchain, the same launcher will be used,
+     * otherwise the service will be started with the same Java executable
+     * as the one which was used to start the Gradle build.
+     *
+     * @return the java launcher
+     */
+    Property<JavaLauncher> getJavaLauncher();
+
+    /**
+     * An alternative to {@link #getJavaLauncher()} in which you can
+     * specify the full path to the Java executable used to start the
+     * test resources service, instead of a toolchain definition.
+     * @return the path to the Java executable
+     */
+    Property<String> getJavaExecutable();
 }


### PR DESCRIPTION
This commit fixes an inconsistency in the way the test resources service was started. In practice for most projects the problem would go unnoticed, but we have test projects which highlight the problem.

Before this change, the test resources service was systematically started using the same Java executable as the one which was used to start Gradle itself. Therefore, if a project was configured to run Gradle with Java 17, but that the test resources service is compiled with Java 21, then it woudln't start. Similarly, if any dependency of the test resources service is not aligned with the JVM version of Gradle itself, this would fail.

This commit introduces an optional JavaLauncher property which lets the user specify the spec of the JVM to use. Alternatively, a path to a Java executable can also be configured in which case it takes precedence.