### PR TITLE
Document editDockerfile workaround for dnf releasever

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1109,6 +1109,52 @@ The `editDockerfile` DSL allows you to:
 - insert lines by calling `insert`
 - replace lines by calling `replace`
 
+There is no dedicated Gradle DSL property for `dnf --releasever`. If you need to opt into a specific DNF release policy for the generated native-image Dockerfile, customize `dockerfileNative` directly and replace the generated `RUN dnf ...` lines.
+
+For example, the following recipe opts into `--releasever=latest` for the DNF-based native-image stages. A concrete release value such as `2023.6.20241031` may be safer than `latest` when your target distribution requires deterministic upgrades.
+
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+tasks.named("dockerfileNative") {
+    editDockerfile {
+        before("FROM graalvm AS builder") {
+            replace(
+                "RUN dnf update -y && dnf install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf",
+                "RUN dnf --releasever=latest update -y && dnf --releasever=latest install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf"
+            )
+        }
+        after("FROM graalvm AS builder") {
+            replace(
+                "RUN dnf update -y && dnf install -y zip && dnf clean all",
+                "RUN dnf --releasever=latest update -y && dnf --releasever=latest install -y zip && dnf clean all"
+            )
+        }
+    }
+}
+----
+
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+tasks.named<io.micronaut.gradle.docker.NativeImageDockerfile>("dockerfileNative") {
+    editDockerfile {
+        before("FROM graalvm AS builder") {
+            replace(
+                "RUN dnf update -y && dnf install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf",
+                "RUN dnf --releasever=latest update -y && dnf --releasever=latest install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf"
+            )
+        }
+        after("FROM graalvm AS builder") {
+            replace(
+                "RUN dnf update -y && dnf install -y zip && dnf clean all",
+                "RUN dnf --releasever=latest update -y && dnf --releasever=latest install -y zip && dnf clean all"
+            )
+        }
+    }
+}
+----
+
+After changing the recipe, run `./gradlew dockerfileNative` and inspect the generated `DockerfileNative` under `build/docker` to confirm the `RUN dnf ...` lines now include your chosen `--releasever` value.
+
 ==== Duplicates on classpath
 
 In some projects, it may happen that different transitive dependencies have the same file name.

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1111,6 +1111,8 @@ The `editDockerfile` DSL allows you to:
 
 There is no dedicated Gradle DSL property for `dnf --releasever`. If you need to opt into a specific DNF release policy for the generated native-image Dockerfile, customize `dockerfileNative` directly and replace the generated `RUN dnf ...` lines.
 
+The `editDockerfile` matchers are exact string replacements. Generate `DockerfileNative` first and copy the current `RUN dnf ...` lines from `build/docker/DockerfileNative` into `replace(...)` so the recipe stays aligned with the Dockerfile produced by your plugin version and chosen base image.
+
 For example, the following recipe opts into `--releasever=latest` for the DNF-based native-image stages. A concrete release value such as `2023.6.20241031` may be safer than `latest` when your target distribution requires deterministic upgrades.
 
 [source, groovy, subs="verbatim,attributes", role="multi-language-sample"]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1113,7 +1113,7 @@ There is no dedicated Gradle DSL property for `dnf --releasever`. If you need to
 
 The `editDockerfile` matchers are exact string replacements. Generate `DockerfileNative` first and copy the current `RUN dnf ...` lines from `build/docker/DockerfileNative` into `replace(...)` so the recipe stays aligned with the Dockerfile produced by your plugin version and chosen base image.
 
-For example, the following recipe opts into `--releasever=latest` for the DNF-based native-image stages. A concrete release value such as `2023.6.20241031` may be safer than `latest` when your target distribution requires deterministic upgrades.
+For example, the following recipe uses a placeholder release value for the DNF-based native-image stages. Replace `<releasever>` with the exact release value you want for your target distribution. If you intentionally want a moving target such as `latest`, treat that as a separate opt-in choice with less deterministic rebuild behavior.
 
 [source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
 ----
@@ -1122,13 +1122,13 @@ tasks.named("dockerfileNative") {
         before("FROM graalvm AS builder") {
             replace(
                 "RUN dnf update -y && dnf install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf",
-                "RUN dnf --releasever=latest update -y && dnf --releasever=latest install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf"
+                "RUN dnf --releasever=<releasever> update -y && dnf --releasever=<releasever> install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf"
             )
         }
         after("FROM graalvm AS builder") {
             replace(
                 "RUN dnf update -y && dnf install -y zip && dnf clean all",
-                "RUN dnf --releasever=latest update -y && dnf --releasever=latest install -y zip && dnf clean all"
+                "RUN dnf --releasever=<releasever> update -y && dnf --releasever=<releasever> install -y zip && dnf clean all"
             )
         }
     }
@@ -1142,13 +1142,13 @@ tasks.named<io.micronaut.gradle.docker.NativeImageDockerfile>("dockerfileNative"
         before("FROM graalvm AS builder") {
             replace(
                 "RUN dnf update -y && dnf install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf",
-                "RUN dnf --releasever=latest update -y && dnf --releasever=latest install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf"
+                "RUN dnf --releasever=<releasever> update -y && dnf --releasever=<releasever> install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf"
             )
         }
         after("FROM graalvm AS builder") {
             replace(
                 "RUN dnf update -y && dnf install -y zip && dnf clean all",
-                "RUN dnf --releasever=latest update -y && dnf --releasever=latest install -y zip && dnf clean all"
+                "RUN dnf --releasever=<releasever> update -y && dnf --releasever=<releasever> install -y zip && dnf clean all"
             )
         }
     }


### PR DESCRIPTION
Fixes #1144

## Summary

- document the supported `editDockerfile` workaround for adding `dnf --releasever=<value>` to generated native-image Dockerfiles
- clarify that this issue does not add a new Gradle DSL option or change the generated default `dnf` commands
- explain that `--releasever=latest` is opt-in and a concrete release value may be safer for deterministic distribution policies

## Validation

- `./gradlew docs --console=plain`

---
###### ✨ This message was AI-generated using gpt-5.4
