### PR TITLE
Fix Lambda API proxy auto-dependencies for explicit function runtimes

### DIFF
--- a/functional-tests/src/test/groovy/io/micronaut/gradle/RuntimeDependenciesSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/RuntimeDependenciesSpec.groovy
@@ -98,4 +98,38 @@ class RuntimeDependenciesSpec extends AbstractEagerConfiguringFunctionalTest {
         'lambda_java'      | ''
         'lambda_provided'  | 'implementation("io.micronaut.aws:micronaut-function-aws-custom-runtime")'
     }
+
+    @Unroll
+    def "test-scoped AWS function dependencies keep automatic lambda API proxy dependencies for #runtime"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id("com.gradleup.shadow") version("$shadowVersion")
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "$runtime"
+            }
+
+            $repositoriesBlock
+
+            dependencies {
+                testImplementation("io.micronaut.aws:micronaut-function-aws")
+                $extraDependency
+            }
+        """
+
+        expect:
+        containsDependency("io.micronaut.aws:micronaut-function-aws-api-proxy", "compileClasspath")
+        containsDependency("io.micronaut.aws:micronaut-function-aws-api-proxy-test", "developmentOnly")
+        containsDependency("io.micronaut.aws:micronaut-function-aws-api-proxy-test", "testRuntimeClasspath")
+
+        where:
+        runtime            | extraDependency
+        'lambda_java'      | ''
+        'lambda_provided'  | ''
+    }
 }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/RuntimeDependenciesSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/RuntimeDependenciesSpec.groovy
@@ -84,7 +84,6 @@ class RuntimeDependenciesSpec extends AbstractEagerConfiguringFunctionalTest {
 
             dependencies {
                 implementation("io.micronaut.aws:micronaut-function-aws")
-                $extraDependency
             }
         """
 
@@ -92,11 +91,12 @@ class RuntimeDependenciesSpec extends AbstractEagerConfiguringFunctionalTest {
         !containsDependency("io.micronaut.aws:micronaut-function-aws-api-proxy", "compileClasspath")
         !containsDependency("io.micronaut.aws:micronaut-function-aws-api-proxy-test", "developmentOnly")
         !containsDependency("io.micronaut.aws:micronaut-function-aws-api-proxy-test", "testRuntimeClasspath")
+        containsCustomRuntime == containsDependency("io.micronaut.aws:micronaut-function-aws-custom-runtime", "compileClasspath")
 
         where:
-        runtime            | extraDependency
-        'lambda_java'      | ''
-        'lambda_provided'  | 'implementation("io.micronaut.aws:micronaut-function-aws-custom-runtime")'
+        runtime            | containsCustomRuntime
+        'lambda_java'      | false
+        'lambda_provided'  | true
     }
 
     @Unroll

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/RuntimeDependenciesSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/RuntimeDependenciesSpec.groovy
@@ -64,4 +64,38 @@ class RuntimeDependenciesSpec extends AbstractEagerConfiguringFunctionalTest {
 
         description =  String.join(",", coordinates)
     }
+
+    @Unroll
+    def "explicit AWS function dependencies disable automatic lambda API proxy dependencies for #runtime"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id("com.gradleup.shadow") version("$shadowVersion")
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "$runtime"
+            }
+
+            $repositoriesBlock
+
+            dependencies {
+                implementation("io.micronaut.aws:micronaut-function-aws")
+                $extraDependency
+            }
+        """
+
+        expect:
+        !containsDependency("io.micronaut.aws:micronaut-function-aws-api-proxy", "compileClasspath")
+        !containsDependency("io.micronaut.aws:micronaut-function-aws-api-proxy-test", "developmentOnly")
+        !containsDependency("io.micronaut.aws:micronaut-function-aws-api-proxy-test", "testRuntimeClasspath")
+
+        where:
+        runtime            | extraDependency
+        'lambda_java'      | ''
+        'lambda_provided'  | 'implementation("io.micronaut.aws:micronaut-function-aws-custom-runtime")'
+    }
 }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
@@ -24,6 +24,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
@@ -176,19 +177,32 @@ public class MicronautMinimalApplicationPlugin implements Plugin<Project> {
         project.afterEvaluate(p -> {
             MicronautRuntime micronautRuntime = resolveRuntime(p);
             DependencyHandler dependencyHandler = p.getDependencies();
-            MicronautRuntimeDependencies.findApplicationPluginDependenciesByRuntime(micronautRuntime)
-                    .toMap()
-                    .forEach((scope, dependencies) -> {
-                for (AutomaticDependency dependency : dependencies) {
-                    dependency.applyTo(project);
-                }
-            });
+            if (!(micronautRuntime.isLambda() && hasExplicitAwsFunctionRuntimeDependency(project))) {
+                MicronautRuntimeDependencies.findApplicationPluginDependenciesByRuntime(micronautRuntime)
+                        .toMap()
+                        .forEach((scope, dependencies) -> {
+                    for (AutomaticDependency dependency : dependencies) {
+                        dependency.applyTo(project);
+                    }
+                });
+            }
             if (micronautRuntime == MicronautRuntime.GOOGLE_FUNCTION) {
                 configureGoogleCloudFunctionRuntime(project, p, dependencyHandler);
             }
             ShadowPluginSupport.withShadowPlugin(project, () -> ShadowPluginSupport.configureDefaults(project));
 
         });
+    }
+
+    private boolean hasExplicitAwsFunctionRuntimeDependency(Project project) {
+        for (Configuration configuration : project.getConfigurations()) {
+            for (Dependency dependency : configuration.getDependencies()) {
+                if (MicronautRuntimeDependencies.isExplicitAwsFunctionRuntimeDependency(dependency.getGroup(), dependency.getName())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private void configureGoogleCloudFunctionRuntime(Project project, Project p, DependencyHandler dependencyHandler) {

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
@@ -195,11 +195,22 @@ public class MicronautMinimalApplicationPlugin implements Plugin<Project> {
     }
 
     private boolean hasExplicitAwsFunctionRuntimeDependency(Project project) {
-        for (Configuration configuration : project.getConfigurations()) {
-            for (Dependency dependency : configuration.getDependencies()) {
-                if (MicronautRuntimeDependencies.isExplicitAwsFunctionRuntimeDependency(dependency.getGroup(), dependency.getName())) {
-                    return true;
-                }
+        SourceSetContainer sourceSets = PluginsHelper.findSourceSets(project);
+        SourceSet sourceSet = sourceSets == null ? null : sourceSets.findByName(SourceSet.MAIN_SOURCE_SET_NAME);
+        if (sourceSet == null) {
+            return false;
+        }
+        return hasExplicitAwsFunctionRuntimeDependency(project.getConfigurations().findByName(sourceSet.getImplementationConfigurationName()))
+                || hasExplicitAwsFunctionRuntimeDependency(project.getConfigurations().findByName(sourceSet.getRuntimeOnlyConfigurationName()));
+    }
+
+    private boolean hasExplicitAwsFunctionRuntimeDependency(Configuration configuration) {
+        if (configuration == null) {
+            return false;
+        }
+        for (Dependency dependency : configuration.getDependencies()) {
+            if (MicronautRuntimeDependencies.isExplicitAwsFunctionRuntimeDependency(dependency.getGroup(), dependency.getName())) {
+                return true;
             }
         }
         return false;

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
@@ -177,15 +177,18 @@ public class MicronautMinimalApplicationPlugin implements Plugin<Project> {
         project.afterEvaluate(p -> {
             MicronautRuntime micronautRuntime = resolveRuntime(p);
             DependencyHandler dependencyHandler = p.getDependencies();
-            if (!(micronautRuntime.isLambda() && hasExplicitAwsFunctionRuntimeDependency(project))) {
-                MicronautRuntimeDependencies.findApplicationPluginDependenciesByRuntime(micronautRuntime)
-                        .toMap()
-                        .forEach((scope, dependencies) -> {
-                    for (AutomaticDependency dependency : dependencies) {
-                        dependency.applyTo(project);
+            boolean hasExplicitAwsFunctionRuntimeDependency = micronautRuntime.isLambda() && hasExplicitAwsFunctionRuntimeDependency(project);
+            MicronautRuntimeDependencies.findApplicationPluginDependenciesByRuntime(micronautRuntime)
+                    .toMap()
+                    .forEach((scope, dependencies) -> {
+                for (AutomaticDependency dependency : dependencies) {
+                    if (hasExplicitAwsFunctionRuntimeDependency
+                            && MicronautRuntimeDependencies.isAutomaticAwsApiProxyDependency(dependency.coordinates())) {
+                        continue;
                     }
-                });
-            }
+                    dependency.applyTo(project);
+                }
+            });
             if (micronautRuntime == MicronautRuntime.GOOGLE_FUNCTION) {
                 configureGoogleCloudFunctionRuntime(project, p, dependencyHandler);
             }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntimeDependencies.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntimeDependencies.java
@@ -167,6 +167,11 @@ public final class MicronautRuntimeDependencies {
         return GROUP_MICRONAUT_AWS.equals(groupId) && ARTIFACT_ID_MICRONAUT_AWS_FUNCTION.equals(artifactId);
     }
 
+    static boolean isAutomaticAwsApiProxyDependency(String coordinates) {
+        return micronautAwsDependency(ARTIFACT_ID_MICRONAUT_AWS_API_PROXY).equals(coordinates)
+                || micronautAwsDependency(ARTIFACT_ID_MICRONAUT_AWS_API_PROXY_TEST).equals(coordinates);
+    }
+
     private static String micronautGcpDependency(String artifactId) {
         return dependency(GROUP_MICRONAUT_GCP, artifactId);
     }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntimeDependencies.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautRuntimeDependencies.java
@@ -56,6 +56,7 @@ public final class MicronautRuntimeDependencies {
     private static final String ARTIFACT_ID_MICRONAUT_AZURE_FUNCTION_HTTP = "micronaut-azure-function-http";
     private static final String ARTIFACT_ID_MICRONAUT_AZURE_FUNCTION_HTTP_TEST = "micronaut-azure-function-http-test";
 
+    private static final String ARTIFACT_ID_MICRONAUT_AWS_FUNCTION = "micronaut-function-aws";
     private static final String ARTIFACT_ID_MICRONAUT_AWS_CUSTOM_RUNTIME = "micronaut-function-aws-custom-runtime";
     private static final String ARTIFACT_ID_MICRONAUT_AWS_API_PROXY = "micronaut-function-aws-api-proxy";
     private static final String ARTIFACT_ID_MICRONAUT_AWS_API_PROXY_TEST = "micronaut-function-aws-api-proxy-test";
@@ -160,6 +161,10 @@ public final class MicronautRuntimeDependencies {
 
     private static String micronautAwsDependency(String artifactId) {
         return dependency(GROUP_MICRONAUT_AWS, artifactId);
+    }
+
+    static boolean isExplicitAwsFunctionRuntimeDependency(String groupId, String artifactId) {
+        return GROUP_MICRONAUT_AWS.equals(groupId) && ARTIFACT_ID_MICRONAUT_AWS_FUNCTION.equals(artifactId);
     }
 
     private static String micronautGcpDependency(String artifactId) {


### PR DESCRIPTION
## Summary

- narrow the Lambda explicit-function opt-out so it only suppresses the automatic AWS API-proxy coordinates while preserving `micronaut-function-aws-custom-runtime` for `lambda_provided`
- preserve the normal Lambda API-proxy defaults when `micronaut-function-aws` is declared only in test scope
- add regression coverage for both the explicit main-scope opt-out path and the test-scoped non-opt-out path, including the expected `lambda_provided` custom-runtime behavior

## Verification

- `JAVA_HOME="$HOME/.local/jdks/jdk-21.0.10+7" PATH="$HOME/.local/jdks/jdk-21.0.10+7/bin:$PATH" ./gradlew functional-tests:test --tests io.micronaut.gradle.RuntimeDependenciesSpec --no-daemon`

Closes #421

---
###### ✨ This message was AI-generated using gpt-5.4