### PR TITLE
Add optimizedTest task for AOT applications

### DIFF
--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -46,6 +46,7 @@ import org.gradle.api.file.RelativePath;
 import org.gradle.api.java.archives.Attributes;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.ApplicationPlugin;
+import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaApplication;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Provider;
@@ -56,6 +57,7 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.application.CreateStartScripts;
 import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.api.tasks.testing.Test;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -110,6 +112,7 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
     );
     public static final String AOT_APPLICATION_CLASSPATH = "aotApplicationClasspath";
     public static final String OPTIMIZED_RUNTIME_CLASSPATH_CONFIGURATION_NAME = "optimizedRuntimeClasspath";
+    public static final String OPTIMIZED_TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME = "optimizedTestRuntimeClasspath";
     public static final String DEFAULT_GENERATED_PACKAGE = "io.micronaut.aot.generated";
 
     @Inject
@@ -316,7 +319,7 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
                 Configuration runtimeClasspath = configurations.getByName("runtimeClasspath");
                 conf.extendsFrom(runtimeClasspath);
                 conf.setCanBeConsumed(false);
-                conf.setCanBeConsumed(true);
+                conf.setCanBeResolved(true);
                 // Use the same attributes as runtimeClasspath for resolution
                 AttributeUtils.copyAttributes(project.getProviders(), runtimeClasspath, conf);
             });
@@ -343,6 +346,30 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
                     }
                 });
             });
+
+            SourceSet mainSourceSet = PluginsHelper.findSourceSets(project).getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+            SourceSet testSourceSet = PluginsHelper.findSourceSets(project).findByName(SourceSet.TEST_SOURCE_SET_NAME);
+            if (testSourceSet != null) {
+                Configuration optimizedTestRuntimeClasspath = configurations.create(OPTIMIZED_TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME, conf -> {
+                    Configuration testRuntimeClasspath = configurations.getByName(testSourceSet.getRuntimeClasspathConfigurationName());
+                    conf.extendsFrom(testRuntimeClasspath);
+                    conf.setCanBeConsumed(false);
+                    conf.setCanBeResolved(true);
+                    AttributeUtils.copyAttributes(project.getProviders(), testRuntimeClasspath, conf);
+                });
+                tasks.register("optimizedTest", Test.class, task -> {
+                    task.setDescription("Executes the Micronaut tests with AOT optimizations");
+                    task.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
+                    task.dependsOn(prepareJit);
+                    task.setTestClassesDirs(testSourceSet.getOutput().getClassesDirs());
+                    task.setClasspath(project.files(
+                            testSourceSet.getOutput(),
+                            jarTask,
+                            optimizedTestRuntimeClasspath,
+                            testSourceSet.getRuntimeClasspath().minus(mainSourceSet.getOutput())
+                    ));
+                });
+            }
         });
     }
 

--- a/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
+++ b/aot-plugin/src/main/java/io/micronaut/gradle/aot/MicronautAotPlugin.java
@@ -347,7 +347,6 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
                 });
             });
 
-            SourceSet mainSourceSet = PluginsHelper.findSourceSets(project).getByName(SourceSet.MAIN_SOURCE_SET_NAME);
             SourceSet testSourceSet = PluginsHelper.findSourceSets(project).findByName(SourceSet.TEST_SOURCE_SET_NAME);
             if (testSourceSet != null) {
                 Configuration optimizedTestRuntimeClasspath = configurations.create(OPTIMIZED_TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME, conf -> {
@@ -365,8 +364,7 @@ public abstract class MicronautAotPlugin implements Plugin<Project> {
                     task.setClasspath(project.files(
                             testSourceSet.getOutput(),
                             jarTask,
-                            optimizedTestRuntimeClasspath,
-                            testSourceSet.getRuntimeClasspath().minus(mainSourceSet.getOutput())
+                            optimizedTestRuntimeClasspath
                     ));
                 });
             }

--- a/aot-plugin/src/test/groovy/io/micronaut/gradle/aot/AotOptimizerConfigurationSpec.groovy
+++ b/aot-plugin/src/test/groovy/io/micronaut/gradle/aot/AotOptimizerConfigurationSpec.groovy
@@ -4,6 +4,7 @@ import io.micronaut.gradle.MicronautComponentPlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.plugins.ApplicationPlugin
+import org.gradle.api.tasks.SourceSet
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.api.tasks.testing.Test
@@ -126,5 +127,14 @@ class AotOptimizerConfigurationSpec extends Specification {
         then:
         project.configurations.findByName(MicronautAotPlugin.OPTIMIZED_TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME) != null
         project.tasks.findByName("optimizedTest") instanceof Test
+
+        and:
+        def optimizedTest = project.tasks.getByName("optimizedTest") as Test
+        def sourceSets = project.extensions.getByType(JavaPluginExtension).sourceSets
+        def mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+        def testSourceSet = sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME)
+
+        optimizedTest.classpath.files.containsAll(testSourceSet.output.files)
+        !optimizedTest.classpath.files.containsAll(mainSourceSet.output.files)
     }
 }

--- a/aot-plugin/src/test/groovy/io/micronaut/gradle/aot/AotOptimizerConfigurationSpec.groovy
+++ b/aot-plugin/src/test/groovy/io/micronaut/gradle/aot/AotOptimizerConfigurationSpec.groovy
@@ -3,8 +3,10 @@ package io.micronaut.gradle.aot
 import io.micronaut.gradle.MicronautComponentPlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.plugins.ApplicationPlugin
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
+import org.gradle.api.tasks.testing.Test
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
@@ -83,7 +85,7 @@ class AotOptimizerConfigurationSpec extends Specification {
         ex.message != null && (ex.message.toString().contains("Failed to query the value of task ':prepareJitOptimizations' property 'javaLauncher'"))
     }
 
-        def "AOT task falls back to default when no toolchain configured"() {
+    def "AOT task falls back to default when no toolchain configured"() {
         given:
         def project = ProjectBuilder.builder().build()
 
@@ -102,5 +104,27 @@ class AotOptimizerConfigurationSpec extends Specification {
 
         then:
         !aotTask.javaLauncher.isPresent()
+    }
+
+    def "registers optimized test task for applications"() {
+        given:
+        def project = ProjectBuilder.builder().build()
+
+        String micronautVersion = System.getProperty("micronautVersion")
+        project.extensions.add('micronautVersion', micronautVersion)
+
+        project.pluginManager.apply(JavaPlugin)
+        project.pluginManager.apply(ApplicationPlugin)
+        project.pluginManager.apply(MicronautComponentPlugin)
+        project.pluginManager.apply(MicronautAotPlugin)
+        project.repositories.mavenCentral()
+        project.dependencies.add("aotApplicationClasspath", "io.micronaut.platform:micronaut-platform:$micronautVersion")
+
+        when:
+        project.evaluate()
+
+        then:
+        project.configurations.findByName(MicronautAotPlugin.OPTIMIZED_TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME) != null
+        project.tasks.findByName("optimizedTest") instanceof Test
     }
 }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/BasicMicronautAOTSpec.groovy
@@ -139,6 +139,55 @@ class BasicMicronautAOTSpec extends AbstractAOTPluginSpec {
 
     }
 
+    def "can run Micronaut tests against the optimized application classpath"() {
+        withSample("aot/basic-app")
+        withPlugins(Plugins.APPLICATION)
+        def optimizedTest = file("src/test/java/demo/app/OptimizedApplicationTest.java")
+        optimizedTest.parentFile.mkdirs()
+        optimizedTest.text = """
+package demo.app;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest
+class OptimizedApplicationTest {
+    @Inject
+    ApplicationContext context;
+
+    @Test
+    void loadsStaticOptimizationsFromOptimizedClasspath() throws Exception {
+        assertNotNull(context);
+
+        Class<?> clazz = Class.forName("io.micronaut.core.optim.StaticOptimizations");
+        Field field = clazz.getDeclaredField("OPTIMIZATIONS");
+        field.setAccessible(true);
+        Map<Class<?>, Object> optimizations = (Map<Class<?>, Object>) field.get(null);
+
+        assertTrue(optimizations.keySet().stream()
+                .map(Class::getName)
+                .anyMatch("io.micronaut.core.util.EnvironmentProperties"::equals));
+    }
+}
+"""
+
+        when:
+        def result = build "optimizedTest"
+
+        then:
+        result.task(":optimizedTest").outcome == TaskOutcome.SUCCESS
+        result.task(":prepareJitOptimizations").outcome == TaskOutcome.SUCCESS
+        result.task(":optimizedJitJar").outcome == TaskOutcome.SUCCESS
+    }
+
     @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/401")
     def "supports spaces in file names"() {
         withSpacesInTestDir()

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1499,6 +1499,7 @@ Therefore, some optimizations like conversion of YAML files to Java configuratio
 The plugin provides a couple of tasks aimed at running an optimized application.
 The first one, `optimizedJar`, will simply run the AOT compiler and produce an "optimized" jar.
 If you want to run the application with the resulting jar, you will need to call the `optimizedRun` task instead, which will create the jar and then start the application.
+For JVM test execution, the plugin also provides an additive `optimizedTest` task, which runs the test source set against the optimized JIT application jar while leaving the standard `test` task unchanged.
 
 If you also have the `distribution` plugin applied, the optimized jar will be used to create optimized distributions, in which case you can call the `optimizedDistZip` task to create a distribution zip, the `optimizedDistTar` to create an optimized distribution tar file, or `installOptimizedDist` to install the optimized application to the `build/install` directory.
 


### PR DESCRIPTION
## Summary
- add an additive `optimizedTest` task and `optimizedTestRuntimeClasspath` for AOT-enabled application builds
- verify `@MicronautTest` can execute against the optimized JIT application classpath without changing the default `test` task
- document the new `optimizedTest` flow in the AOT guide

## Verification
- `./gradlew --no-build-cache --rerun-tasks :micronaut-aot-plugin:test --tests 'io.micronaut.gradle.aot.AotOptimizerConfigurationSpec.registers optimized test task for applications'`
- `./gradlew --no-build-cache --rerun-tasks :functional-tests:test --tests 'io.micronaut.gradle.aot.BasicMicronautAOTSpec.can run Micronaut tests against the optimized application classpath'`

Closes #308

---
###### ✨ This message was AI-generated using gpt-5