### PR TITLE
Only apply Eclipse APT when the eclipse plugin is applied

### DIFF
--- a/gradle-plugin/src/main/java/io/micronaut/gradle/MicronautApplicationPlugin.java
+++ b/gradle-plugin/src/main/java/io/micronaut/gradle/MicronautApplicationPlugin.java
@@ -1,6 +1,5 @@
 package io.micronaut.gradle;
 
-import com.diffplug.gradle.eclipse.apt.AptEclipsePlugin;
 import io.micronaut.gradle.docker.MicronautDockerPlugin;
 import io.micronaut.gradle.graalvm.MicronautGraalPlugin;
 import org.gradle.api.Project;

--- a/gradle-plugin/src/main/java/io/micronaut/gradle/MicronautApplicationPlugin.java
+++ b/gradle-plugin/src/main/java/io/micronaut/gradle/MicronautApplicationPlugin.java
@@ -19,7 +19,7 @@ public class MicronautApplicationPlugin extends MicronautLibraryPlugin {
     public void apply(Project project) {
         PluginManager pluginManager = project.getPluginManager();
         pluginManager.apply(MicronautMinimalApplicationPlugin.class);
-        pluginManager.apply(AptEclipsePlugin.class);
+        applyEclipseAptPlugin(project);
         pluginManager.apply(MicronautDockerPlugin.class);
         pluginManager.apply(MicronautGraalPlugin.class);
     }

--- a/gradle-plugin/src/main/java/io/micronaut/gradle/MicronautLibraryPlugin.java
+++ b/gradle-plugin/src/main/java/io/micronaut/gradle/MicronautLibraryPlugin.java
@@ -19,9 +19,13 @@ public class MicronautLibraryPlugin implements Plugin<Project> {
         final PluginContainer plugins = project.getPlugins();
 
         plugins.apply(MicronautMinimalLibraryPlugin.class);
-        plugins.apply(AptEclipsePlugin.class);
+        applyEclipseAptPlugin(project);
         plugins.apply(MicronautGraalPlugin.class);
 
+    }
+
+    protected void applyEclipseAptPlugin(Project project) {
+        project.getPluginManager().withPlugin("eclipse", ignored -> project.getPlugins().apply(AptEclipsePlugin.class));
     }
 
 }

--- a/gradle-plugin/src/test/groovy/io/micronaut/gradle/MicronautApplicationPluginSpec.groovy
+++ b/gradle-plugin/src/test/groovy/io/micronaut/gradle/MicronautApplicationPluginSpec.groovy
@@ -5,6 +5,30 @@ import spock.lang.Issue
 
 class MicronautApplicationPluginSpec extends AbstractGradleBuildSpec {
 
+    def "test eclipse apt tasks are not added by default"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.application"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+            }
+
+            $repositoriesBlock
+            application { mainClass = "example.Application" }
+        """
+
+        when:
+        def result = build('tasks', '--all')
+
+        then:
+        !result.output.contains('eclipseJdtApt')
+    }
+
     def "test junit 5 test runtime"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"

--- a/gradle-plugin/src/test/groovy/io/micronaut/gradle/MicronautLibraryPluginSpec.groovy
+++ b/gradle-plugin/src/test/groovy/io/micronaut/gradle/MicronautLibraryPluginSpec.groovy
@@ -4,6 +4,32 @@ import org.gradle.testkit.runner.TaskOutcome
 
 class MicronautLibraryPluginSpec extends AbstractGradleBuildSpec {
 
+    def "test eclipse apt tasks are only added when eclipse plugin is applied"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.library"
+                ${applyEclipsePlugin ? 'id "eclipse"' : ''}
+            }
+
+            micronaut {
+                version "$micronautVersion"
+            }
+
+            $repositoriesBlock
+        """
+
+        when:
+        def result = build('tasks', '--all')
+
+        then:
+        result.output.contains('eclipseJdtApt') == applyEclipsePlugin
+
+        where:
+        applyEclipsePlugin << [false, true]
+    }
+
     def "test JUnit 5 platform excludes work"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -270,7 +270,7 @@ plugins {
 }
 ----
 
-`io.micronaut.minimal.application`, `io.micronaut.graalvm` and `io.micronaut.docker` plugins.
+This applies the `io.micronaut.minimal.application`, `io.micronaut.graalvm` and `io.micronaut.docker` plugins.
 
 If the Gradle `eclipse` plugin is also applied, `io.micronaut.application` additionally applies `com.diffplug.gradle.eclipse.apt.AptEclipsePlugin`.
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -62,11 +62,11 @@ For example, the `minimal` plugins can be used to reduce the number of tasks, fo
 
 |https://plugins.gradle.org/plugin/io.micronaut.library[`io.micronaut.library`]
 |A typical Micronaut Library, with support for GraalVM
-|https://plugins.gradle.org/plugin/io.micronaut.minimal.library[`io.micronaut.minimal.library`], https://plugins.gradle.org/plugin/io.micronaut.graalvm[`io.micronaut.graalvm`], `AptEclipsePlugin`
+|https://plugins.gradle.org/plugin/io.micronaut.minimal.library[`io.micronaut.minimal.library`], https://plugins.gradle.org/plugin/io.micronaut.graalvm[`io.micronaut.graalvm`], and `AptEclipsePlugin` when the Gradle `eclipse` plugin is applied
 
 |https://plugins.gradle.org/plugin/io.micronaut.application[`io.micronaut.application`]
 |A typical Micronaut Application, with support for GraalVM and Docker
-|https://plugins.gradle.org/plugin/io.micronaut.minimal.application[`io.micronaut.minimal.application`], https://plugins.gradle.org/plugin/io.micronaut.graalvm[`io.micronaut.graalvm`], https://plugins.gradle.org/plugin/io.micronaut.docker[`io.micronaut.docker`], `AptEclipsePlugin`
+|https://plugins.gradle.org/plugin/io.micronaut.minimal.application[`io.micronaut.minimal.application`], https://plugins.gradle.org/plugin/io.micronaut.graalvm[`io.micronaut.graalvm`], https://plugins.gradle.org/plugin/io.micronaut.docker[`io.micronaut.docker`], and `AptEclipsePlugin` when the Gradle `eclipse` plugin is applied
 
 |https://plugins.gradle.org/plugin/io.micronaut.test-resources[`io.micronaut.test-resources`]
 |Provides automatic test resources provisioning on a single project
@@ -259,7 +259,6 @@ plugins {
   id 'io.micronaut.docker' version '{gradle-project-version}'
   id 'io.micronaut.graalvm' version '{gradle-project-version}'
 }
-apply plugin: com.diffplug.gradle.eclipse.apt.AptEclipsePlugin
 ----
 
 [source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
@@ -269,10 +268,11 @@ plugins {
   id("io.micronaut.docker") version "{gradle-project-version}"
   id("io.micronaut.graalvm") version "{gradle-project-version}"
 }
-apply(plugin=com.diffplug.gradle.eclipse.apt.AptEclipsePlugin::class.java)
 ----
 
-`io.micronaut.minimal.application`, `io.micronaut.graalvm` and `io.micronaut.docker` plugins (as well as the Eclipse annotation processing support plugin).
+`io.micronaut.minimal.application`, `io.micronaut.graalvm` and `io.micronaut.docker` plugins.
+
+If the Gradle `eclipse` plugin is also applied, `io.micronaut.application` additionally applies `com.diffplug.gradle.eclipse.apt.AptEclipsePlugin`.
 
 == Quick Start
 
@@ -459,6 +459,7 @@ The https://plugins.gradle.org/plugin/io.micronaut.library[Micronaut library plu
 * Applies the `java-library` plugin
 * Configures annotation processing for the current language (Groovy, Java or Kotlin)
 * <<#sec:automatic-annotation-processors, Adds annotation processors automatically>> for Micronaut modules
+* Applies `com.diffplug.gradle.eclipse.apt.AptEclipsePlugin` when the Gradle `eclipse` plugin is applied
 
 The `micronaut` DSL can be used to configure how this behaves.
 
@@ -627,6 +628,7 @@ The https://plugins.gradle.org/plugin/io.micronaut.application[Micronaut applica
 * Instead of the `java-library` plugin the plugin applies the Gradle `application` plugin
 * Applies the `io.micronaut.graalvm` plugin
 * Correctly configures Gradle for continuous build
+* Applies `com.diffplug.gradle.eclipse.apt.AptEclipsePlugin` when the Gradle `eclipse` plugin is applied
 
 The following additional tasks are provided by this plugin:
 


### PR DESCRIPTION
## Summary
- only apply `com.diffplug.gradle.eclipse.apt.AptEclipsePlugin` when the Gradle `eclipse` plugin is present
- add regression coverage for library and application plugin task exposure
- update the docs to describe Eclipse APT as opt-in behavior

Fixes #603

---
###### ✨ This message was AI-generated using gpt-5.4
