### PR TITLE
docs: document exposedPorts for generated Dockerfiles

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1040,7 +1040,7 @@ tasks.named("dockerfileNative") {
 
 [source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
 ----
-tasks.named<MicronautDockerfile>("dockerfile") {
+tasks.named<io.micronaut.gradle.docker.MicronautDockerfile>("dockerfile") {
    exposedPorts.set(listOf(8123, 8443))
 }
 tasks.named<io.micronaut.gradle.docker.NativeImageDockerfile>("dockerfileNative") {
@@ -1048,7 +1048,7 @@ tasks.named<io.micronaut.gradle.docker.NativeImageDockerfile>("dockerfileNative"
 }
 ----
 
-After updating the task, run `./gradlew dockerfile` or `./gradlew dockerfileNative` and inspect the generated Dockerfile under `build/docker` to confirm the expected `EXPOSE` lines are present.
+After updating the task, run `./gradlew dockerfile` or `./gradlew dockerfileNative` and inspect the generated Dockerfile under `build/docker/<imageName>/Dockerfile` or `build/docker/native-<imageName>/DockerfileNative` (for example, `build/docker/main/Dockerfile`) to confirm the expected `EXPOSE` lines are present.
 
 ==== GraalVM JDK version
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1026,6 +1026,30 @@ tasks.named<io.micronaut.gradle.docker.NativeImageDockerfile>("dockerfileNative"
 
 The above configuration uses a max heap setting of `128m` for Java and `64m` for native executable for the application.
 
+The generated `dockerfile` and `dockerfileNative` tasks expose port `8080` by default. To override the ports declared in the generated Dockerfile, configure `exposedPorts` on the corresponding task:
+
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+tasks.named("dockerfile") {
+   exposedPorts = [8123, 8443]
+}
+tasks.named("dockerfileNative") {
+   exposedPorts = [9000]
+}
+----
+
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+tasks.named<MicronautDockerfile>("dockerfile") {
+   exposedPorts.set(listOf(8123, 8443))
+}
+tasks.named<io.micronaut.gradle.docker.NativeImageDockerfile>("dockerfileNative") {
+   exposedPorts.set(listOf(9000))
+}
+----
+
+After updating the task, run `./gradlew dockerfile` or `./gradlew dockerfileNative` and inspect the generated Dockerfile under `build/docker` to confirm the expected `EXPOSE` lines are present.
+
 ==== GraalVM JDK version
 
 By default, the `dockerfileNative` task will create a dockerfile that uses the Graal JDK base image with the current JDK version.


### PR DESCRIPTION
## Summary
- document that generated `dockerfile` and `dockerfileNative` tasks expose port `8080` by default
- add Groovy and Kotlin examples for overriding `exposedPorts`
- tell users to regenerate the Dockerfile and verify the resulting `EXPOSE` lines under `build/docker`

## Release targeting
- QA intake selected the Micronaut organization project `5.0.0-M3`
- Ambiguity note preserved from QA: `5.0.0 Release` may become the better final attachment if this lands after the next milestone cutoff

Closes #343

---
###### ✨ This message was AI-generated using gpt-5.4
