### PR TITLE
Fix issue using test-resources and configuration cache

### DIFF
--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -235,7 +235,7 @@ public abstract class StartTestResourcesService extends DefaultTask {
                     executable = javaLauncher.getExecutablePath().getAsFile().getAbsolutePath();
                 }
                 String finalExecutable = executable;
-                var logger = getProject().getLogger();
+                var logger = getLogger();
                 var result = getExecOperations().javaexec(spec -> {
                     if (finalExecutable != null) {
                         logger.info("Starting test resources service with Java at {}", finalExecutable);


### PR DESCRIPTION
In the reported [issue](https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/1202), getProject() prevents the use of the Gradle configuration cache. I tested this in my own project, and the proposed fix appears sufficient to make it work. 