### PR TITLE
Fix consumer plugin not wiring test resources JVM args to run task

### DIFF
--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesConsumerPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesConsumerPlugin.java
@@ -29,6 +29,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.plugins.ApplicationPlugin;
 import org.gradle.api.plugins.PluginManager;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.JavaExec;
@@ -89,7 +90,7 @@ public class MicronautTestResourcesConsumerPlugin implements Plugin<Project> {
         project.getTasks().withType(Test.class).configureEach(t ->
                 t.getJvmArgumentProviders().add(jvmArgumentsConfiguration)
         );
-        project.getPlugins().withId("java-application", unused ->
+        project.getPlugins().withType(ApplicationPlugin.class, unused ->
                 project.getTasks().named("run", JavaExec.class, t ->
                         t.getJvmArgumentProviders().add(jvmArgumentsConfiguration)
                 )

--- a/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/MultiProjectTestResourcePluginSpec.groovy
+++ b/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/MultiProjectTestResourcePluginSpec.groovy
@@ -25,6 +25,28 @@ class MultiProjectTestResourcePluginSpec extends AbstractGradleBuildSpec {
         result.output.contains "io.micronaut.testresources.postgres.PostgreSQLTestResourceProvider"
     }
 
+    def "runs the application with test resources support in a multiproject consumer"() {
+        withSample("test-resources/multiproject")
+
+        // The sample Application.java already checks System.getProperty("interruptStartup"),
+        // but the build.gradle doesn't forward the system property from Gradle to the JVM.
+        file("app1/build.gradle") << """
+            tasks.withType(JavaExec).configureEach {
+                if (System.getProperty("interruptStartup")) {
+                    systemProperty "interruptStartup", "true"
+                }
+            }
+        """
+
+        when:
+        def result = build '-DinterruptStartup=true', ':app1:run'
+
+        then:
+        result.task(':testresources:internalStartTestResourcesService').outcome == TaskOutcome.SUCCESS
+        result.task(':app1:run').outcome == TaskOutcome.SUCCESS
+        result.output.contains "Loaded 4 test resources resolvers"
+    }
+
     def "can use independent test resource services"() {
         withSample("test-resources/isolated-multiproject")
 


### PR DESCRIPTION
## Summary

`MicronautTestResourcesConsumerPlugin` uses `project.getPlugins().withId("java-application", ...)` to lazily configure the `run` task with test resources JVM argument providers. However, `"java-application"` is not a valid Gradle core plugin ID — `ApplicationPlugin` is registered under `"application"`. Because `io.micronaut.minimal.application` and `io.micronaut.application` both apply `ApplicationPlugin` **by class** (`pluginManager.apply(ApplicationPlugin.class)`), the string ID `"java-application"` is never registered, and the `withId` callback is dead code.

This means the `run` task in consumer projects never receives:
- The `ServerConnectionParametersProvider` JVM argument provider (which passes `-Dmicronaut.test.resources.server.uri=...` etc.)
- The implicit task dependency on `copyTestResourceServerConfig`

The application starts without knowing where the test resources server is, so property resolution fails (e.g., `No URL specified` for datasources).

## Root Cause

In `MicronautTestResourcesConsumerPlugin.java` line 92:

```java
project.getPlugins().withId("java-application", unused ->
        project.getTasks().named("run", JavaExec.class, t ->
                t.getJvmArgumentProviders().add(jvmArgumentsConfiguration)
        )
);
```

Gradle's `ApplicationPlugin` has the plugin ID `"application"` (see [Gradle docs](https://docs.gradle.org/current/userguide/application_plugin.html)). The string `"java-application"` doesn't match any Gradle core plugin. You can confirm this by trying `plugins { id("java-application") }` in a `build.gradle.kts` — Gradle reports "Plugin [id: 'java-application'] was not found".

## Why tests didn't catch this

The existing test "runs the application with test resources support" in `ApplicationTestResourcesPluginSpec` uses the `data-mysql` sample, which applies the **full** `io.micronaut.test-resources` plugin (not the consumer). The full plugin uses `tasks.withType(JavaExec.class).configureEach(...)` (a broader approach that catches all JavaExec tasks), so it doesn't exercise the `withId("java-application")` code path.

The `MultiProjectTestResourcePluginSpec` tests *do* use the consumer plugin, but they only test the `test` task — not `run`. The `test` task wiring uses `tasks.withType(Test.class).configureEach(...)` which works correctly.

## Fix

Replace the string-based `withId("java-application", ...)` with type-safe `withType(ApplicationPlugin.class, ...)`. This avoids magic strings entirely — the compiler ensures the class reference is valid.

```java
// Before (broken — "java-application" is not a valid Gradle plugin ID)
project.getPlugins().withId("java-application", unused -> ...);

// After (type-safe — matches by class, no magic string)
project.getPlugins().withType(ApplicationPlugin.class, unused -> ...);
```