### PR TITLE
docs: Clarify packaging options and document the runner JAR

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1129,6 +1129,10 @@ tasks.withType(io.micronaut.gradle.docker.tasks.BuildLayersTask) {
 }
 ----
 
+==== Runner JAR
+
+The plugin produces an additional "runner" `Jar`. This is used by the Docker build layers, but is otherwise irrelevant
+
 
 === Micronaut Runtimes
 
@@ -1251,13 +1255,11 @@ dockerfileNative {
 === Packaging the application
 
 By default, the plugin doesn't create a runnable fatjar when running `./gradlew assemble`.
-There are a couple of options:
 
-==== Layered application
+==== Standard distribution
 
-The plugin creates a "layered" application in `build/docker/main/layers` and from that directory you can run `java -jar myapp.jar`.
-It works because that directory contains a `lib` directory with all the libraries and a `resources` directory with the configuration.
-Keep in mind that copying the only `.jar` file to another directory won't work.
+Use the standard Gradle application distributions provided in `build/distributions`. These come with scripts to run your
+application, and package all the dependencies independently.
 
 ==== Add Shadow plugin
 
@@ -1545,7 +1547,7 @@ tasks.withType(ShadowJar).configureEach {
 [source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
 ----
 tasks.withType<ShadowJar>().configureEach {
-    zip64.set(true)
+    isZip64 = true
 }
 ----
 ====

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1129,9 +1129,13 @@ tasks.withType(io.micronaut.gradle.docker.tasks.BuildLayersTask) {
 }
 ----
 
-==== Runner JAR
+==== Docker build layers
 
-The plugin produces an additional "runner" `Jar`. This is used by the Docker build layers, but is otherwise irrelevant
+The `buildLayers` task creates files under `build/docker/main/layers` for the generated Docker image.
+This directory is an internal Docker build artifact, not a supported application distribution.
+
+The plugin also produces an additional runner JAR in `build/libs` with the `runner` classifier.
+That archive is used to populate the Docker layers and is not meant to be copied or run on its own.
 
 
 === Micronaut Runtimes
@@ -1258,8 +1262,8 @@ By default, the plugin doesn't create a runnable fatjar when running `./gradlew 
 
 ==== Standard distribution
 
-Use the standard Gradle application distributions provided in `build/distributions`. These come with scripts to run your
-application, and package all the dependencies independently.
+Use the standard Gradle application distributions provided in `build/distributions`.
+These distributions include the application scripts together with the dependency layout expected by the application.
 
 ==== Add Shadow plugin
 


### PR DESCRIPTION
## Summary

Fixes #1213

- **Replace misleading "Layered application" section** with "Standard distribution" — the old section described `build/docker/main/layers` as a runnable directory, but that's an internal artifact of the Docker build layers, not a supported way to run the application. Points users to `build/distributions` instead.
- **Add "Runner JAR" note** explaining that the Docker plugin produces an extra JAR in `build/libs/` that is used internally by the Docker build layers and is otherwise irrelevant. This addresses the confusion described in #1213 about unexpected JARs appearing in `build/libs/`.
- **Fix Kotlin DSL syntax** for ShadowJar `zip64` (use idiomatic property assignment instead of `.set()`)

## Context

I considered moving the runner JAR's output directory out of `build/libs/` (as suggested in the issue), but that conflicts with `BuildLayersTask` which owns `build/docker/main/layers` as its `@OutputDirectory` and deletes it at the start of each run.

## Test plan

- [x] Documentation renders correctly in the generated site
- [x] Existing `BuildLayersSpec` and `DockerBuildTaskSpec` tests continue to pass (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)