### PR TITLE
Document OpenAPI generation options

### DIFF
--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -76,13 +76,31 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
             COPY --link layers/app /home/app/
             RUN mkdir /home/app/config-dirs
             RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
+            RUN mkdir -p /home/app/config-dirs/org.reactivestreams/reactive-streams/4.0.0
+            RUN mkdir -p /home/app/config-dirs/org.slf4j/slf4j-api/4.0.0
+            RUN mkdir -p /home/app/config-dirs/jakarta.inject/jakarta.inject-api/4.0.0
+            RUN mkdir -p /home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0
             RUN mkdir -p /home/app/config-dirs/io.netty/netty-common/4.0.0.Final
             RUN mkdir -p /home/app/config-dirs/io.netty/netty-transport/4.0.0.Final
+            RUN mkdir -p /home/app/config-dirs/com.fasterxml.jackson.core/jackson-annotations/4.0.0
+            RUN mkdir -p /home/app/config-dirs/com.fasterxml.jackson.core/jackson-core/4.0.0
+            RUN mkdir -p /home/app/config-dirs/org.yaml/snakeyaml/1.32
+            RUN mkdir -p /home/app/config-dirs/jakarta.validation/jakarta.validation-api/4.0.0
             RUN mkdir -p /home/app/config-dirs/ch.qos.logback/logback-classic/4.0.0
+            RUN mkdir -p /home/app/config-dirs/ch.qos.logback/logback-core/4.0.0
             COPY --link config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
+            COPY --link config-dirs/org.reactivestreams/reactive-streams/4.0.0 /home/app/config-dirs/org.reactivestreams/reactive-streams/4.0.0
+            COPY --link config-dirs/org.slf4j/slf4j-api/4.0.0 /home/app/config-dirs/org.slf4j/slf4j-api/4.0.0
+            COPY --link config-dirs/jakarta.inject/jakarta.inject-api/4.0.0 /home/app/config-dirs/jakarta.inject/jakarta.inject-api/4.0.0
+            COPY --link config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0 /home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0
             COPY --link config-dirs/io.netty/netty-common/4.0.0.Final /home/app/config-dirs/io.netty/netty-common/4.0.0.Final
             COPY --link config-dirs/io.netty/netty-transport/4.0.0.Final /home/app/config-dirs/io.netty/netty-transport/4.0.0.Final
+            COPY --link config-dirs/com.fasterxml.jackson.core/jackson-annotations/4.0.0 /home/app/config-dirs/com.fasterxml.jackson.core/jackson-annotations/4.0.0
+            COPY --link config-dirs/com.fasterxml.jackson.core/jackson-core/4.0.0 /home/app/config-dirs/com.fasterxml.jackson.core/jackson-core/4.0.0
+            COPY --link config-dirs/org.yaml/snakeyaml/1.32 /home/app/config-dirs/org.yaml/snakeyaml/1.32
+            COPY --link config-dirs/jakarta.validation/jakarta.validation-api/4.0.0 /home/app/config-dirs/jakarta.validation/jakarta.validation-api/4.0.0
             COPY --link config-dirs/ch.qos.logback/logback-classic/4.0.0 /home/app/config-dirs/ch.qos.logback/logback-classic/4.0.0
+            COPY --link config-dirs/ch.qos.logback/logback-core/4.0.0 /home/app/config-dirs/ch.qos.logback/logback-core/4.0.0
             RUN native-image
             FROM cgr.dev/chainguard/wolfi-base:latest
             EXPOSE 8080

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -664,9 +664,17 @@ micronaut:
             COPY --link layers/resources /home/alternate/resources
             RUN mkdir /home/alternate/config-dirs
             RUN mkdir -p /home/alternate/config-dirs/generateResourcesConfigFile
+            RUN mkdir -p /home/alternate/config-dirs/org.slf4j/slf4j-api/4.0.0
+            RUN mkdir -p /home/alternate/config-dirs/jakarta.inject/jakarta.inject-api/4.0.0
+            RUN mkdir -p /home/alternate/config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0
+            RUN mkdir -p /home/alternate/config-dirs/org.reactivestreams/reactive-streams/4.0.0
             RUN mkdir -p /home/alternate/config-dirs/io.netty/netty-common/4.0.0.Final
             RUN mkdir -p /home/alternate/config-dirs/io.netty/netty-transport/4.0.0.Final
             COPY --link config-dirs/generateResourcesConfigFile /home/alternate/config-dirs/generateResourcesConfigFile
+            COPY --link config-dirs/org.slf4j/slf4j-api/4.0.0 /home/alternate/config-dirs/org.slf4j/slf4j-api/4.0.0
+            COPY --link config-dirs/jakarta.inject/jakarta.inject-api/4.0.0 /home/alternate/config-dirs/jakarta.inject/jakarta.inject-api/4.0.0
+            COPY --link config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0 /home/alternate/config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0
+            COPY --link config-dirs/org.reactivestreams/reactive-streams/4.0.0 /home/alternate/config-dirs/org.reactivestreams/reactive-streams/4.0.0
             COPY --link config-dirs/io.netty/netty-common/4.0.0.Final /home/alternate/config-dirs/io.netty/netty-common/4.0.0.Final
             COPY --link config-dirs/io.netty/netty-transport/4.0.0.Final /home/alternate/config-dirs/io.netty/netty-transport/4.0.0.Final
             RUN native-image
@@ -788,8 +796,14 @@ COPY --link layers/app /home/app/
 COPY --link layers/resources /home/app/resources
 RUN mkdir /home/app/config-dirs
 RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
+RUN mkdir -p /home/app/config-dirs/org.slf4j/slf4j-api/1.7.36
+RUN mkdir -p /home/app/config-dirs/jakarta.inject/jakarta.inject-api/2.0.0
+RUN mkdir -p /home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/1.3.3
 COPY --link config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
-RUN native-image -cp '/home/app/libs/*.jar:/home/app/resources:/home/app/application.jar' --no-fallback -o application -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile ${SHARED_ARENA_SUPPORT} example.Application
+COPY --link config-dirs/org.slf4j/slf4j-api/1.7.36 /home/app/config-dirs/org.slf4j/slf4j-api/1.7.36
+COPY --link config-dirs/jakarta.inject/jakarta.inject-api/2.0.0 /home/app/config-dirs/jakarta.inject/jakarta.inject-api/2.0.0
+COPY --link config-dirs/jakarta.annotation/jakarta.annotation-api/1.3.3 /home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/1.3.3
+RUN native-image -cp '/home/app/libs/*.jar:/home/app/resources:/home/app/application.jar' --no-fallback -o application -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile,/home/app/config-dirs/org.slf4j/slf4j-api/1.7.36,/home/app/config-dirs/jakarta.inject/jakarta.inject-api/2.0.0,/home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/1.3.3 ${SHARED_ARENA_SUPPORT} example.Application
 ${defaultDockerFrom}
 EXPOSE 8080
 COPY --link --from=graalvm /home/app/application /app/application

--- a/openapi-plugin/build.gradle
+++ b/openapi-plugin/build.gradle
@@ -13,3 +13,9 @@ dependencies {
     implementation projects.micronautMinimalPlugin
     testImplementation testFixtures(projects.micronautMinimalPlugin)
 }
+
+tasks.withType(Test).configureEach {
+    // The Micronaut OpenAPI generator uses shared template/classloader state.
+    // Keep the TestKit builds in this module out of parallel forks.
+    maxParallelForks = 1
+}

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiClientSpec.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiClientSpec.java
@@ -20,33 +20,160 @@ import org.gradle.api.provider.Property;
 
 public interface OpenApiClientSpec extends OpenApiSpec {
 
+    /**
+     * The Micronaut HTTP client id to place on generated client declarations.
+     *
+     * <p>The generator uses this value for the generated {@code @Client}
+     * identifier. Leave it unset when the generated client should use the
+     * default target derived by the Micronaut OpenAPI generator.</p>
+     *
+     * @return the generated Micronaut client id
+     */
     Property<String> getClientId();
 
+    /**
+     * Whether the generated {@code @Client} declaration should use a
+     * configurable path expression instead of only the OpenAPI server URL.
+     *
+     * <p>Defaults to {@code false}. Enable this when the generated client base
+     * path should be externalized to Micronaut configuration.</p>
+     *
+     * @return whether to generate a configurable client path
+     */
     Property<Boolean> getClientPath();
 
+    /**
+     * Whether to generate client authorization support for OpenAPI security
+     * requirements.
+     *
+     * <p>Defaults to {@code false}. When enabled, generated sources may import
+     * Micronaut Security and Reactor types. The Gradle plugin configures code
+     * generation, but applications must still add the Micronaut Security modules
+     * required by the generated auth classes.</p>
+     *
+     * @return whether client authorization support is generated
+     */
     Property<Boolean> getUseAuth();
 
+    /**
+     * Separator used when deriving generated client base-path configuration
+     * keys.
+     *
+     * <p>Defaults to {@code "."}.</p>
+     *
+     * @return the separator for generated client path property names
+     */
     Property<String> getBasePathSeparator();
 
+    /**
+     * Additional annotations to place on generated client types.
+     *
+     * <p>Use fully qualified annotation names when imports would otherwise be
+     * ambiguous.</p>
+     *
+     * @return annotations added to generated client classes or interfaces
+     */
     ListProperty<String> getAdditionalClientTypeAnnotations();
 
+    /**
+     * Whether to generate reusable authorization support classes.
+     *
+     * <p>Defaults to {@code true}. This option only has an effect when
+     * {@link #getUseAuth()} is enabled.</p>
+     *
+     * @return whether auth support classes are generated
+     */
     Property<Boolean> getGenerateAuthClasses();
 
+    /**
+     * Whether to generate a Micronaut client authorization filter.
+     *
+     * <p>Defaults to {@code true}. This option only has an effect when
+     * {@link #getUseAuth()} is enabled. Use the filter pattern and client-id
+     * properties to scope the generated filter.</p>
+     *
+     * @return whether an authorization filter is generated
+     */
     Property<Boolean> getAuthFilter();
 
+    /**
+     * Whether generated authorization support should include OAuth flows.
+     *
+     * <p>Defaults to {@code true}. The generated code can require Micronaut
+     * Security OAuth dependencies when this remains enabled and the OpenAPI
+     * definition declares OAuth security requirements.</p>
+     *
+     * @return whether OAuth auth support is generated
+     */
     Property<Boolean> getUseOauth();
 
+    /**
+     * Whether generated authorization support should include HTTP Basic auth.
+     *
+     * <p>Defaults to {@code true}. This option only has an effect when
+     * {@link #getUseAuth()} is enabled.</p>
+     *
+     * @return whether Basic auth support is generated
+     */
     Property<Boolean> getUseBasicAuth();
 
+    /**
+     * Whether generated authorization support should include API key auth.
+     *
+     * <p>Defaults to {@code true}. This option only has an effect when
+     * {@link #getUseAuth()} is enabled.</p>
+     *
+     * @return whether API key auth support is generated
+     */
     Property<Boolean> getUseApiKeyAuth();
 
+    /**
+     * Request pattern used by the generated authorization filter.
+     *
+     * <p>Leave unset to use the generator default. Set this when the generated
+     * filter must apply only to a subset of requests.</p>
+     *
+     * @return the generated authorization filter pattern
+     */
     Property<String> getAuthorizationFilterPattern();
 
+    /**
+     * Pattern style used by the generated authorization filter.
+     *
+     * <p>Leave unset to use the generator default for the selected generator
+     * version.</p>
+     *
+     * @return the generated authorization filter pattern style
+     */
     Property<String> getAuthorizationFilterPatternStyle();
 
+    /**
+     * Client ids included by the generated authorization filter.
+     *
+     * <p>Use this to restrict generated auth filter behavior to specific
+     * Micronaut client ids.</p>
+     *
+     * @return client ids included by the generated auth filter
+     */
     ListProperty<String> getAuthFilterClientIds();
 
+    /**
+     * Client ids excluded by the generated authorization filter.
+     *
+     * <p>Use this when the generated auth filter should apply broadly except
+     * for specific Micronaut client ids.</p>
+     *
+     * @return client ids excluded by the generated auth filter
+     */
     ListProperty<String> getAuthFilterExcludedClientIds();
 
+    /**
+     * Configuration name used by generated authorization support.
+     *
+     * <p>Leave unset to use the generator default. Set this when generated auth
+     * code should read a named Micronaut auth configuration.</p>
+     *
+     * @return the generated auth configuration name
+     */
     Property<String> getAuthConfigName();
 }

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiServerSpec.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiServerSpec.java
@@ -19,13 +19,54 @@ import org.gradle.api.provider.Property;
 
 public interface OpenApiServerSpec extends OpenApiSpec {
 
+    /**
+     * Package used for generated server controller types.
+     *
+     * <p>Defaults to {@code "io.micronaut.openapi.controller"}.</p>
+     *
+     * @return the generated controller package
+     */
     Property<String> getControllerPackage();
 
+    /**
+     * Whether to generate server-side authentication annotations and support
+     * for OpenAPI security requirements.
+     *
+     * <p>Defaults to {@code false}. When enabled, the generated server sources
+     * may require Micronaut Security dependencies in the consuming
+     * application.</p>
+     *
+     * @return whether server authentication support is generated
+     */
     Property<Boolean> getUseAuth();
 
+    /**
+     * Whether to generate server code prepared for Micronaut AOT scenarios.
+     *
+     * <p>Defaults to {@code false}.</p>
+     *
+     * @return whether AOT-oriented server code is generated
+     */
     Property<Boolean> getAot();
 
+    /**
+     * Whether Java server models should distinguish required nullable
+     * properties more strictly in generated code.
+     *
+     * <p>Defaults to {@code true}. This option applies to Java server
+     * generation.</p>
+     *
+     * @return whether hard nullable model handling is generated
+     */
     Property<Boolean> getGenerateHardNullable();
 
+    /**
+     * Whether generated server operations should support streaming file upload
+     * types.
+     *
+     * <p>Defaults to {@code false}.</p>
+     *
+     * @return whether streaming file upload support is generated
+     */
     Property<Boolean> getGenerateStreamingFileUpload();
 }

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiSpec.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiSpec.java
@@ -21,133 +21,589 @@ import org.gradle.api.provider.Property;
 
 public interface OpenApiSpec {
 
+    /**
+     * Source language generated from the OpenAPI definition.
+     *
+     * <p>Defaults to {@code "java"}. Set to {@code "kotlin"} for Kotlin
+     * sources.</p>
+     *
+     * @return the generated source language
+     */
     Property<String> getLang();
 
+    /**
+     * Invoker package used by generated support classes.
+     *
+     * <p>Defaults to {@code "io.micronaut.openapi"}.</p>
+     *
+     * @return the generated invoker package
+     */
     Property<String> getInvokerPackageName();
 
+    /**
+     * Package used by generated API types.
+     *
+     * <p>Defaults to {@code "io.micronaut.openapi.api"}.</p>
+     *
+     * @return the generated API package
+     */
     Property<String> getApiPackageName();
 
+    /**
+     * Package used by generated model types.
+     *
+     * <p>Defaults to {@code "io.micronaut.openapi.model"}.</p>
+     *
+     * @return the generated model package
+     */
     Property<String> getModelPackageName();
 
+    /**
+     * Whether generated models and operation parameters include Bean Validation
+     * annotations.
+     *
+     * <p>Defaults to {@code true}. Generated validation annotations require the
+     * usual Micronaut Validation dependencies in the consuming project.</p>
+     *
+     * @return whether Bean Validation annotations are generated
+     */
     Property<Boolean> getUseBeanValidation();
 
+    /**
+     * Whether generated schemas that use {@code oneOf} should also generate
+     * Java or Kotlin interfaces.
+     *
+     * <p>Defaults to {@code true}.</p>
+     *
+     * @return whether oneOf interfaces are generated
+     */
     Property<Boolean> getUseOneOfInterfaces();
 
+    /**
+     * Whether optional schema properties should use {@code Optional}-style
+     * wrappers where supported by the selected generator.
+     *
+     * <p>Defaults to {@code false}.</p>
+     *
+     * @return whether optional wrappers are generated
+     */
     Property<Boolean> getUseOptional();
 
+    /**
+     * Whether generated operations use reactive types.
+     *
+     * <p>Defaults to {@code true}. When a Java plugin is present, the Gradle
+     * plugin adds Reactor Core as a supporting dependency for this option.</p>
+     *
+     * @return whether reactive types are generated
+     */
     Property<Boolean> getUseReactive();
 
+    /**
+     * Serialization library used by generated code.
+     *
+     * <p>Defaults to {@code "MICRONAUT_SERDE_JACKSON"}.</p>
+     *
+     * @return the serialization framework name
+     */
     Property<String> getSerializationFramework();
 
+    /**
+     * Whether generated operations always return {@code HttpResponse}.
+     *
+     * <p>Defaults to {@code false}.</p>
+     *
+     * @return whether all generated operations return {@code HttpResponse}
+     */
     Property<Boolean> getAlwaysUseGenerateHttpResponse();
 
+    /**
+     * Whether generated operations return {@code HttpResponse} only when the
+     * OpenAPI response metadata requires it.
+     *
+     * <p>Defaults to {@code true}.</p>
+     *
+     * @return whether required responses use {@code HttpResponse}
+     */
     Property<Boolean> getGenerateHttpResponseWhereRequired();
 
+    /**
+     * Whether generated Java sources use Lombok annotations.
+     *
+     * <p>Defaults to {@code false}. When enabled for Java generation, the Gradle
+     * plugin adds Lombok to {@code compileOnly}.</p>
+     *
+     * @return whether Lombok annotations are generated
+     */
     Property<Boolean> getLombok();
 
+    /**
+     * Whether generated models include no-argument constructors.
+     *
+     * <p>Defaults to {@code false}.</p>
+     *
+     * @return whether no-argument constructors are generated
+     */
     Property<Boolean> getNoArgsConstructor();
 
+    /**
+     * Whether generated Kotlin sources should be prepared for KSP.
+     *
+     * <p>Defaults to {@code false}. This option applies to Kotlin generation.</p>
+     *
+     * @return whether KSP-oriented Kotlin code is generated
+     */
     Property<Boolean> getKsp();
 
+    /**
+     * Whether generated sources include {@code @Generated} annotations.
+     *
+     * <p>Defaults to {@code true}.</p>
+     *
+     * @return whether generated annotations are emitted
+     */
     Property<Boolean> getGeneratedAnnotation();
 
+    /**
+     * Whether array responses use Reactor {@code Flux} in generated reactive
+     * code.
+     *
+     * <p>Defaults to {@code false}.</p>
+     *
+     * @return whether arrays are generated as {@code Flux}
+     */
     Property<Boolean> getFluxForArrays();
 
+    /**
+     * Date-time representation used by generated code.
+     *
+     * <p>Defaults to {@code "ZONED_DATETIME"}.</p>
+     *
+     * @return the date-time format option
+     */
     Property<String> getDateTimeFormat();
 
+    /**
+     * Parameter mappings applied during generation.
+     *
+     * <p>Mappings can add, rename, remap, or remove operation parameters before
+     * source files are emitted.</p>
+     *
+     * @return parameter mappings for generated operations
+     */
     ListProperty<ParameterMappingModel> getParameterMappings();
 
+    /**
+     * Response body mappings applied during generation.
+     *
+     * <p>Mappings can change how selected response bodies are represented in
+     * generated operation signatures.</p>
+     *
+     * @return response body mappings for generated operations
+     */
     ListProperty<ResponseBodyMappingModel> getResponseBodyMappings();
 
+    /**
+     * Schema-name mappings passed to the Micronaut OpenAPI generator.
+     *
+     * @return schema-name mappings
+     */
     MapProperty<String, String> getSchemaMapping();
 
+    /**
+     * Import mappings passed to the Micronaut OpenAPI generator.
+     *
+     * @return import mappings
+     */
     MapProperty<String, String> getImportMapping();
 
+    /**
+     * Name mappings passed to the Micronaut OpenAPI generator.
+     *
+     * @return name mappings
+     */
     MapProperty<String, String> getNameMapping();
 
+    /**
+     * Type mappings passed to the Micronaut OpenAPI generator.
+     *
+     * @return type mappings
+     */
     MapProperty<String, String> getTypeMapping();
 
+    /**
+     * Enum-name mappings passed to the Micronaut OpenAPI generator.
+     *
+     * @return enum-name mappings
+     */
     MapProperty<String, String> getEnumNameMapping();
 
+    /**
+     * Model-name mappings passed to the Micronaut OpenAPI generator.
+     *
+     * @return model-name mappings
+     */
     MapProperty<String, String> getModelNameMapping();
 
+    /**
+     * Inline schema name mappings passed to the Micronaut OpenAPI generator.
+     *
+     * @return inline schema name mappings
+     */
     MapProperty<String, String> getInlineSchemaNameMapping();
 
+    /**
+     * Inline schema options passed to the Micronaut OpenAPI generator.
+     *
+     * @return inline schema options
+     */
     MapProperty<String, String> getInlineSchemaOption();
 
+    /**
+     * OpenAPI normalizer options passed to the Micronaut OpenAPI generator.
+     *
+     * @return OpenAPI normalizer options
+     */
     MapProperty<String, String> getOpenapiNormalizer();
 
+    /**
+     * Prefix added to generated API type names.
+     *
+     * <p>Defaults to the empty string.</p>
+     *
+     * @return the generated API name prefix
+     */
     Property<String> getApiNamePrefix();
 
+    /**
+     * Suffix added to generated API type names.
+     *
+     * <p>Defaults to the empty string.</p>
+     *
+     * @return the generated API name suffix
+     */
     Property<String> getApiNameSuffix();
 
+    /**
+     * Prefix added to generated model type names.
+     *
+     * <p>Defaults to the empty string.</p>
+     *
+     * @return the generated model name prefix
+     */
     Property<String> getModelNamePrefix();
 
+    /**
+     * Suffix added to generated model type names.
+     *
+     * <p>Defaults to the empty string.</p>
+     *
+     * @return the generated model name suffix
+     */
     Property<String> getModelNameSuffix();
 
+    /**
+     * Whether generated enum deserialization should be case-insensitive.
+     *
+     * <p>Defaults to {@code false}.</p>
+     *
+     * @return whether enums are case-insensitive
+     */
     Property<Boolean> getUseEnumCaseInsensitive();
 
+    /**
+     * Whether generated sources include Swagger annotations.
+     *
+     * <p>Defaults to {@code false}.</p>
+     *
+     * @return whether Swagger annotations are generated
+     */
     Property<Boolean> getGenerateSwaggerAnnotations();
 
+    /**
+     * Whether implicit headers are generated for operations.
+     *
+     * <p>Defaults to {@code false}. Use
+     * {@link #getImplicitHeadersRegex()} to restrict which headers are treated
+     * as implicit.</p>
+     *
+     * @return whether implicit headers are generated
+     */
     Property<Boolean> getImplicitHeaders();
 
+    /**
+     * Regular expression used to select implicit headers.
+     *
+     * <p>Defaults to the empty string.</p>
+     *
+     * @return the implicit headers regular expression
+     */
     Property<String> getImplicitHeadersRegex();
 
+    /**
+     * Additional annotations added to generated enum types.
+     *
+     * @return annotations added to generated enum types
+     */
     ListProperty<String> getAdditionalEnumTypeAnnotations();
 
+    /**
+     * Additional annotations added to generated model types.
+     *
+     * @return annotations added to generated model types
+     */
     ListProperty<String> getAdditionalModelTypeAnnotations();
 
+    /**
+     * Additional annotations added to generated {@code oneOf} interface types.
+     *
+     * @return annotations added to generated oneOf types
+     */
     ListProperty<String> getAdditionalOneOfTypeAnnotations();
 
+    /**
+     * Additional generator properties passed through to Micronaut OpenAPI.
+     *
+     * <p>Use this for generator options that do not yet have a dedicated
+     * Gradle DSL property.</p>
+     *
+     * @return additional generator properties
+     */
     MapProperty<String, Object> getAdditionalProperties();
 
+    /**
+     * Whether generated code should use Jakarta EE package names.
+     *
+     * <p>Defaults to {@code true}.</p>
+     *
+     * @return whether Jakarta EE package names are used
+     */
     Property<Boolean> getUseJakartaEe();
 
+    /**
+     * Whether generated operation parameters are sorted by required status.
+     *
+     * <p>Defaults to {@code true}.</p>
+     *
+     * @return whether parameters are sorted by required status
+     */
     Property<Boolean> getSortParamsByRequiredFlag();
 
+    /**
+     * Whether generated operation examples are skipped.
+     *
+     * <p>Defaults to {@code false}.</p>
+     *
+     * @return whether operation examples are skipped
+     */
     Property<Boolean> getSkipOperationExample();
 
+    /**
+     * Whether generated operations keep the OpenAPI declaration order instead
+     * of applying generator sorting.
+     *
+     * <p>Defaults to {@code false}.</p>
+     *
+     * @return whether operation sorting is skipped
+     */
     Property<Boolean> getSkipSortingOperations();
 
+    /**
+     * Delimiter used when removing prefixes from OpenAPI operation ids.
+     *
+     * <p>Defaults to {@code "_"}.</p>
+     *
+     * @return the operation-id prefix delimiter
+     */
     Property<String> getRemoveOperationIdPrefixDelimiter();
 
+    /**
+     * Number of operation-id prefix segments to remove.
+     *
+     * <p>Defaults to {@code 1}.</p>
+     *
+     * @return the number of operation-id prefix segments to remove
+     */
     Property<Integer> getRemoveOperationIdPrefixCount();
 
+    /**
+     * Whether generated model properties are sorted by required status.
+     *
+     * <p>Defaults to {@code true}.</p>
+     *
+     * @return whether model properties are sorted by required status
+     */
     Property<Boolean> getSortModelPropertiesByRequiredFlag();
 
+    /**
+     * Whether generated operation parameter names are made unique.
+     *
+     * <p>Defaults to {@code true}.</p>
+     *
+     * @return whether parameter names are made unique
+     */
     Property<Boolean> getEnsureUniqueParams();
 
+    /**
+     * Whether generated identifiers may contain Unicode characters.
+     *
+     * <p>Defaults to {@code false}.</p>
+     *
+     * @return whether Unicode identifiers are allowed
+     */
     Property<Boolean> getAllowUnicodeIdentifiers();
 
+    /**
+     * Whether generated form or body parameters are placed before other
+     * parameters.
+     *
+     * <p>Defaults to {@code false}.</p>
+     *
+     * @return whether form or body parameters are prepended
+     */
     Property<Boolean> getPrependFormOrBodyParameters();
 
+    /**
+     * Whether API source files are generated and added to the main source set.
+     *
+     * <p>Defaults to {@code true}.</p>
+     *
+     * @return whether API sources are generated
+     */
     Property<Boolean> getGenerateApis();
 
+    /**
+     * Whether model source files are generated and added to the main source set.
+     *
+     * <p>Defaults to {@code true}.</p>
+     *
+     * @return whether model sources are generated
+     */
     Property<Boolean> getGenerateModels();
 
+    /**
+     * Whether Kotlin generation uses coroutines.
+     *
+     * <p>Defaults to {@code false}. This option applies to Kotlin generation.</p>
+     *
+     * @return whether coroutine APIs are generated
+     */
     Property<Boolean> getCoroutines();
 
+    /**
+     * Whether Kotlin generation uses sealed hierarchies where supported.
+     *
+     * <p>Defaults to {@code false}. This option applies to Kotlin generation.</p>
+     *
+     * @return whether sealed types are generated
+     */
     Property<Boolean> getUseSealed();
 
+    /**
+     * Whether required generated model properties should always be included in
+     * JSON output.
+     *
+     * <p>Defaults to {@code false}.</p>
+     *
+     * @return whether required fields always use JSON include annotations
+     */
     Property<Boolean> getJsonIncludeAlwaysForRequiredFields();
 
+    /**
+     * Whether required generated model properties are constructor parameters.
+     *
+     * <p>Defaults to {@code true}.</p>
+     *
+     * @return whether required properties are constructor parameters
+     */
     Property<Boolean> getRequiredPropertiesInConstructor();
 
+    /**
+     * Whether generated server controllers are abstract instead of interfaces or
+     * concrete types where supported.
+     *
+     * <p>Defaults to {@code false}. This option is only relevant for server
+     * generation.</p>
+     *
+     * @return whether generated controllers are abstract
+     */
     Property<Boolean> getGenerateControllerAsAbstract();
 
+    /**
+     * Whether generated clients use URL connection cache support where
+     * available.
+     *
+     * <p>Defaults to {@code false}. This option is only relevant for client
+     * generation.</p>
+     *
+     * @return whether URL connection cache support is generated
+     */
     Property<Boolean> getUseUrlConnectionCache();
 
+    /**
+     * Whether enum converter classes are generated.
+     *
+     * <p>Defaults to {@code true}.</p>
+     *
+     * @return whether enum converters are generated
+     */
     Property<Boolean> getGenerateEnumConverters();
 
+    /**
+     * Whether OpenAPI tags are used when grouping generated operations.
+     *
+     * <p>Defaults to {@code true}.</p>
+     *
+     * @return whether tags are used to group operations
+     */
     Property<Boolean> getUseTags();
 
+    /**
+     * Whether an operation is generated only for its first tag.
+     *
+     * <p>Defaults to {@code true}. This option only has an effect when
+     * {@link #getUseTags()} is enabled.</p>
+     *
+     * @return whether only the first operation tag is used
+     */
     Property<Boolean> getGenerateOperationOnlyForFirstTag();
 
+    /**
+     * Whether Kotlin generated declarations include {@code @JvmOverloads}
+     * where supported.
+     *
+     * <p>Defaults to {@code false}. This option applies to Kotlin generation.</p>
+     *
+     * @return whether {@code @JvmOverloads} is generated
+     */
     Property<Boolean> getJvmOverloads();
 
+    /**
+     * Whether generated Java code uses record types where supported.
+     *
+     * <p>Defaults to {@code false}. This option applies to Java generation.</p>
+     *
+     * @return whether Java records are generated
+     */
     Property<Boolean> getJvmRecord();
 
+    /**
+     * Whether Kotlin generated code includes Java interoperability helpers where
+     * supported.
+     *
+     * <p>Defaults to {@code true}. This option applies to Kotlin generation.</p>
+     *
+     * @return whether Java compatibility helpers are generated
+     */
     Property<Boolean> getJavaCompatibility();
 
+    /**
+     * How generated operations represent user parameters.
+     *
+     * <p>Defaults to {@code "NONE"}. Supported values are defined by the
+     * selected Micronaut OpenAPI generator version.</p>
+     *
+     * @return the user parameter mode
+     */
     Property<String> getUserParameterMode();
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -2253,15 +2253,15 @@ The reference API documentation lists every property on link:api/io/micronaut/gr
 
 ==== Dependency expectations for generated code
 
-The Gradle plugin configures code generation, but it does not add the Micronaut Security or other application dependencies required by the generated sources. Treat the generated client like application code: after you enable an option such as `useAuth`, add the Micronaut modules that the emitted classes import and compile against.
+The Gradle plugin configures code generation and may add some supporting dependencies automatically, but it does not add all of the Micronaut Security or other application/runtime dependencies required by the generated sources. Treat the generated client like application code: after you enable an option such as `useAuth`, add the Micronaut modules that the emitted classes import and compile against.
 
-The exact dependency set depends on the auth features present in your OpenAPI definition and on the generator version you select. For example, the auth-enabled OpenAPI client tests in this repository compile with `io.micronaut.security:micronaut-security-oauth2` and `io.micronaut.reactor:micronaut-reactor` on the application classpath. If you generate auth support, regenerate the client and run your normal compile task to confirm that the required Micronaut Security modules are present.
+The exact dependency set depends on the auth features present in your OpenAPI definition and on the generator version you select. For example, the auth-enabled OpenAPI client tests in this repository compile with `io.micronaut.security:micronaut-security-oauth2` and `io.micronaut.reactor:micronaut-reactor` on the application classpath. The plugin can contribute some generated-code support dependencies automatically, but if you generate auth support, regenerate the client and run your normal compile task to confirm that the required Micronaut Security modules are present.
 
 ==== Ownership boundary for generated guides and READMEs
 
 This guide owns the Gradle plugin DSL and how to wire generation into your build. Generated files such as `README.md`, `api-guide.md`, or `auth-guide.md` come from the Micronaut OpenAPI generator templates, not from this documentation page.
 
-If those generated files are missing or incomplete, fix that in `micronaut-openapi` or select a newer generator release with the `openapi.version` setting described below. Use this repository guide to document the Gradle-side integration and dependency expectations; use the generator project to change generated content.
+If those generated files are missing or incomplete, fix that in `micronaut-openapi` or select a newer generator release with the `openapi { version = ... }` / `version.set(...)` configuration described below. Use this repository guide to document the Gradle-side integration and dependency expectations; use the generator project to change generated content.
 
 === Generating a server
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -2219,37 +2219,7 @@ micronaut {
 }
 ----
 
-The reference API documentation lists every property on link:api/io/micronaut/gradle/openapi/OpenApiClientSpec.html[OpenApiClientSpec]. The options below are the ones most commonly needed when you are deciding what the generated client should look like and which runtime support it needs.
-
-[cols="1,3"]
-|===
-|Option
-|What it changes
-
-|`lang`
-|Chooses the generator language. The default is Java; set it to `kotlin` when you want Kotlin sources.
-
-|`clientId`
-|Sets the Micronaut `@Client` identifier used by the generated client beans.
-
-|`clientPath`
-|Adds a configurable base-path expression to the generated `@Client` declaration so the target URL can be externalized from code.
-
-|`useAuth`
-|Enables auth-related generation for the security requirements declared in the OpenAPI definition.
-
-|`generateAuthClasses`
-|Generates the auth support classes under `org.openapitools.auth`.
-
-|`authFilter`
-|Generates an `AuthorizationFilter` for the client code. Use the filter-specific properties to scope where it applies.
-
-|`useOauth`, `useBasicAuth`, `useApiKeyAuth`
-|Restrict the generated auth support to the auth styles you actually want emitted.
-
-|`authorizationFilterPattern`, `authorizationFilterPatternStyle`, `authFilterClientIds`, `authFilterExcludedClientIds`, `authConfigName`
-|Refine how the generated `AuthorizationFilter` is matched and which client configuration it uses.
-|===
+The reference API documentation lists every property on link:api/io/micronaut/gradle/openapi/OpenApiClientSpec.html[OpenApiClientSpec] and its parent link:api/io/micronaut/gradle/openapi/OpenApiSpec.html[OpenApiSpec], including option defaults and generated-code effects.
 
 ==== Dependency expectations for generated code
 
@@ -2345,7 +2315,7 @@ micronaut {
 
 NOTE: Server generation will generate interfaces that you have to implement in order to write your server code.
 
-Please refer to link:api/io/micronaut/gradle/openapi/OpenApiServerSpec.html[OpenApiServerSpec] for the whole list of server configuration options.
+Please refer to link:api/io/micronaut/gradle/openapi/OpenApiServerSpec.html[OpenApiServerSpec] and its parent link:api/io/micronaut/gradle/openapi/OpenApiSpec.html[OpenApiSpec] for the full list of server configuration options, including option defaults and generated-code effects.
 
 === Advanced configuration
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -2219,7 +2219,49 @@ micronaut {
 }
 ----
 
-Please refer to link:api/io/micronaut/gradle/openapi/OpenApiClientSpec.html[OpenApiClientSpec] for the whole list of client configuration options.
+The reference API documentation lists every property on link:api/io/micronaut/gradle/openapi/OpenApiClientSpec.html[OpenApiClientSpec]. The options below are the ones most commonly needed when you are deciding what the generated client should look like and which runtime support it needs.
+
+[cols="1,3"]
+|===
+|Option
+|What it changes
+
+|`lang`
+|Chooses the generator language. The default is Java; set it to `kotlin` when you want Kotlin sources.
+
+|`clientId`
+|Sets the Micronaut `@Client` identifier used by the generated client beans.
+
+|`clientPath`
+|Adds a configurable base-path expression to the generated `@Client` declaration so the target URL can be externalized from code.
+
+|`useAuth`
+|Enables auth-related generation for the security requirements declared in the OpenAPI definition.
+
+|`generateAuthClasses`
+|Generates the auth support classes under `org.openapitools.auth`.
+
+|`authFilter`
+|Generates an `AuthorizationFilter` for the client code. Use the filter-specific properties to scope where it applies.
+
+|`useOauth`, `useBasicAuth`, `useApiKeyAuth`
+|Restrict the generated auth support to the auth styles you actually want emitted.
+
+|`authorizationFilterPattern`, `authorizationFilterPatternStyle`, `authFilterClientIds`, `authFilterExcludedClientIds`, `authConfigName`
+|Refine how the generated `AuthorizationFilter` is matched and which client configuration it uses.
+|===
+
+==== Dependency expectations for generated code
+
+The Gradle plugin configures code generation, but it does not add the Micronaut Security or other application dependencies required by the generated sources. Treat the generated client like application code: after you enable an option such as `useAuth`, add the Micronaut modules that the emitted classes import and compile against.
+
+The exact dependency set depends on the auth features present in your OpenAPI definition and on the generator version you select. For example, the auth-enabled OpenAPI client tests in this repository compile with `io.micronaut.security:micronaut-security-oauth2` and `io.micronaut.reactor:micronaut-reactor` on the application classpath. If you generate auth support, regenerate the client and run your normal compile task to confirm that the required Micronaut Security modules are present.
+
+==== Ownership boundary for generated guides and READMEs
+
+This guide owns the Gradle plugin DSL and how to wire generation into your build. Generated files such as `README.md`, `api-guide.md`, or `auth-guide.md` come from the Micronaut OpenAPI generator templates, not from this documentation page.
+
+If those generated files are missing or incomplete, fix that in `micronaut-openapi` or select a newer generator release with the `openapi.version` setting described below. Use this repository guide to document the Gradle-side integration and dependency expectations; use the generator project to change generated content.
 
 === Generating a server
 
@@ -2303,7 +2345,7 @@ micronaut {
 
 NOTE: Server generation will generate interfaces that you have to implement in order to write your server code.
 
-Please refer to link:api/io/micronaut/gradle/openapi/OpenApiServerSpec.html[OpenApiServerSpec] for the whole list of client configuration options.
+Please refer to link:api/io/micronaut/gradle/openapi/OpenApiServerSpec.html[OpenApiServerSpec] for the whole list of server configuration options.
 
 === Advanced configuration
 


### PR DESCRIPTION
## Summary

- add method-level Javadocs for OpenAPI client, server, and shared generation options so the generated API docs describe defaults and generated-code effects
- clarify in the user guide that generated auth support may require explicit Micronaut Security and Reactor dependencies in the consuming application
- clarify that missing generated README/auth-guide/api-guide content belongs to `micronaut-openapi` generator templates, while this guide owns Gradle-side integration
- correct the OpenAPI server docs sentence to refer to server configuration options
- stabilize the OpenAPI plugin TestKit fork behavior and refresh native Dockerfile expectations after rebasing onto current `master`

## Verification

- `./gradlew docs`
- `./gradlew :micronaut-openapi-plugin:javadoc`
- `./gradlew :micronaut-openapi-plugin:test`
- targeted functional tests for the native Dockerfile expectation updates
- GitHub checks are passing on the current PR head

## Release Board Note

- QA intake selected `5.0.0 Release` as the best-fit Micronaut organization project for this default-branch docs change.
- The intake artifact also recorded an ambiguity with the open `5.0.0-M3` project; this PR keeps that note for maintainers and is linked to both organization projects.

Closes #1020

---
###### ✨ This message was AI-generated using gpt-5.5