### PR TITLE
Preserve buildLayers file mtimes across reruns

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/BuildLayersTask.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/BuildLayersTask.java
@@ -19,8 +19,12 @@ import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
 import javax.inject.Inject;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @CacheableTask
 public abstract class BuildLayersTask extends DefaultTask {
@@ -47,15 +51,60 @@ public abstract class BuildLayersTask extends DefaultTask {
             final Provider<Directory> layerDir = layerDirectoryOf(layer, getOutputDir());
             if (layer.getLayerKind().get() == LayerKind.APP) {
                 // special case for now
-                fileOperations.copy(copy -> {
-                    configureDuplicatesStrategy(copy);
-                    copy.from(layer.getFiles()).into(getOutputDir().dir("app")).rename(s -> "application.jar");
-                });
+                copyLayer(fileOperations, layer, getOutputDir().dir("app"), true, copy -> copy.rename(s -> "application.jar"));
             } else {
-                fileOperations.copy(copy -> {
-                    configureDuplicatesStrategy(copy);
-                    copy.from(layer.getFiles()).into(layerDir);
+                copyLayer(fileOperations, layer, layerDir, false, copy -> {
                 });
+            }
+        }
+    }
+
+    private void copyLayer(FileOperations fileOperations,
+                           Layer layer,
+                           Provider<Directory> destination,
+                           boolean renameToApplicationJar,
+                           org.gradle.api.Action<CopySpec> customizer) {
+        Path destinationPath = destination.get().getAsFile().toPath();
+        Map<Path, Path> copiedFiles = copiedFilesOf(layer, destinationPath, renameToApplicationJar);
+        fileOperations.copy(copy -> {
+            configureDuplicatesStrategy(copy);
+            copy.from(layer.getFiles()).into(destination);
+            customizer.execute(copy);
+        });
+        restoreLastModifiedTimes(copiedFiles);
+    }
+
+    private Map<Path, Path> copiedFilesOf(Layer layer, Path destinationPath, boolean renameToApplicationJar) {
+        Map<Path, Path> copiedFiles = new LinkedHashMap<>();
+        for (File sourceFile : layer.getFiles().getFiles()) {
+            Path sourcePath = sourceFile.toPath();
+            if (!Files.exists(sourcePath)) {
+                continue;
+            }
+            if (Files.isDirectory(sourcePath)) {
+                try (var children = Files.walk(sourcePath)) {
+                    children.filter(Files::isRegularFile)
+                        .forEach(file -> copiedFiles.put(destinationPath.resolve(sourcePath.relativize(file).toString()), file));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            } else if (renameToApplicationJar) {
+                copiedFiles.put(destinationPath.resolve("application.jar"), sourcePath);
+            } else {
+                copiedFiles.put(destinationPath.resolve(sourceFile.getName()), sourcePath);
+            }
+        }
+        return copiedFiles;
+    }
+
+    private void restoreLastModifiedTimes(Map<Path, Path> copiedFiles) {
+        for (Map.Entry<Path, Path> entry : copiedFiles.entrySet()) {
+            try {
+                if (Files.exists(entry.getKey())) {
+                    Files.setLastModifiedTime(entry.getKey(), Files.getLastModifiedTime(entry.getValue()));
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             }
         }
     }

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/BuildLayersTask.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/BuildLayersTask.java
@@ -3,6 +3,7 @@ package io.micronaut.gradle.docker.tasks;
 import io.micronaut.gradle.docker.model.Layer;
 import io.micronaut.gradle.docker.model.LayerKind;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
@@ -19,7 +20,6 @@ import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
 import javax.inject.Inject;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -51,9 +51,9 @@ public abstract class BuildLayersTask extends DefaultTask {
             final Provider<Directory> layerDir = layerDirectoryOf(layer, getOutputDir());
             if (layer.getLayerKind().get() == LayerKind.APP) {
                 // special case for now
-                copyLayer(fileOperations, layer, getOutputDir().dir("app"), true, copy -> copy.rename(s -> "application.jar"));
+                copyLayer(fileOperations, layer, getOutputDir().dir("app"), copy -> copy.rename(s -> "application.jar"));
             } else {
-                copyLayer(fileOperations, layer, layerDir, false, copy -> {
+                copyLayer(fileOperations, layer, layerDir, copy -> {
                 });
             }
         }
@@ -62,39 +62,24 @@ public abstract class BuildLayersTask extends DefaultTask {
     private void copyLayer(FileOperations fileOperations,
                            Layer layer,
                            Provider<Directory> destination,
-                           boolean renameToApplicationJar,
                            org.gradle.api.Action<CopySpec> customizer) {
         Path destinationPath = destination.get().getAsFile().toPath();
-        Map<Path, Path> copiedFiles = copiedFilesOf(layer, destinationPath, renameToApplicationJar);
+        Map<Path, Path> copiedFiles = new LinkedHashMap<>();
         fileOperations.copy(copy -> {
             configureDuplicatesStrategy(copy);
             copy.from(layer.getFiles()).into(destination);
             customizer.execute(copy);
+            copy.eachFile(details -> copiedFiles.put(destinationPath.resolve(relativePathOf(details)), details.getFile().toPath()));
         });
         restoreLastModifiedTimes(copiedFiles);
     }
 
-    private Map<Path, Path> copiedFilesOf(Layer layer, Path destinationPath, boolean renameToApplicationJar) {
-        Map<Path, Path> copiedFiles = new LinkedHashMap<>();
-        for (File sourceFile : layer.getFiles().getFiles()) {
-            Path sourcePath = sourceFile.toPath();
-            if (!Files.exists(sourcePath)) {
-                continue;
-            }
-            if (Files.isDirectory(sourcePath)) {
-                try (var children = Files.walk(sourcePath)) {
-                    children.filter(Files::isRegularFile)
-                        .forEach(file -> copiedFiles.put(destinationPath.resolve(sourcePath.relativize(file).toString()), file));
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            } else if (renameToApplicationJar) {
-                copiedFiles.put(destinationPath.resolve("application.jar"), sourcePath);
-            } else {
-                copiedFiles.put(destinationPath.resolve(sourceFile.getName()), sourcePath);
-            }
+    private Path relativePathOf(org.gradle.api.file.FileCopyDetails details) {
+        String[] segments = details.getRelativePath().getSegments();
+        if (segments.length == 0) {
+            return Path.of("");
         }
-        return copiedFiles;
+        return Path.of(segments[0], java.util.Arrays.copyOfRange(segments, 1, segments.length));
     }
 
     private void restoreLastModifiedTimes(Map<Path, Path> copiedFiles) {
@@ -104,7 +89,7 @@ public abstract class BuildLayersTask extends DefaultTask {
                     Files.setLastModifiedTime(entry.getKey(), Files.getLastModifiedTime(entry.getValue()));
                 }
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new UncheckedIOException("Failed to restore mtime from " + entry.getValue() + " to " + entry.getKey(), e);
             }
         }
     }
@@ -122,7 +107,7 @@ public abstract class BuildLayersTask extends DefaultTask {
         try {
             Files.createDirectories(dir.get().getAsFile().toPath());
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException("Failed to create layer directory " + dir.get().getAsFile(), e);
         }
         return dir;
     }

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/BuildLayersTask.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/BuildLayersTask.java
@@ -69,9 +69,17 @@ public abstract class BuildLayersTask extends DefaultTask {
             configureDuplicatesStrategy(copy);
             copy.from(layer.getFiles()).into(destination);
             customizer.execute(copy);
-            copy.eachFile(details -> copiedFiles.put(destinationPath.resolve(relativePathOf(details)), details.getFile().toPath()));
+            copy.eachFile(details -> recordCopiedFile(copiedFiles, destinationPath.resolve(relativePathOf(details)), details.getFile().toPath()));
         });
         restoreLastModifiedTimes(copiedFiles);
+    }
+
+    private void recordCopiedFile(Map<Path, Path> copiedFiles, Path target, Path source) {
+        if (getDuplicatesStrategy().isPresent() && getDuplicatesStrategy().get() == DuplicatesStrategy.EXCLUDE) {
+            copiedFiles.putIfAbsent(target, source);
+        } else {
+            copiedFiles.put(target, source);
+        }
     }
 
     private Path relativePathOf(org.gradle.api.file.FileCopyDetails details) {

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
@@ -1,6 +1,9 @@
 package io.micronaut.gradle
 
+import groovy.io.FileType
 import org.gradle.testkit.runner.TaskOutcome
+
+import java.nio.file.Files
 
 class BuildLayersSpec extends AbstractGradleBuildSpec {
 
@@ -91,5 +94,74 @@ class BuildLayersSpec extends AbstractGradleBuildSpec {
         then:
         task.outcome == TaskOutcome.SUCCESS
         new File(testProjectDir.root, "build/docker/main/layers").exists()
+    }
+
+    void 'test build layers preserves dependency mtimes across reruns'() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.docker"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+                testRuntime "junit5"
+            }
+
+            $repositoriesBlock
+
+            dependencies {
+                runtimeOnly("ch.qos.logback:logback-classic")
+            }
+            application { mainClass = "example.Application" }
+        """
+
+        when:
+        def firstBuild = build('buildLayers')
+        def copiedJar = new File(testProjectDir.root, "build/docker/main/layers/libs").listFiles().find {
+            it.name.startsWith("logback-classic-") && it.name.endsWith(".jar")
+        }
+        assert copiedJar != null
+        def sourceJar = cachedDependency("ch.qos.logback", "logback-classic", copiedJar.name)
+        def sourceMtime = Files.getLastModifiedTime(sourceJar.toPath()).toMillis()
+        def firstCopiedMtime = Files.getLastModifiedTime(copiedJar.toPath()).toMillis()
+
+        sleep(1100)
+        def secondBuild = build('buildLayers', '--rerun-tasks')
+        def secondCopiedMtime = Files.getLastModifiedTime(copiedJar.toPath()).toMillis()
+
+        then:
+        firstBuild.task(":buildLayers").outcome == TaskOutcome.SUCCESS
+        secondBuild.task(":buildLayers").outcome == TaskOutcome.SUCCESS
+        firstCopiedMtime == sourceMtime
+        secondCopiedMtime == sourceMtime
+        secondCopiedMtime == firstCopiedMtime
+    }
+
+    private static File cachedDependency(String group, String module, String fileName) {
+        def cacheRoots = [
+            System.getenv("GRADLE_USER_HOME"),
+            new File(System.getProperty("java.io.tmpdir"), ".gradle-test-kit").absolutePath,
+            new File(System.getProperty("user.home"), ".gradle").absolutePath
+        ].findAll { it != null }
+        for (def cacheRoot : cacheRoots) {
+            def cacheDir = new File(cacheRoot, "caches/modules-2/files-2.1/${group}/${module}")
+            if (!cacheDir.exists()) {
+                continue
+            }
+            File dependencyJar
+            cacheDir.eachFileRecurse(FileType.FILES) { file ->
+                if (file.name == fileName) {
+                    dependencyJar = file
+                }
+            }
+            if (dependencyJar != null) {
+                return dependencyJar
+            }
+        }
+        assert false: "Unable to locate ${fileName} for ${group}:${module} under ${cacheRoots}"
     }
 }

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
@@ -4,6 +4,7 @@ import groovy.io.FileType
 import org.gradle.testkit.runner.TaskOutcome
 
 import java.nio.file.Files
+import java.nio.file.attribute.FileTime
 
 class BuildLayersSpec extends AbstractGradleBuildSpec {
 
@@ -129,7 +130,7 @@ class BuildLayersSpec extends AbstractGradleBuildSpec {
         def sourceMtime = Files.getLastModifiedTime(sourceJar.toPath()).toMillis()
         def firstCopiedMtime = Files.getLastModifiedTime(copiedJar.toPath()).toMillis()
 
-        sleep(1100)
+        Files.setLastModifiedTime(copiedJar.toPath(), FileTime.fromMillis(1))
         def secondBuild = build('buildLayers', '--rerun-tasks')
         def secondCopiedMtime = Files.getLastModifiedTime(copiedJar.toPath()).toMillis()
 
@@ -146,7 +147,7 @@ class BuildLayersSpec extends AbstractGradleBuildSpec {
             System.getenv("GRADLE_USER_HOME"),
             new File(System.getProperty("java.io.tmpdir"), ".gradle-test-kit").absolutePath,
             new File(System.getProperty("user.home"), ".gradle").absolutePath
-        ].findAll { it != null }
+        ].findAll { it?.trim() }
         for (def cacheRoot : cacheRoots) {
             def cacheDir = new File(cacheRoot, "caches/modules-2/files-2.1/${group}/${module}")
             if (!cacheDir.exists()) {
@@ -162,6 +163,6 @@ class BuildLayersSpec extends AbstractGradleBuildSpec {
                 return dependencyJar
             }
         }
-        assert false: "Unable to locate ${fileName} for ${group}:${module} under ${cacheRoots}"
+        throw new IllegalStateException("Unable to locate ${fileName} for ${group}:${module} under ${cacheRoots}")
     }
 }

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
@@ -97,6 +97,61 @@ class BuildLayersSpec extends AbstractGradleBuildSpec {
         new File(testProjectDir.root, "build/docker/main/layers").exists()
     }
 
+    void 'test build layers preserves duplicate winner mtime with exclude strategy'() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.docker"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+                testRuntime "junit5"
+            }
+
+            $repositoriesBlock
+
+            dependencies {
+                runtimeOnly("ch.qos.logback:logback-classic")
+                testImplementation("io.micronaut:micronaut-http-client")
+            }
+            application { mainClass = "example.Application" }
+
+            def jar1 = tasks.register("otherJar", Jar) {
+                destinationDirectory = file("build/libs1")
+                archiveBaseName = 'toto'
+                from sourceSets.main.output
+                doLast {
+                    archiveFile.get().asFile.setLastModified(1000L)
+                }
+            }
+            def jar2 = tasks.register("otherJar2", Jar) {
+                destinationDirectory = file("build/libs2")
+                archiveBaseName = 'toto'
+                from sourceSets.main.output
+                doLast {
+                    archiveFile.get().asFile.setLastModified(2000L)
+                }
+            }
+
+            configurations.runtimeOnly.dependencies.add(dependencies.create(files(jar1, jar2)))
+
+            tasks.withType(io.micronaut.gradle.docker.tasks.BuildLayersTask) {
+                duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+            }
+        """
+
+        when:
+        def result = build('buildLayers')
+
+        then:
+        result.task(":buildLayers").outcome == TaskOutcome.SUCCESS
+        Files.getLastModifiedTime(new File(testProjectDir.root, "build/docker/main/layers/libs/toto.jar").toPath()).toMillis() == 1000L
+    }
+
     void 'test build layers preserves dependency mtimes across reruns'() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"


### PR DESCRIPTION
## Summary

Closes #978

- restore copied file mtimes in `BuildLayersTask` after each layer copy so unchanged dependency jars keep the source artifact timestamp across reruns
- preserve the existing layer layout, duplicate-target winner behavior, and the APP-layer `application.jar` rename path while applying the timestamp fix
- add a focused `BuildLayersSpec` regression that reruns `buildLayers --rerun-tasks` and asserts the copied dependency jar mtime still matches the source artifact

## Context

QA intake chose the Micronaut organization project `5.0.0-M3` for this fix. `5.0.0 Release` remains the umbrella fallback if milestone scope shifts later.

## Verification

- [x] `./gradlew :micronaut-docker-plugin:test --tests io.micronaut.gradle.BuildLayersSpec --rerun-tasks`

---
###### ✨ This message was AI-generated using gpt-5
