### PR TITLE
Fix a typo in a method name. No behavior change.

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -166,7 +166,7 @@ public class MicronautComponentPlugin implements Plugin<Project> {
 
     private void configureMicronautBom(Project project, MicronautExtension micronautExtension) {
         Configuration micronautBoms = project.getConfigurations().getByName(MICRONAUT_BOMS_CONFIGURATION);
-        PluginsHelper.maybeAddMicronautPlaformBom(project, micronautBoms);
+        PluginsHelper.maybeAddMicronautPlatformBom(project, micronautBoms);
         var registry = project.getExtensions().getByType(SourceSetConfigurerRegistry.class);
         var knownSourceSets = new HashSet<SourceSet>();
         registry.register(sourceSet -> {

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/PluginsHelper.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/PluginsHelper.java
@@ -93,7 +93,7 @@ public abstract class PluginsHelper {
     private PluginsHelper() {
     }
 
-    public static void maybeAddMicronautPlaformBom(Project p, Configuration configuration) {
+    public static void maybeAddMicronautPlatformBom(Project p, Configuration configuration) {
         MicronautExtension micronautExtension = p.getExtensions().findByType(MicronautExtension.class);
         configuration.getDependencies().addAllLater(
                 micronautExtension.getImportMicronautPlatform().zip(PluginsHelper.findMicronautVersion(p), (usePlatform, version) -> {

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesConsumerPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesConsumerPlugin.java
@@ -62,7 +62,7 @@ public class MicronautTestResourcesConsumerPlugin implements Plugin<Project> {
     private Configuration createTestResourcesExtension(Project project) {
         ConfigurationContainer configurations = project.getConfigurations();
         Configuration boms = configurations.findByName(MICRONAUT_BOMS_CONFIGURATION);
-        PluginsHelper.maybeAddMicronautPlaformBom(project, boms);
+        PluginsHelper.maybeAddMicronautPlatformBom(project, boms);
         var testResourcesConfiguration = project.getConfigurations().create(MicronautTestResourcesPlugin.TESTRESOURCES_CONFIGURATION, conf -> {
             conf.extendsFrom(boms);
             conf.setCanBeConsumed(false);

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -408,7 +408,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
     private static Configuration createTestResourcesServerConfiguration(Project project) {
         ConfigurationContainer configurations = project.getConfigurations();
         Configuration boms = configurations.findByName(MICRONAUT_BOMS_CONFIGURATION);
-        PluginsHelper.maybeAddMicronautPlaformBom(project, boms);
+        PluginsHelper.maybeAddMicronautPlatformBom(project, boms);
         return configurations.create(TESTRESOURCES_CONFIGURATION, conf -> {
             conf.extendsFrom(boms);
             conf.setDescription("Dependencies for the Micronaut test resources service");


### PR DESCRIPTION
Fix a typo in a method name. No behavior change.
