### PR TITLE
Add import factory generation from dependency jars

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/GenerateImportFactoryTask.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/GenerateImportFactoryTask.java
@@ -3,7 +3,7 @@ package io.micronaut.gradle;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.internal.file.FileOperations;
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
@@ -35,6 +35,8 @@ import java.util.regex.Pattern;
  */
 @CacheableTask
 public abstract class GenerateImportFactoryTask extends DefaultTask {
+    private static final Pattern MULTI_RELEASE_JAR_PREFIX = Pattern.compile("^META-INF/versions/\\d+/");
+
     @Classpath
     public abstract ConfigurableFileCollection getDependencyJars();
 
@@ -52,12 +54,12 @@ public abstract class GenerateImportFactoryTask extends DefaultTask {
     public abstract DirectoryProperty getOutputDirectory();
 
     @Inject
-    protected abstract FileOperations getFileOperations();
+    protected abstract FileSystemOperations getFileSystemOperations();
 
     @TaskAction
     public void generate() {
         File outputDirectory = getOutputDirectory().get().getAsFile();
-        getFileOperations().delete(outputDirectory);
+        getFileSystemOperations().delete(spec -> spec.delete(outputDirectory));
 
         Set<String> packages = collectPackages();
         if (packages.isEmpty()) {
@@ -103,7 +105,7 @@ public abstract class GenerateImportFactoryTask extends DefaultTask {
         if (entry.isDirectory()) {
             return null;
         }
-        String entryName = entry.getName();
+        String entryName = stripMultiReleaseJarPrefix(entry.getName());
         if (!entryName.endsWith(".class")) {
             return null;
         }
@@ -116,6 +118,10 @@ public abstract class GenerateImportFactoryTask extends DefaultTask {
             return null;
         }
         return packageName;
+    }
+
+    private String stripMultiReleaseJarPrefix(String entryName) {
+        return MULTI_RELEASE_JAR_PREFIX.matcher(entryName).replaceFirst("");
     }
 
     private String normalizedTargetPackage() {

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/GenerateImportFactoryTask.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/GenerateImportFactoryTask.java
@@ -1,0 +1,165 @@
+package io.micronaut.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.internal.file.FileOperations;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+import javax.lang.model.SourceVersion;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Pattern;
+
+/**
+ * Generates {@code ImportFactory} source files from dependency jars.
+ *
+ * @since 5.0.0
+ */
+@CacheableTask
+public abstract class GenerateImportFactoryTask extends DefaultTask {
+    @Classpath
+    public abstract ConfigurableFileCollection getDependencyJars();
+
+    @Input
+    public abstract Property<String> getIncludePackagesFilter();
+
+    @Input
+    public abstract Property<String> getExcludePackagesFilter();
+
+    @Input
+    @Optional
+    public abstract Property<String> getTargetPackage();
+
+    @OutputDirectory
+    public abstract DirectoryProperty getOutputDirectory();
+
+    @Inject
+    protected abstract FileOperations getFileOperations();
+
+    @TaskAction
+    public void generate() {
+        File outputDirectory = getOutputDirectory().get().getAsFile();
+        getFileOperations().delete(outputDirectory);
+
+        Set<String> packages = collectPackages();
+        if (packages.isEmpty()) {
+            return;
+        }
+
+        String targetPackage = normalizedTargetPackage();
+        if (targetPackage == null) {
+            for (String packageName : packages) {
+                writeImportFactory(packageName, List.of(packageName));
+            }
+        } else {
+            writeImportFactory(targetPackage, List.copyOf(packages));
+        }
+    }
+
+    private Set<String> collectPackages() {
+        Pattern includePackages = Pattern.compile(getIncludePackagesFilter().get());
+        Pattern excludePackages = Pattern.compile(getExcludePackagesFilter().get());
+        Set<String> packages = new TreeSet<>();
+        for (File dependencyJar : getDependencyJars().getFiles()) {
+            packages.addAll(readPackages(dependencyJar, includePackages, excludePackages));
+        }
+        return packages;
+    }
+
+    private Set<String> readPackages(File dependencyJar, Pattern includePackages, Pattern excludePackages) {
+        try (JarFile jarFile = new JarFile(dependencyJar, false)) {
+            Set<String> packages = new TreeSet<>();
+            jarFile.stream()
+                .map(this::packageNameOf)
+                .filter(packageName -> packageName != null)
+                .filter(includePackages.asMatchPredicate())
+                .filter(excludePackages.asMatchPredicate().negate())
+                .forEach(packages::add);
+            return packages;
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to read " + dependencyJar, e);
+        }
+    }
+
+    private String packageNameOf(JarEntry entry) {
+        if (entry.isDirectory()) {
+            return null;
+        }
+        String entryName = entry.getName();
+        if (!entryName.endsWith(".class")) {
+            return null;
+        }
+        int slashIndex = entryName.lastIndexOf('/');
+        if (slashIndex <= 0) {
+            return null;
+        }
+        String packageName = entryName.substring(0, slashIndex).replace('/', '.');
+        if (!SourceVersion.isName(packageName)) {
+            return null;
+        }
+        return packageName;
+    }
+
+    private String normalizedTargetPackage() {
+        if (!getTargetPackage().isPresent()) {
+            return null;
+        }
+        String packageName = getTargetPackage().get().trim();
+        if (packageName.isEmpty()) {
+            return null;
+        }
+        if (!SourceVersion.isName(packageName)) {
+            throw new IllegalArgumentException("Invalid target package: " + packageName);
+        }
+        return packageName;
+    }
+
+    private void writeImportFactory(String packageName, List<String> importedPackages) {
+        Path factoryPath = getOutputDirectory().get().getAsFile().toPath()
+            .resolve(packageName.replace('.', '/'))
+            .resolve("ImportFactory.java");
+
+        List<String> code = new ArrayList<>();
+        code.add("package " + packageName + ";");
+        code.add("");
+        code.add("import io.micronaut.context.annotation.Factory;");
+        code.add("import io.micronaut.context.annotation.Import;");
+        code.add("");
+        code.add("@Factory");
+        code.add("@Import(");
+        code.add("    packages = {");
+        for (String importedPackage : importedPackages) {
+            code.add("        \"" + importedPackage + "\",");
+        }
+        code.add("    }");
+        code.add(")");
+        code.add("public final class ImportFactory {");
+        code.add("}");
+        code.add("");
+
+        try {
+            Files.createDirectories(factoryPath.getParent());
+            Files.write(factoryPath, code, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to write " + factoryPath, e);
+        }
+    }
+}

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/ImportFactoryConfiguration.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/ImportFactoryConfiguration.java
@@ -1,0 +1,76 @@
+package io.micronaut.gradle;
+
+import org.gradle.api.provider.Property;
+
+import javax.inject.Inject;
+
+/**
+ * Configuration for generating Micronaut import factories from dependency jars.
+ *
+ * @since 5.0.0
+ */
+public abstract class ImportFactoryConfiguration {
+    @Inject
+    public ImportFactoryConfiguration() {
+    }
+
+    /**
+     * @return Whether import factory generation is enabled.
+     */
+    public abstract Property<Boolean> getEnabled();
+
+    /**
+     * @return Regex used to include dependencies, matched against {@code group:name}.
+     */
+    public abstract Property<String> getIncludeDependenciesFilter();
+
+    /**
+     * @return Regex used to exclude dependencies, matched against {@code group:name}.
+     */
+    public abstract Property<String> getExcludeDependenciesFilter();
+
+    /**
+     * @return Regex used to include packages.
+     */
+    public abstract Property<String> getIncludePackagesFilter();
+
+    /**
+     * @return Regex used to exclude packages.
+     */
+    public abstract Property<String> getExcludePackagesFilter();
+
+    /**
+     * @return The target package for a single aggregated import factory.
+     */
+    public abstract Property<String> getTargetPackage();
+
+    public ImportFactoryConfiguration enabled(boolean enabled) {
+        getEnabled().set(enabled);
+        return this;
+    }
+
+    public ImportFactoryConfiguration includeDependenciesFilter(String filter) {
+        getIncludeDependenciesFilter().set(filter);
+        return this;
+    }
+
+    public ImportFactoryConfiguration excludeDependenciesFilter(String filter) {
+        getExcludeDependenciesFilter().set(filter);
+        return this;
+    }
+
+    public ImportFactoryConfiguration includePackagesFilter(String filter) {
+        getIncludePackagesFilter().set(filter);
+        return this;
+    }
+
+    public ImportFactoryConfiguration excludePackagesFilter(String filter) {
+        getExcludePackagesFilter().set(filter);
+        return this;
+    }
+
+    public ImportFactoryConfiguration targetPackage(String targetPackage) {
+        getTargetPackage().set(targetPackage);
+        return this;
+    }
+}

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -20,6 +20,8 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ExternalModuleDependency;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
@@ -40,6 +42,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 
 import static io.micronaut.gradle.PluginsHelper.applyAdditionalProcessors;
 import static io.micronaut.gradle.PluginsHelper.configureAnnotationProcessors;
@@ -72,6 +75,7 @@ public class MicronautComponentPlugin implements Plugin<Project> {
     );
     public static final String MICRONAUT_BOMS_CONFIGURATION = "micronautBoms";
     public static final String INSPECT_RUNTIME_CLASSPATH_TASK_NAME = "inspectRuntimeClasspath";
+    public static final String GENERATE_IMPORT_FACTORIES_TASK_NAME = "generateImportFactories";
 
     @Override
     public void apply(Project project) {
@@ -81,7 +85,7 @@ public class MicronautComponentPlugin implements Plugin<Project> {
         TaskContainer tasks = project.getTasks();
         TaskProvider<ApplicationClasspathInspector> inspectRuntimeClasspath = registerInspectRuntimeClasspath(project, tasks);
 
-        configureJava(project, tasks);
+        configureJava(project, tasks, micronautExtension);
 
         configureGroovy(project, tasks, micronautExtension);
 
@@ -216,9 +220,18 @@ public class MicronautComponentPlugin implements Plugin<Project> {
     }
 
 
-    private void configureJava(Project project, TaskContainer tasks) {
+    private void configureJava(Project project, TaskContainer tasks, MicronautExtension micronautExtension) {
+        TaskProvider<GenerateImportFactoryTask> generateImportFactories = registerGenerateImportFactories(project, tasks, micronautExtension);
 
         project.afterEvaluate(p -> {
+            boolean importFactoryEnabled = micronautExtension.getImportFactory().getEnabled().getOrElse(false);
+            generateImportFactories.configure(task -> task.setEnabled(importFactoryEnabled));
+            if (importFactoryEnabled) {
+                SourceSet mainSourceSet = PluginsHelper.findSourceSets(p).findByName(SourceSet.MAIN_SOURCE_SET_NAME);
+                if (mainSourceSet != null) {
+                    mainSourceSet.getJava().srcDir(generateImportFactories);
+                }
+            }
             var sourceSets = PluginsHelper.findSourceSets(p);
             for (String sourceSetName : SOURCESETS) {
                 SourceSet sourceSet = sourceSets.findByName(sourceSetName);
@@ -245,7 +258,6 @@ public class MicronautComponentPlugin implements Plugin<Project> {
             }
 
             tasks.withType(JavaCompile.class).configureEach(javaCompile -> {
-                final MicronautExtension micronautExtension = p.getExtensions().getByType(MicronautExtension.class);
                 final AnnotationProcessing processing = micronautExtension.getProcessing();
                 final boolean isIncremental = processing.getIncremental().getOrElse(true);
                 final String group = processing.getGroup().getOrElse(p.getGroup().toString());
@@ -276,6 +288,38 @@ public class MicronautComponentPlugin implements Plugin<Project> {
             });
         });
 
+    }
+
+    private static TaskProvider<GenerateImportFactoryTask> registerGenerateImportFactories(Project project,
+                                                                                           TaskContainer tasks,
+                                                                                           MicronautExtension micronautExtension) {
+        return tasks.register(GENERATE_IMPORT_FACTORIES_TASK_NAME, GenerateImportFactoryTask.class, task -> {
+            ImportFactoryConfiguration importFactory = micronautExtension.getImportFactory();
+            task.setGroup(BasePlugin.BUILD_GROUP);
+            task.setDescription("Generates Micronaut import factories from dependency jars");
+            task.getIncludePackagesFilter().convention(importFactory.getIncludePackagesFilter());
+            task.getExcludePackagesFilter().convention(importFactory.getExcludePackagesFilter());
+            task.getTargetPackage().convention(importFactory.getTargetPackage());
+            task.getOutputDirectory().convention(project.getLayout().getBuildDirectory().dir("generated-sources/importfactory"));
+            task.getDependencyJars().from(project.getConfigurations()
+                .getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+                .getIncoming()
+                .artifactView(view -> view.componentFilter(componentIdentifier ->
+                    matchesDependencyFilter(componentIdentifier,
+                        importFactory.getIncludeDependenciesFilter().get(),
+                        importFactory.getExcludeDependenciesFilter().get())))
+                .getFiles());
+        });
+    }
+
+    private static boolean matchesDependencyFilter(ComponentIdentifier componentIdentifier,
+                                                  String includeFilter,
+                                                  String excludeFilter) {
+        if (!(componentIdentifier instanceof ModuleComponentIdentifier moduleComponentIdentifier)) {
+            return false;
+        }
+        String identifier = moduleComponentIdentifier.getGroup() + ":" + moduleComponentIdentifier.getModule();
+        return Pattern.matches(includeFilter, identifier) && !Pattern.matches(excludeFilter, identifier);
     }
 
 

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -295,6 +295,8 @@ public class MicronautComponentPlugin implements Plugin<Project> {
                                                                                            MicronautExtension micronautExtension) {
         return tasks.register(GENERATE_IMPORT_FACTORIES_TASK_NAME, GenerateImportFactoryTask.class, task -> {
             ImportFactoryConfiguration importFactory = micronautExtension.getImportFactory();
+            Pattern includeDependencyFilter = Pattern.compile(importFactory.getIncludeDependenciesFilter().get());
+            Pattern excludeDependencyFilter = Pattern.compile(importFactory.getExcludeDependenciesFilter().get());
             task.setGroup(BasePlugin.BUILD_GROUP);
             task.setDescription("Generates Micronaut import factories from dependency jars");
             task.getIncludePackagesFilter().convention(importFactory.getIncludePackagesFilter());
@@ -306,20 +308,20 @@ public class MicronautComponentPlugin implements Plugin<Project> {
                 .getIncoming()
                 .artifactView(view -> view.componentFilter(componentIdentifier ->
                     matchesDependencyFilter(componentIdentifier,
-                        importFactory.getIncludeDependenciesFilter().get(),
-                        importFactory.getExcludeDependenciesFilter().get())))
+                        includeDependencyFilter,
+                        excludeDependencyFilter)))
                 .getFiles());
         });
     }
 
     private static boolean matchesDependencyFilter(ComponentIdentifier componentIdentifier,
-                                                  String includeFilter,
-                                                  String excludeFilter) {
+                                                   Pattern includeFilter,
+                                                   Pattern excludeFilter) {
         if (!(componentIdentifier instanceof ModuleComponentIdentifier moduleComponentIdentifier)) {
             return false;
         }
         String identifier = moduleComponentIdentifier.getGroup() + ":" + moduleComponentIdentifier.getModule();
-        return Pattern.matches(includeFilter, identifier) && !Pattern.matches(excludeFilter, identifier);
+        return includeFilter.matcher(identifier).matches() && !excludeFilter.matcher(identifier).matches();
     }
 
 

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
@@ -25,6 +25,7 @@ public abstract class MicronautExtension implements ExtensionAware {
     private final Property<Boolean> enableNativeImage;
     private final Property<MicronautRuntime> runtime;
     private final Property<MicronautTestRuntime> testRuntime;
+    private final ImportFactoryConfiguration importFactory;
 
     /**
      * If set to false, then the Micronaut Gradle plugins will not automatically
@@ -48,6 +49,7 @@ public abstract class MicronautExtension implements ExtensionAware {
     @Inject
     public MicronautExtension(ObjectFactory objectFactory, SourceSetConfigurer sourceSetConfigurer) {
         this.processing = objectFactory.newInstance(AnnotationProcessing.class, sourceSetConfigurer);
+        this.importFactory = objectFactory.newInstance(ImportFactoryConfiguration.class);
         this.version = objectFactory.property(String.class);
         this.enableNativeImage = objectFactory.property(Boolean.class)
                                     .convention(true);
@@ -56,6 +58,11 @@ public abstract class MicronautExtension implements ExtensionAware {
         this.testRuntime = objectFactory.property(MicronautTestRuntime.class)
                                         .convention(MicronautTestRuntime.NONE);
         getImportMicronautPlatform().convention(true);
+        this.importFactory.getEnabled().convention(false);
+        this.importFactory.getIncludeDependenciesFilter().convention("^.*:.*$");
+        this.importFactory.getExcludeDependenciesFilter().convention("^$");
+        this.importFactory.getIncludePackagesFilter().convention("^.*$");
+        this.importFactory.getExcludePackagesFilter().convention("^$");
     }
 
     /**
@@ -166,6 +173,13 @@ public abstract class MicronautExtension implements ExtensionAware {
     }
 
     /**
+     * @return Configuration for import factory generation.
+     */
+    public ImportFactoryConfiguration getImportFactory() {
+        return importFactory;
+    }
+
+    /**
      * Property which drives if incremental native builds should be enabled.
      * @return the incremental property
      */
@@ -178,6 +192,16 @@ public abstract class MicronautExtension implements ExtensionAware {
      */
     public MicronautExtension processing(Action<AnnotationProcessing> processingAction) {
         processingAction.execute(this.getProcessing());
+        return this;
+    }
+
+    /**
+     * Allows configuring import factory generation.
+     * @param importFactoryAction The import factory configuration action
+     * @return This extension
+     */
+    public MicronautExtension importFactory(Action<ImportFactoryConfiguration> importFactoryAction) {
+        importFactoryAction.execute(this.getImportFactory());
         return this;
     }
 

--- a/minimal-plugin/src/test/groovy/io/micronaut/gradle/GenerateImportFactoryTaskSpec.groovy
+++ b/minimal-plugin/src/test/groovy/io/micronaut/gradle/GenerateImportFactoryTaskSpec.groovy
@@ -169,10 +169,12 @@ class ImportFactoryEnabledTest {
         when:
         def result = build('compileJava')
         File generatedSources = file("build/generated-sources/importfactory")
-        List<String> generatedFiles = Files.walk(generatedSources.toPath())
-            .filter(path -> path.fileName.toString() == "ImportFactory.java")
-            .collect { generatedSources.toPath().relativize(it).toString().replace(File.separatorChar, '/' as char) }
-            .sort()
+        List<String> generatedFiles = Files.walk(generatedSources.toPath()).withCloseable { paths ->
+            paths
+                .filter(path -> path.fileName.toString() == "ImportFactory.java")
+                .collect { generatedSources.toPath().relativize(it).toString().replace(File.separatorChar, '/' as char) }
+                .sort()
+        }
 
         then:
         result.task(":generateImportFactories").outcome == TaskOutcome.SUCCESS
@@ -220,6 +222,46 @@ class ImportFactoryEnabledTest {
         result.task(":generateImportFactories").outcome == TaskOutcome.SUCCESS
         result.task(":compileJava").outcome == TaskOutcome.NO_SOURCE
         (!generatedSources.exists()) || generatedSources.list().length == 0
+    }
+
+    def "multi-release jar entries contribute package imports"() {
+        given:
+        File repositoryDir = publishDependencyRepository()
+        settingsFile << "rootProject.name = 'import-factory-multi-release'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.library"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                importFactory {
+                    enabled.set(true)
+                    includeDependenciesFilter.set("com\\\\.example\\\\.imports:sample-alpha")
+                    includePackagesFilter.set("example\\\\.versioned.*")
+                    targetPackage.set("example.generated")
+                }
+            }
+
+            repositories {
+                maven { url = uri("${repositoryDir.toURI()}") }
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation "com.example.imports:sample-alpha:1.0"
+            }
+        """
+
+        when:
+        def result = build('compileJava')
+        File generatedFactory = file("build/generated-sources/importfactory/example/generated/ImportFactory.java")
+
+        then:
+        result.task(":generateImportFactories").outcome == TaskOutcome.SUCCESS
+        result.task(":compileJava").outcome == TaskOutcome.SUCCESS
+        generatedFactory.exists()
+        normalizeLineEndings(generatedFactory.text).contains('"example.versioned"')
     }
 
     private File publishDependencyRepository() {
@@ -289,6 +331,7 @@ import jakarta.inject.Singleton;
 public class HiddenService {
 }
 """)
+        writeDependencyBinaryResource(repositoryProjectDir, "sample-alpha", "META-INF/versions/17/example/versioned/VersionedService.class")
         writeDependencySource(repositoryProjectDir, "sample-beta", "example/imported/beta/BetaService.java", """
 package example.imported.beta;
 
@@ -322,6 +365,12 @@ public class SharedBetaService {
         File sourceFile = new File(repositoryProjectDir, "${projectName}/src/main/java/${relativePath}")
         sourceFile.parentFile.mkdirs()
         sourceFile.text = source
+    }
+
+    private void writeDependencyBinaryResource(File repositoryProjectDir, String projectName, String relativePath) {
+        File resourceFile = new File(repositoryProjectDir, "${projectName}/src/main/resources/${relativePath}")
+        resourceFile.parentFile.mkdirs()
+        Files.write(resourceFile.toPath(), [0] as byte[])
     }
 
     private void writeTest(String source) {

--- a/minimal-plugin/src/test/groovy/io/micronaut/gradle/GenerateImportFactoryTaskSpec.groovy
+++ b/minimal-plugin/src/test/groovy/io/micronaut/gradle/GenerateImportFactoryTaskSpec.groovy
@@ -1,0 +1,332 @@
+package io.micronaut.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Issue
+
+import java.nio.file.Files
+
+@Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/960")
+class GenerateImportFactoryTaskSpec extends AbstractGradleBuildSpec {
+
+    def "import factory generation is disabled by default"() {
+        given:
+        File repositoryDir = publishDependencyRepository()
+        settingsFile << "rootProject.name = 'import-factory-disabled'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.library"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                testRuntime "junit5"
+            }
+
+            repositories {
+                maven { url = uri("${repositoryDir.toURI()}") }
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation "com.example.imports:sample-alpha:1.0"
+            }
+        """
+        writeTest("""
+package example;
+
+import example.imported.alpha.AlphaService;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@MicronautTest
+class ImportFactoryDisabledTest {
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Test
+    void importedBeansAreNotRegistered() {
+        Assertions.assertFalse(applicationContext.containsBean(AlphaService.class));
+    }
+}
+""")
+
+        when:
+        def result = build('test')
+
+        then:
+        result.task(":test").outcome == TaskOutcome.SUCCESS
+        !file("build/generated-sources/importfactory").exists()
+    }
+
+    def "enabled import factory generation honors filters"() {
+        given:
+        File repositoryDir = publishDependencyRepository()
+        settingsFile << "rootProject.name = 'import-factory-enabled'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.library"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                testRuntime "junit5"
+                importFactory {
+                    enabled.set(true)
+                    includeDependenciesFilter.set("com\\\\.example\\\\.imports:sample-.*")
+                    excludeDependenciesFilter.set("com\\\\.example\\\\.imports:sample-beta")
+                    includePackagesFilter.set("example\\\\.(imported\\\\.alpha|shared).*")
+                    excludePackagesFilter.set("example\\\\.shared\\\\.internal.*")
+                    targetPackage.set("example.generated")
+                }
+            }
+
+            repositories {
+                maven { url = uri("${repositoryDir.toURI()}") }
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation "com.example.imports:sample-alpha:1.0"
+                implementation "com.example.imports:sample-beta:1.0"
+            }
+        """
+        writeTest("""
+package example;
+
+import example.imported.alpha.AlphaService;
+import example.imported.beta.BetaService;
+import example.shared.SharedAlphaService;
+import example.shared.internal.HiddenService;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@MicronautTest
+class ImportFactoryEnabledTest {
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Test
+    void matchingBeansAreImported() {
+        Assertions.assertTrue(applicationContext.containsBean(AlphaService.class));
+        Assertions.assertTrue(applicationContext.containsBean(SharedAlphaService.class));
+        Assertions.assertFalse(applicationContext.containsBean(BetaService.class));
+        Assertions.assertFalse(applicationContext.containsBean(HiddenService.class));
+    }
+}
+""")
+
+        when:
+        def result = build('test')
+        File generatedFactory = file("build/generated-sources/importfactory/example/generated/ImportFactory.java")
+
+        then:
+        result.task(":generateImportFactories").outcome == TaskOutcome.SUCCESS
+        result.task(":test").outcome == TaskOutcome.SUCCESS
+        generatedFactory.exists()
+        normalizeLineEndings(generatedFactory.text).contains('"example.imported.alpha"')
+        normalizeLineEndings(generatedFactory.text).contains('"example.shared"')
+        !normalizeLineEndings(generatedFactory.text).contains('"example.imported.beta"')
+        !normalizeLineEndings(generatedFactory.text).contains('"example.shared.internal"')
+    }
+
+    def "target package unset generates per-package factories with deduplicated output"() {
+        given:
+        File repositoryDir = publishDependencyRepository()
+        settingsFile << "rootProject.name = 'import-factory-per-package'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.library"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                importFactory {
+                    enabled.set(true)
+                    includeDependenciesFilter.set("com\\\\.example\\\\.imports:sample-.*")
+                    includePackagesFilter.set("example\\\\.(imported\\\\.(alpha|beta)|shared).*")
+                    excludePackagesFilter.set("example\\\\.shared\\\\.internal.*")
+                }
+            }
+
+            repositories {
+                maven { url = uri("${repositoryDir.toURI()}") }
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation "com.example.imports:sample-alpha:1.0"
+                implementation "com.example.imports:sample-beta:1.0"
+            }
+        """
+
+        when:
+        def result = build('compileJava')
+        File generatedSources = file("build/generated-sources/importfactory")
+        List<String> generatedFiles = Files.walk(generatedSources.toPath())
+            .filter(path -> path.fileName.toString() == "ImportFactory.java")
+            .collect { generatedSources.toPath().relativize(it).toString().replace(File.separatorChar, '/' as char) }
+            .sort()
+
+        then:
+        result.task(":generateImportFactories").outcome == TaskOutcome.SUCCESS
+        result.task(":compileJava").outcome == TaskOutcome.SUCCESS
+        generatedFiles == [
+            "example/imported/alpha/ImportFactory.java",
+            "example/imported/beta/ImportFactory.java",
+            "example/shared/ImportFactory.java"
+        ]
+        normalizeLineEndings(file("build/generated-sources/importfactory/example/shared/ImportFactory.java").text).count('"example.shared"') == 1
+    }
+
+    def "enabled import factory generation succeeds with no matching dependencies"() {
+        given:
+        File repositoryDir = publishDependencyRepository()
+        settingsFile << "rootProject.name = 'import-factory-no-matches'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.library"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                importFactory {
+                    enabled.set(true)
+                    includeDependenciesFilter.set("com\\\\.example\\\\.imports:missing")
+                }
+            }
+
+            repositories {
+                maven { url = uri("${repositoryDir.toURI()}") }
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation "com.example.imports:sample-alpha:1.0"
+            }
+        """
+
+        when:
+        def result = build('compileJava')
+        File generatedSources = file("build/generated-sources/importfactory")
+
+        then:
+        result.task(":generateImportFactories").outcome == TaskOutcome.SUCCESS
+        result.task(":compileJava").outcome == TaskOutcome.NO_SOURCE
+        (!generatedSources.exists()) || generatedSources.list().length == 0
+    }
+
+    private File publishDependencyRepository() {
+        File repositoryProjectDir = file("dependency-repository")
+        repositoryProjectDir.mkdirs()
+        new File(repositoryProjectDir, "settings.gradle") << """
+            rootProject.name = 'dependency-repository'
+            include 'sample-alpha', 'sample-beta'
+        """
+        new File(repositoryProjectDir, "build.gradle") << """
+            allprojects {
+                group = 'com.example.imports'
+                version = '1.0'
+
+                repositories {
+                    mavenCentral()
+                }
+            }
+
+            subprojects {
+                apply plugin: 'java-library'
+                apply plugin: 'maven-publish'
+
+                dependencies {
+                    api 'jakarta.inject:jakarta.inject-api:2.0.1'
+                }
+
+                publishing {
+                    publications {
+                        maven(MavenPublication) {
+                            from components.java
+                        }
+                    }
+                    repositories {
+                        maven {
+                            name = 'test'
+                            url = uri(rootProject.layout.buildDirectory.dir('repo').get().asFile)
+                        }
+                    }
+                }
+            }
+        """
+        writeDependencySource(repositoryProjectDir, "sample-alpha", "example/imported/alpha/AlphaService.java", """
+package example.imported.alpha;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class AlphaService {
+}
+""")
+        writeDependencySource(repositoryProjectDir, "sample-alpha", "example/shared/SharedAlphaService.java", """
+package example.shared;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class SharedAlphaService {
+}
+""")
+        writeDependencySource(repositoryProjectDir, "sample-alpha", "example/shared/internal/HiddenService.java", """
+package example.shared.internal;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class HiddenService {
+}
+""")
+        writeDependencySource(repositoryProjectDir, "sample-beta", "example/imported/beta/BetaService.java", """
+package example.imported.beta;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class BetaService {
+}
+""")
+        writeDependencySource(repositoryProjectDir, "sample-beta", "example/shared/SharedBetaService.java", """
+package example.shared;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class SharedBetaService {
+}
+""")
+
+        GradleRunner.create()
+            .withProjectDir(repositoryProjectDir)
+            .withArguments("--no-watch-fs", "-S", "publishAllPublicationsToTestRepository")
+            .forwardStdOutput(System.out.newWriter())
+            .forwardStdError(System.err.newWriter())
+            .build()
+
+        return new File(repositoryProjectDir, "build/repo")
+    }
+
+    private void writeDependencySource(File repositoryProjectDir, String projectName, String relativePath, String source) {
+        File sourceFile = new File(repositoryProjectDir, "${projectName}/src/main/java/${relativePath}")
+        sourceFile.parentFile.mkdirs()
+        sourceFile.text = source
+    }
+
+    private void writeTest(String source) {
+        File testFile = file("src/test/java/example/ImportFactoryTest.java")
+        testFile.parentFile.mkdirs()
+        testFile.text = source
+    }
+}

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -93,6 +93,54 @@ For example, the `minimal` plugins can be used to reduce the number of tasks, fo
 |
 |===
 
+[[import-factory-generation]]
+== Import Factories From Dependencies
+
+The minimal Micronaut plugins can generate Java `ImportFactory` sources from dependency jars so that `@Import` declarations stay aligned with packages published by external libraries.
+
+This feature is opt-in and disabled by default. When enabled, the plugin scans matching runtime dependency jars, generates Java sources under `build/generated-sources/importfactory`, and wires them into the main source set automatically.
+
+Use narrow dependency and package filters where possible instead of scanning every dependency on the runtime classpath.
+
+.Groovy DSL
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+micronaut {
+  importFactory {
+    enabled.set(true)
+    includeDependenciesFilter.set("com\\.example:legacy-.*")
+    excludeDependenciesFilter.set("com\\.example:legacy-tests")
+    includePackagesFilter.set("com\\.example\\.legacy\\..*")
+    excludePackagesFilter.set("com\\.example\\.legacy\\.internal\\..*")
+    targetPackage.set("com.example.generated")
+  }
+}
+----
+
+.Kotlin DSL
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+micronaut {
+    importFactory {
+        enabled.set(true)
+        includeDependenciesFilter.set("com\\.example:legacy-.*")
+        excludeDependenciesFilter.set("com\\.example:legacy-tests")
+        includePackagesFilter.set("com\\.example\\.legacy\\..*")
+        excludePackagesFilter.set("com\\.example\\.legacy\\.internal\\..*")
+        targetPackage.set("com.example.generated")
+    }
+}
+----
+
+Configuration properties:
+
+* `enabled`: turns generation on
+* `includeDependenciesFilter`: regex matched against `group:name`
+* `excludeDependenciesFilter`: regex matched against `group:name`
+* `includePackagesFilter`: regex matched against discovered package names
+* `excludePackagesFilter`: regex matched against discovered package names
+* `targetPackage`: when set, generates one aggregated `ImportFactory`; otherwise one `ImportFactory` is generated per matched package
+
 [[configuration-validation]]
 == Micronaut Configuration Validation Plugin
 


### PR DESCRIPTION
## Summary
- add an opt-in `micronaut.importFactory` DSL for generating Micronaut import factories from dependency jars
- register a cacheable `generateImportFactories` task and wire generated Java into the main source set
- add functional coverage and guide docs for filters, per-package generation, and `targetPackage`

## Verification
- `./gradlew :micronaut-minimal-plugin:test --tests 'io.micronaut.gradle.GenerateImportFactoryTaskSpec'`
- `./gradlew :micronaut-minimal-plugin:check docs`

Closes #960
---
###### ✨ This message was AI-generated using gpt-5
