### PR TITLE
Fix lambda_provided JVM main class handling

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
@@ -152,7 +152,8 @@ public abstract class MicronautDockerfile extends Dockerfile implements DockerBu
                 );
                 break;
             case LAMBDA:
-                javaApplication.getMainClass().set("io.micronaut.function.aws.runtime.MicronautLambdaRuntime");
+                // Lambda JVM images use the standard runner JAR entrypoint.
+                // Native lambda main-class handling stays task-local in NativeImageDockerfile.
             default:
                 from(new Dockerfile.From(from != null ? from : DEFAULT_BASE_IMAGE + getDockerDefaultImageJavaTag()));
                 setupResources(this, getLayers().get(), null);

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
@@ -152,8 +152,7 @@ public abstract class MicronautDockerfile extends Dockerfile implements DockerBu
                 );
                 break;
             case LAMBDA:
-                // Lambda JVM images use the standard runner JAR entrypoint.
-                // Native lambda main-class handling stays task-local in NativeImageDockerfile.
+                // JVM Lambda images share the standard layer layout; the entrypoint is specialized below.
             default:
                 from(new Dockerfile.From(from != null ? from : DEFAULT_BASE_IMAGE + getDockerDefaultImageJavaTag()));
                 setupResources(this, getLayers().get(), null);
@@ -161,11 +160,17 @@ public abstract class MicronautDockerfile extends Dockerfile implements DockerBu
                 getInstructions().addAll(additionalInstructions);
                 if (getInstructions().get().stream().noneMatch(instruction -> instruction.getKeyword().equals(EntryPointInstruction.KEYWORD))) {
                     entryPoint(getArgs().map(strings -> {
-                        var newList = new ArrayList<String>(strings.size() + 3);
+                        var newList = new ArrayList<String>(strings.size() + 4);
                         newList.add("java");
                         newList.addAll(strings);
-                        newList.add("-jar");
-                        newList.add(workDir + "/application.jar");
+                        if (buildStrategy == DockerBuildStrategy.LAMBDA) {
+                            newList.add("-cp");
+                            newList.add(workDir + "/libs/*:" + workDir + "/resources:" + workDir + "/application.jar");
+                            newList.add("io.micronaut.function.aws.runtime.MicronautLambdaRuntime");
+                        } else {
+                            newList.add("-jar");
+                            newList.add(workDir + "/application.jar");
+                        }
                         return newList;
                     }));
                 }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerJvmFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerJvmFunctionalTest.groovy
@@ -1,0 +1,59 @@
+package io.micronaut.gradle.docker
+
+import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Issue
+
+import java.util.jar.JarFile
+
+@Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/820")
+class DockerJvmFunctionalTest extends AbstractEagerConfiguringFunctionalTest {
+
+    void "assemble keeps explicit application main class for lambda_provided when dockerfile is customized"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.docker"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "lambda_provided"
+            }
+
+            $repositoriesBlock
+
+            application {
+                mainClass.set("example.Application")
+            }
+
+            dockerfile {
+                baseImage("test_base_image_jvm")
+            }
+        """
+        testProjectDir.newFolder("src", "main", "java", "example")
+        def javaFile = testProjectDir.newFile("src/main/java/example/Application.java")
+        javaFile << """
+package example;
+
+public class Application {
+    public static void main(String... args) {
+    }
+}
+"""
+
+        when:
+        def result = build("assemble")
+        def runnerJar = new File(testProjectDir.root, "build/libs/hello-world-runner.jar")
+        def manifestMainClass
+        new JarFile(runnerJar).withCloseable { jar ->
+            manifestMainClass = jar.manifest.mainAttributes.getValue("Main-Class")
+        }
+
+        then:
+        result.task(":assemble").outcome == TaskOutcome.SUCCESS
+        manifestMainClass == "example.Application"
+    }
+}

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerJvmFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerJvmFunctionalTest.groovy
@@ -56,4 +56,55 @@ public class Application {
         result.task(":assemble").outcome == TaskOutcome.SUCCESS
         manifestMainClass == "example.Application"
     }
+
+    void "dockerfile uses lambda runtime entrypoint without changing runner jar main class"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.docker"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "lambda_provided"
+            }
+
+            $repositoriesBlock
+
+            application {
+                mainClass.set("example.Application")
+            }
+
+            dockerfile {
+                baseImage("test_base_image_jvm")
+            }
+        """
+        testProjectDir.newFolder("src", "main", "java", "example")
+        def javaFile = testProjectDir.newFile("src/main/java/example/Application.java")
+        javaFile << """
+package example;
+
+public class Application {
+    public static void main(String... args) {
+    }
+}
+"""
+
+        when:
+        def result = build("dockerfile", "assemble")
+        def dockerFile = new File(testProjectDir.root, "build/docker/main/Dockerfile").readLines("UTF-8")
+        def runnerJar = new File(testProjectDir.root, "build/libs/hello-world-runner.jar")
+        def manifestMainClass
+        new JarFile(runnerJar).withCloseable { jar ->
+            manifestMainClass = jar.manifest.mainAttributes.getValue("Main-Class")
+        }
+
+        then:
+        result.task(":dockerfile").outcome == TaskOutcome.SUCCESS
+        result.task(":assemble").outcome == TaskOutcome.SUCCESS
+        manifestMainClass == "example.Application"
+        dockerFile.find { s -> s == 'ENTRYPOINT ["java", "-cp", "/home/app/libs/*:/home/app/resources:/home/app/application.jar", "io.micronaut.function.aws.runtime.MicronautLambdaRuntime"]' }
+    }
 }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerJvmFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerJvmFunctionalTest.groovy
@@ -95,6 +95,7 @@ public class Application {
         when:
         def result = build("dockerfile", "assemble")
         def dockerFile = new File(testProjectDir.root, "build/docker/main/Dockerfile").readLines("UTF-8")
+        def imageLibraries = new File(testProjectDir.root, "build/docker/main/layers/libs").list()
         def runnerJar = new File(testProjectDir.root, "build/libs/hello-world-runner.jar")
         def manifestMainClass
         new JarFile(runnerJar).withCloseable { jar ->
@@ -106,5 +107,6 @@ public class Application {
         result.task(":assemble").outcome == TaskOutcome.SUCCESS
         manifestMainClass == "example.Application"
         dockerFile.find { s -> s == 'ENTRYPOINT ["java", "-cp", "/home/app/libs/*:/home/app/resources:/home/app/application.jar", "io.micronaut.function.aws.runtime.MicronautLambdaRuntime"]' }
+        imageLibraries.any { it.startsWith("micronaut-function-aws-custom-runtime-") }
     }
 }


### PR DESCRIPTION
## Summary
- stop mutating shared `JavaApplication.mainClass` from the JVM Docker `lambda_provided` path
- add an eager functional regression that proves `assemble` preserves an explicit `application.mainClass` when `dockerfile { baseImage(...) }` is configured
- keep native lambda main-class behavior task-local in `NativeImageDockerfile`

## Verification
- `./gradlew functional-tests:cleanTest functional-tests:test --tests 'io.micronaut.gradle.docker.DockerJvmFunctionalTest'`
- `./gradlew functional-tests:cleanTest functional-tests:test --tests 'io.micronaut.gradle.lambda.LambdaNativeImageSpec'` (suite skipped by existing GraalVM guards in this environment)

Release board: `5.0.0-M3`.
Ambiguity note: `5.0.0 Release` remains the broader umbrella board for the same line.

Closes #820

---
###### ✨ This message was AI-generated using gpt-5