### PR TITLE
fix: default HTTP server runtime dependencies to runtimeOnly

### DIFF
--- a/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/BaseCracGradleBuildSpec.groovy
+++ b/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/BaseCracGradleBuildSpec.groovy
@@ -61,6 +61,7 @@ abstract class BaseCracGradleBuildSpec extends AbstractGradleBuildSpec {
     String getDependenciesBlock(String cracVersion = '1.0.0-SNAPSHOT') {
         """
             dependencies {
+                implementation("io.micronaut:micronaut-http-server")
                 implementation("io.micronaut.crac:micronaut-crac:$cracVersion")
             }""".stripIndent()
     }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/FullMicronautRuntimeSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/FullMicronautRuntimeSpec.groovy
@@ -25,6 +25,7 @@ class FullMicronautRuntimeSpec extends AbstractEagerConfiguringFunctionalTest {
             $repositoriesBlock
             
             dependencies {
+                implementation("io.micronaut:micronaut-http")
                 runtimeOnly("ch.qos.logback:logback-classic")
                 testImplementation("io.micronaut:micronaut-http-client")
             }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/RuntimeDependenciesSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/RuntimeDependenciesSpec.groovy
@@ -37,11 +37,11 @@ class RuntimeDependenciesSpec extends AbstractEagerConfiguringFunctionalTest {
 
         where:
         runtime                | configuration          || coordinates
-        'netty'                | 'compileClasspath'     || ['io.micronaut:micronaut-http-server-netty']
-        'jetty'                | 'compileClasspath'     || ['io.micronaut.servlet:micronaut-http-server-jetty']
-        'http_server_jdk'      | 'compileClasspath'     || ['io.micronaut.servlet:micronaut-http-server-jdk']
-        'tomcat'               | 'compileClasspath'     || ['io.micronaut.servlet:micronaut-http-server-tomcat']
-        'undertow'             | 'compileClasspath'     || ['io.micronaut.servlet:micronaut-http-server-undertow']
+        'netty'                | 'runtimeClasspath'     || ['io.micronaut:micronaut-http-server-netty']
+        'jetty'                | 'runtimeClasspath'     || ['io.micronaut.servlet:micronaut-http-server-jetty']
+        'http_server_jdk'      | 'runtimeClasspath'     || ['io.micronaut.servlet:micronaut-http-server-jdk']
+        'tomcat'               | 'runtimeClasspath'     || ['io.micronaut.servlet:micronaut-http-server-tomcat']
+        'undertow'             | 'runtimeClasspath'     || ['io.micronaut.servlet:micronaut-http-server-undertow']
         'google_function'      | 'compileClasspath'     || ['io.micronaut.gcp:micronaut-gcp-function-http']
         'google_function'      | 'developmentOnly'      || ['com.google.cloud.functions:functions-framework-api', 'io.micronaut.gcp:micronaut-gcp-function-http-test']
         'google_function'      | 'compileOnly'          || ['com.google.cloud.functions:functions-framework-api']
@@ -59,7 +59,7 @@ class RuntimeDependenciesSpec extends AbstractEagerConfiguringFunctionalTest {
         'lambda_provided'      | 'compileClasspath'     || ["io.micronaut.aws:micronaut-function-aws-api-proxy", "io.micronaut.aws:micronaut-function-aws-custom-runtime"]
         'lambda_provided'      | 'developmentOnly'      || ["io.micronaut.aws:micronaut-function-aws-api-proxy-test"]
         'lambda_provided'      | 'testRuntimeClasspath' || ["io.micronaut.aws:micronaut-function-aws-api-proxy-test"]
-        'http_poja'            | 'compileClasspath'     || ['io.micronaut.servlet:micronaut-http-poja-apache']
+        'http_poja'            | 'runtimeClasspath'     || ['io.micronaut.servlet:micronaut-http-poja-apache']
         'http_poja'            | 'testRuntimeClasspath' || ['io.micronaut.servlet:micronaut-http-poja-apache', 'io.micronaut.servlet:micronaut-http-poja-test']
 
         description =  String.join(",", coordinates)

--- a/gradle-plugin/src/test/groovy/io/micronaut/gradle/MicronautApplicationPluginSpec.groovy
+++ b/gradle-plugin/src/test/groovy/io/micronaut/gradle/MicronautApplicationPluginSpec.groovy
@@ -22,6 +22,11 @@ class MicronautApplicationPluginSpec extends AbstractGradleBuildSpec {
             $withSerde
             
             $repositoriesBlock
+
+            dependencies {
+                implementation("io.micronaut:micronaut-http-server")
+            }
+
             application { mainClass = "example.Application" }
         """
         testProjectDir.newFolder("src", "test", "java", "example")

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntimeDependencies.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntimeDependencies.java
@@ -129,23 +129,23 @@ public final class MicronautRuntimeDependencies {
                     .build();
 
         } else if (runtime == NETTY) {
-            return Dependencies.builder().implementation(dependency(GROUP_MICRONAUT, ARTIFACT_ID_MICRONAUT_SERVER_NETTY), HTTP_NETTY_VERSION_PROPERTY).build();
+            return Dependencies.builder().runtimeOnly(dependency(GROUP_MICRONAUT, ARTIFACT_ID_MICRONAUT_SERVER_NETTY), HTTP_NETTY_VERSION_PROPERTY).build();
 
         } else if (runtime == TOMCAT) {
-            return Dependencies.builder().implementation(micronautServletDependency(ARTIFACT_ID_MICRONAUT_SERVLET_TOMCAT), SERVLET_VERSION_PROPERTY).build();
+            return Dependencies.builder().runtimeOnly(micronautServletDependency(ARTIFACT_ID_MICRONAUT_SERVLET_TOMCAT), SERVLET_VERSION_PROPERTY).build();
 
         } else if (runtime == JETTY) {
-            return Dependencies.builder().implementation(micronautServletDependency(ARTIFACT_ID_MICRONAUT_SERVLET_JETTY), SERVLET_VERSION_PROPERTY).build();
+            return Dependencies.builder().runtimeOnly(micronautServletDependency(ARTIFACT_ID_MICRONAUT_SERVLET_JETTY), SERVLET_VERSION_PROPERTY).build();
 
         } else if (runtime == UNDERTOW) {
-            return Dependencies.builder().implementation(micronautServletDependency(ARTIFACT_ID_MICRONAUT_SERVLET_UNDERTOW), SERVLET_VERSION_PROPERTY).build();
+            return Dependencies.builder().runtimeOnly(micronautServletDependency(ARTIFACT_ID_MICRONAUT_SERVLET_UNDERTOW), SERVLET_VERSION_PROPERTY).build();
         } else if (runtime == HTTP_POJA) {
-            return Dependencies.builder().implementation(micronautServletDependency(ARTIFACT_ID_MICRONAUT_SERVLET_POJA_APACHE), SERVLET_VERSION_PROPERTY)
-                    .testImplementation(micronautServletDependency(ARTIFACT_ID_MICRONAUT_SERVLET_POJA_TEST), SERVLET_VERSION_PROPERTY)
+            return Dependencies.builder().runtimeOnly(micronautServletDependency(ARTIFACT_ID_MICRONAUT_SERVLET_POJA_APACHE), SERVLET_VERSION_PROPERTY)
+                    .testRuntimeOnly(micronautServletDependency(ARTIFACT_ID_MICRONAUT_SERVLET_POJA_TEST), SERVLET_VERSION_PROPERTY)
                     .build();
         } else if (runtime == HTTP_SERVER_JDK) {
             return Dependencies.builder()
-                    .implementation(micronautServletDependency(ARTIFACT_ID_MICRONAUT_HTTP_SERVER_JDK), SERVLET_VERSION_PROPERTY)
+                    .runtimeOnly(micronautServletDependency(ARTIFACT_ID_MICRONAUT_HTTP_SERVER_JDK), SERVLET_VERSION_PROPERTY)
                     .build();
 
         } else if (runtime != NONE) {

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/internal/Dependencies.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/internal/Dependencies.java
@@ -97,6 +97,15 @@ public class Dependencies {
             return this;
         }
 
+        public Builder testRuntimeOnly(String coordinates) {
+            return testRuntimeOnly(coordinates, null);
+        }
+
+        public Builder testRuntimeOnly(String coordinates, ConfigurableVersionProperty version) {
+            this.dependencies.add(new AutomaticDependency(JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME, coordinates, Optional.ofNullable(version)));
+            return this;
+        }
+
         public Dependencies build() {
             return new Dependencies(Collections.unmodifiableList(dependencies));
         }

--- a/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMinimalApplicationPluginSpec.groovy
+++ b/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMinimalApplicationPluginSpec.groovy
@@ -21,6 +21,11 @@ class MicronautMinimalApplicationPluginSpec extends AbstractGradleBuildSpec {
             }
             
             $repositoriesBlock
+
+            dependencies {
+                implementation("io.micronaut:micronaut-http-server")
+            }
+
             application { mainClass = "example.Application" }
 
             $withSerde
@@ -100,6 +105,11 @@ class MicronautMinimalApplicationPluginSpec extends AbstractGradleBuildSpec {
             }
             
             $repositoriesBlock
+
+            dependencies {
+                implementation("io.micronaut:micronaut-http-server")
+            }
+
             application { mainClass = "example.Application" }
             configurations.all {
                 exclude module: 'snakeyaml'
@@ -285,6 +295,11 @@ public class ExampleTest {
             }
             
             $repositoriesBlock
+
+            dependencies {
+                implementation("io.micronaut:micronaut-http-server")
+            }
+
             application { mainClass = "example.Application" }
 
             $withSerde
@@ -316,6 +331,11 @@ public class ExampleTest {
             }
             
             $repositoriesBlock
+
+            dependencies {
+                implementation("io.micronaut:micronaut-http-server")
+            }
+
             application { mainClass = "example.Application" }
 
             $withSerde
@@ -349,6 +369,11 @@ public class ExampleTest {
             }
             
             $repositoriesBlock
+
+            dependencies {
+                implementation("io.micronaut:micronaut-http-server")
+            }
+
             application { mainClass = "example.Application" }
         """
         testProjectDir.newFolder("src", "test", "java", "example")

--- a/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautRuntimeSpec.groovy
+++ b/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautRuntimeSpec.groovy
@@ -24,6 +24,7 @@ class MicronautRuntimeSpec extends AbstractGradleBuildSpec {
             $repositoriesBlock
             
             dependencies {
+                implementation("io.micronaut:micronaut-http")
                 runtimeOnly("ch.qos.logback:logback-classic")
                 testImplementation("io.micronaut:micronaut-http-client")
             }


### PR DESCRIPTION
## Problem

The Micronaut Gradle plugin applies the selected runtime as an
`implementation` dependency. For HTTP server runtimes, this is
unnecessarily broad.
In my case and understanding most users compile against
`micronaut-http` / `micronaut-http-server` abstractions, not against runtime
implementation classes.
If so they should explicitly state so in their build.gradle(.kts)

I discovered this because the
[dependency-analysis-gradle-plugin](https://github.com/autonomousapps/dependency-analysis-gradle-plugin)
reports these dependencies as unused on the compile classpath.

## Reproducer

Happy to create a minimal reproducer if that helps the merge :)

## Solution

Default HTTP server runtimes to `runtimeOnly`:
- micronaut-http-server-netty
- micronaut-servlet-tomcat
- micronaut-servlet-jetty
- micronaut-servlet-undertow
- micronaut-http-server-jdk
- micronaut-http-poja-apache
- micronaut-http-poja-test

Serverless/function runtimes remain `implementation`, as users
typically extend base classes or reference provider-specific types.
(Don't really have any knowledge about these, any input is welcome)

## Impact

No behavioral change at runtime. Reduces unnecessary compile
classpath pollution and resolves dependency analysis warnings.

### BREAKING
Users which don't have a dependency hygiene Plugin might need to explicitly add `micronaut-http` / `micronaut-http-server` to their implementation configuration.