### PR TITLE
Add buildLayers exclude patterns

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/BuildLayersTask.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/BuildLayersTask.java
@@ -12,6 +12,7 @@ import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
@@ -35,6 +36,10 @@ public abstract class BuildLayersTask extends DefaultTask {
     @Input
     @Optional
     public abstract Property<DuplicatesStrategy> getDuplicatesStrategy();
+
+    @Input
+    @Optional
+    public abstract SetProperty<String> getExcludes();
 
     @OutputDirectory
     public abstract DirectoryProperty getOutputDir();
@@ -67,6 +72,7 @@ public abstract class BuildLayersTask extends DefaultTask {
         Map<Path, Path> copiedFiles = new LinkedHashMap<>();
         fileOperations.copy(copy -> {
             configureDuplicatesStrategy(copy);
+            configureExcludes(copy);
             copy.from(layer.getFiles()).into(destination);
             customizer.execute(copy);
             copy.eachFile(details -> recordCopiedFile(copiedFiles, destinationPath.resolve(relativePathOf(details)), details.getFile().toPath()));
@@ -105,6 +111,12 @@ public abstract class BuildLayersTask extends DefaultTask {
     private void configureDuplicatesStrategy(CopySpec copy) {
         if (getDuplicatesStrategy().isPresent()) {
             copy.setDuplicatesStrategy(getDuplicatesStrategy().get());
+        }
+    }
+
+    private void configureExcludes(CopySpec copy) {
+        if (getExcludes().isPresent()) {
+            copy.exclude(getExcludes().get());
         }
     }
 

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
@@ -152,6 +152,48 @@ class BuildLayersSpec extends AbstractGradleBuildSpec {
         Files.getLastModifiedTime(new File(testProjectDir.root, "build/docker/main/layers/libs/toto.jar").toPath()).toMillis() == 1000L
     }
 
+    void 'test build layers excludes configured resources'() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.docker"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+                testRuntime "junit5"
+            }
+
+            $repositoriesBlock
+
+            dependencies {
+                runtimeOnly("ch.qos.logback:logback-classic")
+                testImplementation("io.micronaut:micronaut-http-client")
+            }
+            application { mainClass = "example.Application" }
+
+            tasks.withType(io.micronaut.gradle.docker.tasks.BuildLayersTask).configureEach {
+                excludes.add("**/application-dev.properties")
+            }
+        """
+        file("src/main/resources").mkdirs()
+        file("src/main/resources/application.properties") << "micronaut.application.name=test-app"
+        file("src/main/resources/application-dev.properties") << "micronaut.server.port=8181"
+
+        when:
+        def result = build('buildLayers')
+
+        def task = result.task(":buildLayers")
+
+        then:
+        task.outcome == TaskOutcome.SUCCESS
+        new File(testProjectDir.root, "build/docker/main/layers/resources/application.properties").exists()
+        !new File(testProjectDir.root, "build/docker/main/layers/resources/application-dev.properties").exists()
+    }
+
     void 'test build layers preserves dependency mtimes across reruns'() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1209,6 +1209,24 @@ tasks.withType(io.micronaut.gradle.docker.tasks.BuildLayersTask) {
 }
 ----
 
+==== Excluding files from layers
+
+If you need to keep specific files out of the generated Docker layers, configure exclude patterns on the task:
+
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+tasks.withType(io.micronaut.gradle.docker.tasks.BuildLayersTask).configureEach {
+    excludes.add("**/application-dev.properties")
+}
+----
+
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+tasks.withType<io.micronaut.gradle.docker.tasks.BuildLayersTask>().configureEach {
+    excludes.add("**/application-dev.properties")
+}
+----
+
 ==== Docker build layers
 
 The `buildLayers` task creates files under `build/docker/main/layers` for the generated Docker image.


### PR DESCRIPTION
Closes #1105

## Summary

- add an optional `excludes` `SetProperty<String>` to `BuildLayersTask` and apply the patterns to each layer copy operation
- add a regression spec proving excluded resources do not land under `build/docker/main/layers/resources`
- document Groovy and Kotlin DSL configuration for excluding files from generated Docker layers

## Validation

- [x] `./gradlew :micronaut-docker-plugin:test --tests io.micronaut.gradle.BuildLayersSpec`
- [x] `./gradlew docs`

## Release Board

- No prior `qa-intake` artifact exists on `DEV-94`, so this PR records the current best-fit Micronaut organization project choice directly: `5.0.0 Release`
- Ambiguity note: `5.0.0-M3` is also open/public for the unreleased `master` line, but `5.0.0 Release` is the better stable-target board for this additive improvement
- Project linkage could not be applied from this run because the available GitHub authentication cannot enumerate or mutate the Micronaut organization project state cleanly

---
###### ✨ This message was AI-generated using gpt-5.4
