### PR TITLE
disable useClassDataSharing by default

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,8 +20,8 @@ openrewrite = "7.26.0"
 micronaut-platform = "4.10.10" # This is the platform version, used in our tests
 micronaut-aot = "3.0.0-M2"
 micronaut-openapi = "6.20.0"
-micronaut-testresources = "3.0.0-M6"
 micronaut-jsonschema = "2.0.0-M4"
+micronaut-testresources = "4.0.0-M1"
 
 [libraries]
 # Core

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,8 +20,8 @@ openrewrite = "7.26.0"
 micronaut-platform = "4.10.10" # This is the platform version, used in our tests
 micronaut-aot = "3.0.0-M2"
 micronaut-openapi = "6.20.0"
-micronaut-jsonschema = "2.0.0-M4"
 micronaut-testresources = "4.0.0-M1"
+micronaut-jsonschema = "2.0.0-M7"
 
 [libraries]
 # Core

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -267,7 +267,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
             task.getStopFile().set(stopFile.toFile());
             task.getStandalone().set(isStandalone);
             task.getClassDataSharingDir().convention(cdsDir);
-            task.getUseClassDataSharing().convention(JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17));
+            task.getUseClassDataSharing().convention(false);
             task.getSystemProperties().convention(config.getServerSystemProperties());
             task.getEnvironment().convention(config.getServerEnvironment());
             task.getDebugServer().convention(config.getDebugServer());


### PR DESCRIPTION
with useClassDataSharing enabled I am getting in Micronaut 5 projects errors such as:

```
Caused by: javax.management.NotCompliantMBeanException: com.sun.management.UnixOperatingSystemMXBean: During -Xshare:dump, module system cannot be modified after it's initialize
```