### PR TITLE
Add JUnit Platform Launcher to Spock tests

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
@@ -31,7 +31,8 @@ public enum MicronautTestRuntime {
             List.of(
                     "org.spockframework:spock-core",
                     "io.micronaut.test:micronaut-test-spock",
-                    "org.apache.groovy:groovy"
+                    "org.apache.groovy:groovy",
+                    "org.junit.platform:junit-platform-launcher"
             )
     ), true),
     /**


### PR DESCRIPTION
Fixes #1182

Also checked that this doesn't happen with kotest.