### PR TITLE
Escape shell metacharacters in docker native build args

### DIFF
--- a/docker-plugin/build.gradle
+++ b/docker-plugin/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 
     compileOnly libs.graalvmPlugin
 
+    testImplementation libs.graalvmPlugin
     testImplementation testFixtures(projects.micronautMinimalPlugin)
     testImplementation libs.mockserver.netty
 }

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static io.micronaut.gradle.PluginsHelper.findMicronautExtension;
 import static io.micronaut.gradle.docker.MicronautDockerfile.DEFAULT_WORKING_DIR;
@@ -76,6 +77,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
     private static final String GRAALVM_DISTRIBUTION_PATH = "/%s/%s/graalvm-jdk-%s_linux-%s_bin.tar.gz";
     //Latest version of GraalVM for JDK 17 available under the GraalVM Free Terms and Conditions (GFTC) licence
     private static final String GRAALVM_FOR_JDK17 = "17.0.12";
+    private static final Pattern POSIX_SAFE_SHELL_TOKEN = Pattern.compile("[A-Za-z0-9_@%+=:,./-]+");
 
     /**
      * @return The JDK version to use with native image. Defaults to the toolchain version, or the current Java version.
@@ -535,7 +537,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
                             .toList();
                 }
         ));
-        runCommand(getProviders().provider(() -> String.join(" ", buildActualCommandLine(executable, buildStrategy, imageResolver))));
+        runCommand(getProviders().provider(() -> renderShellCommand(buildActualCommandLine(executable, buildStrategy, imageResolver))));
         switch (buildStrategy) {
             case ORACLE_FUNCTION:
                 from(new From("fnproject/fn-java-fdk:" + getProjectFnVersion()).withStage("fnfdk"));
@@ -633,6 +635,22 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
             commandLine.add("-H:+StaticExecutableWithDynamicLibC");
         }
         return commandLine;
+    }
+
+    private static String renderShellCommand(List<String> commandLine) {
+        return String.join(" ", commandLine.stream()
+                .map(NativeImageDockerfile::renderShellToken)
+                .toList());
+    }
+
+    private static String renderShellToken(String token) {
+        if (token.isEmpty()) {
+            return "''";
+        }
+        if (POSIX_SAFE_SHELL_TOKEN.matcher(token).matches()) {
+            return token;
+        }
+        return "'" + token.replace("'", "'\"'\"'") + "'";
     }
 
     private List<String> buildNativeImageCommandLineArgs(Provider<String> executable, NativeImageOptions options) {

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/docker/NativeImageDockerfileShellRenderingSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/docker/NativeImageDockerfileShellRenderingSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.gradle.docker
+
+import spock.lang.Specification
+
+class NativeImageDockerfileShellRenderingSpec extends Specification {
+
+    void "renderShellCommand quotes shell metacharacters"() {
+        given:
+        def commandLine = [
+                'native-image',
+                '-cp',
+                '/home/app/libs/*.jar:/home/app/resources:/home/app/application.jar',
+                '--initialize-at-build-time=io.micronaut.flyway.StaticResourceProvider$StaticLoadableResource',
+                '-H:IncludeResources=application(-|.)(foo|bar)?[.]properties',
+                "contains'apostrophe"
+        ]
+
+        expect:
+        renderShellCommand(commandLine) == "native-image -cp '/home/app/libs/*.jar:/home/app/resources:/home/app/application.jar' '--initialize-at-build-time=io.micronaut.flyway.StaticResourceProvider\$StaticLoadableResource' '-H:IncludeResources=application(-|.)(foo|bar)?[.]properties' 'contains'\"'\"'apostrophe'"
+    }
+
+    private static String renderShellCommand(List<String> commandLine) {
+        def method = NativeImageDockerfile.getDeclaredMethod('renderShellCommand', List)
+        method.accessible = true
+        return (String) method.invoke(null, commandLine)
+    }
+}

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -789,12 +789,66 @@ COPY --link layers/resources /home/app/resources
 RUN mkdir /home/app/config-dirs
 RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
 COPY --link config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
-RUN native-image -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -o application -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile ${SHARED_ARENA_SUPPORT} example.Application
+RUN native-image -cp '/home/app/libs/*.jar:/home/app/resources:/home/app/application.jar' --no-fallback -o application -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile ${SHARED_ARENA_SUPPORT} example.Application
 ${defaultDockerFrom}
 EXPOSE 8080
 COPY --link --from=graalvm /home/app/application /app/application
 ENTRYPOINT ["/app/application"]
 """
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/1198")
+    def "dockerfile native escapes shell metacharacters in build args"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.docker"
+                id "io.micronaut.graalvm"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+            }
+
+            $repositoriesBlock
+
+            application { mainClass = "example.Application" }
+
+            graalvmNative {
+                binaries.all {
+                    buildArgs.add('--initialize-at-build-time=io.micronaut.flyway.StaticResourceProvider\$StaticLoadableResource')
+                    buildArgs.add('-H:IncludeResources=application(-|.)(foo|bar)?[.]properties')
+                }
+            }
+        """
+        testProjectDir.newFolder("src", "main", "java", "example")
+        def javaFile = testProjectDir.newFile("src/main/java/example/Application.java")
+        javaFile.parentFile.mkdirs()
+        javaFile << """
+package example;
+
+class Application {
+    public static void main(String... args) {
+
+    }
+}
+"""
+
+        when:
+        def result = build('dockerfileNative')
+        def dockerfileNativeTask = result.task(':dockerfileNative')
+        def dockerFileNative = new File(testProjectDir.root, 'build/docker/native-main/DockerfileNative').text
+
+        then:
+        dockerfileNativeTask.outcome == TaskOutcome.SUCCESS
+        dockerFileNative.contains("RUN native-image")
+        dockerFileNative.contains("'-H:IncludeResources=application(-|.)(foo|bar)?[.]properties'")
+        dockerFileNative.contains("'--initialize-at-build-time=io.micronaut.flyway.StaticResourceProvider\$StaticLoadableResource'")
+        !dockerFileNative.contains(' --initialize-at-build-time=io.micronaut.flyway.StaticResourceProvider$StaticLoadableResource ')
+        !dockerFileNative.contains(' -H:IncludeResources=application(-|.)(foo|bar)?[.]properties ')
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/667")


### PR DESCRIPTION
## Summary
- quote shell-unsafe native-image Dockerfile tokens before rendering the `RUN native-image ...` command
- keep `buildActualCommandLine(...)` unchanged so non-Docker native-image flows are unaffected
- add unit and functional regressions covering `$`, regex metacharacters, and apostrophes

## Release Targeting
- Target branch: `master`
- Target release line: `5.0.0`
- Selected Micronaut project: `5.0.0-M3`
- Note: `5.0.0 Release` remains the broader umbrella for this release line

Closes #1198

---
###### ✨ This message was AI-generated using gpt-5.4
