### PR TITLE
Avoid duplicate Micronaut processing when both KAPT and KSP are applied

### DIFF
--- a/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
@@ -111,6 +111,55 @@ class Foo {}
         'minimal.library' | kotlin2Version
     }
 
+    def "test Micronaut processing prefers KSP when KAPT is also applied for #plugin with #pluginOrder"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile.delete()
+        kotlinBuildFile << """
+            plugins {
+                id("org.jetbrains.kotlin.jvm") version("$kotlin2Version")
+                $processingPlugins
+                id("org.jetbrains.kotlin.plugin.allopen") version("$kotlin2Version")
+                id("io.micronaut.$plugin")
+            }
+
+            micronaut {
+                version("$micronautVersion")
+                processing {
+                    incremental(true)
+                }
+            }
+
+            ${getRepositoriesBlock('kotlin')}
+
+        """
+        testProjectDir.newFolder("src", "main", "kotlin", "example")
+        def javaFile = testProjectDir.newFile("src/main/kotlin/example/Foo.kt")
+        javaFile.parentFile.mkdirs()
+        javaFile << """
+package example
+
+@jakarta.inject.Singleton
+class Foo {}
+"""
+
+        when:
+        def result = build('assemble')
+
+        then:
+        result.task(":assemble").outcome == TaskOutcome.SUCCESS
+        file('build/generated/ksp/main/classes/example/$Foo$Definition.class').exists()
+        !file('build/tmp/kapt3/classes/main/example/$Foo$Definition.class').exists()
+        result.output.contains("Micronaut processing will use KSP")
+
+        where:
+        plugin            | pluginOrder   | processingPlugins
+        'library'         | 'KAPT first'  | """id("org.jetbrains.kotlin.kapt") version("$kotlin2Version")\nid("com.google.devtools.ksp") version("$ksp2Version")"""
+        'library'         | 'KSP first'   | """id("com.google.devtools.ksp") version("$ksp2Version")\nid("org.jetbrains.kotlin.kapt") version("$kotlin2Version")"""
+        'minimal.library' | 'KAPT first'  | """id("org.jetbrains.kotlin.kapt") version("$kotlin2Version")\nid("com.google.devtools.ksp") version("$ksp2Version")"""
+        'minimal.library' | 'KSP first'   | """id("com.google.devtools.ksp") version("$ksp2Version")\nid("org.jetbrains.kotlin.kapt") version("$kotlin2Version")"""
+    }
+
     def "test custom sourceSet for micronaut-library and kotlin with kotlin DSL for #plugin (Kotlin #kotlin)"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
@@ -148,7 +148,9 @@ class Foo {}
 
         then:
         result.task(":assemble").outcome == TaskOutcome.SUCCESS
-        file('build/generated/ksp/main/classes/example/$Foo$Definition.class').exists()
+        new File(testProjectDir.root, "build/generated/ksp/main/classes/example")
+                .listFiles()
+                ?.find { it.name.endsWith(".class") && it.name.contains('$Definition') }
         !file('build/tmp/kapt3/classes/main/example/$Foo$Definition.class').exists()
         result.output.contains("Micronaut processing will use KSP")
 

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
@@ -117,7 +117,7 @@ public class MicronautKotlinSupport {
 
     private static void configureKapt(Project project) {
         warnAboutKspTakingPrecedence(project);
-        configureKotlinCompilerPlugin(project, KAPT_CONFIGURATIONS, "kapt", PluginsHelper.ANNOTATION_PROCESSOR_MODULES, () -> shouldConfigureMicronautKapt(project));
+        configureKotlinCompilerPlugin(project, KAPT_CONFIGURATIONS, "kapt", PluginsHelper.ANNOTATION_PROCESSOR_MODULES, () -> !isMicronautKaptDisabledByKsp(project));
 
         // Need to identify KAPT version. We can't configure KAPT 2.x for incremental processing
         // Remove this block after the end of support for KAPT 1.9
@@ -129,7 +129,7 @@ public class MicronautKotlinSupport {
             var processingConfig = micronautExtension.getProcessing();
             project.afterEvaluate(unused -> {
                 // need to use afterEvaluate because lazy APIs are not available on the Kotlin 1.9 plugin
-                if (!shouldConfigureMicronautKapt(project)) {
+                if (isMicronautKaptDisabledByKsp(project)) {
                     return;
                 }
                 var isIncremental = processingConfig.getIncremental().getOrElse(true);
@@ -304,12 +304,12 @@ public class MicronautKotlinSupport {
         });
     }
 
-    private static boolean shouldConfigureMicronautKapt(Project project) {
-        return !(project.getPluginManager().hasPlugin(KAPT_PLUGIN_ID) && project.getPluginManager().hasPlugin(KSP_PLUGIN_ID));
+    private static boolean isMicronautKaptDisabledByKsp(Project project) {
+        return project.getPluginManager().hasPlugin(KAPT_PLUGIN_ID) && project.getPluginManager().hasPlugin(KSP_PLUGIN_ID);
     }
 
     private static void warnAboutKspTakingPrecedence(Project project) {
-        if (!shouldConfigureMicronautKapt(project)) {
+        if (isMicronautKaptDisabledByKsp(project)) {
             ExtraPropertiesExtension extraProperties = project.getExtensions().getExtraProperties();
             if (!extraProperties.has(BOTH_KAPT_AND_KSP_WARNING_EMITTED)) {
                 extraProperties.set(BOTH_KAPT_AND_KSP_WARNING_EMITTED, true);

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
@@ -7,6 +7,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.plugins.PluginManager;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
@@ -24,6 +25,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
 import static io.micronaut.gradle.PluginsHelper.CORE_VERSION_PROPERTY;
@@ -37,6 +39,9 @@ import static io.micronaut.gradle.PluginsHelper.resolveMicronautPlatform;
  * @since 1.0.0
  */
 public class MicronautKotlinSupport {
+    private static final String KAPT_PLUGIN_ID = "org.jetbrains.kotlin.kapt";
+    private static final String KSP_PLUGIN_ID = "com.google.devtools.ksp";
+    private static final String BOTH_KAPT_AND_KSP_WARNING_EMITTED = "io.micronaut.gradle.kotlin.kaptAndKspWarningEmitted";
     private static final String[] KAPT_CONFIGURATIONS = {
         "kapt",
         "kaptTest"
@@ -85,11 +90,12 @@ public class MicronautKotlinSupport {
             kotlinOptions.setJavaParameters(true);
         });
         pluginManager.withPlugin("org.jetbrains.kotlin.plugin.allopen", unused -> configureAllOpen(project));
-        pluginManager.withPlugin("org.jetbrains.kotlin.kapt", unused -> configureKapt(project));
-        pluginManager.withPlugin("com.google.devtools.ksp", unused -> configureKsp(project));
+        pluginManager.withPlugin(KAPT_PLUGIN_ID, unused -> configureKapt(project));
+        pluginManager.withPlugin(KSP_PLUGIN_ID, unused -> configureKsp(project));
     }
 
     private static void configureKsp(Project project) {
+        warnAboutKspTakingPrecedence(project);
         configureKotlinCompilerPlugin(project, KSP_CONFIGURATIONS, "ksp", KSP_ANNOTATION_PROCESSOR_MODULES);
 
         final ExtensionContainer extensions = project.getExtensions();
@@ -110,7 +116,8 @@ public class MicronautKotlinSupport {
     }
 
     private static void configureKapt(Project project) {
-        configureKotlinCompilerPlugin(project, KAPT_CONFIGURATIONS, "kapt", PluginsHelper.ANNOTATION_PROCESSOR_MODULES);
+        warnAboutKspTakingPrecedence(project);
+        configureKotlinCompilerPlugin(project, KAPT_CONFIGURATIONS, "kapt", PluginsHelper.ANNOTATION_PROCESSOR_MODULES, () -> shouldConfigureMicronautKapt(project));
 
         // Need to identify KAPT version. We can't configure KAPT 2.x for incremental processing
         // Remove this block after the end of support for KAPT 1.9
@@ -122,6 +129,9 @@ public class MicronautKotlinSupport {
             var processingConfig = micronautExtension.getProcessing();
             project.afterEvaluate(unused -> {
                 // need to use afterEvaluate because lazy APIs are not available on the Kotlin 1.9 plugin
+                if (!shouldConfigureMicronautKapt(project)) {
+                    return;
+                }
                 var isIncremental = processingConfig.getIncremental().getOrElse(true);
                 var group = processingConfig.getGroup().getOrElse(project.getGroup().toString());
                 var module = processingConfig.getModule().getOrElse(project.getName());
@@ -180,9 +190,17 @@ public class MicronautKotlinSupport {
     }
 
     private static void configureKotlinCompilerPlugin(Project project, String[] compilerConfigurations, String compilerType, List<String> annotationProcessorModules) {
+        configureKotlinCompilerPlugin(project, compilerConfigurations, compilerType, annotationProcessorModules, () -> true);
+    }
+
+    private static void configureKotlinCompilerPlugin(Project project,
+                                                      String[] compilerConfigurations,
+                                                      String compilerType,
+                                                      List<String> annotationProcessorModules,
+                                                      BooleanSupplier condition) {
         // add inject-java to kapt scopes
-        PluginsHelper.registerAnnotationProcessors(project, annotationProcessorModules, compilerConfigurations);
-        addGraalVmDependencies(compilerConfigurations, project);
+        PluginsHelper.registerAnnotationProcessors(project, annotationProcessorModules, condition, compilerConfigurations);
+        addGraalVmDependencies(compilerConfigurations, project, condition);
 
         Configuration kotlinProcessors = project.getConfigurations().getByName(KOTLIN_PROCESSORS);
         for (String compilerConfiguration : compilerConfigurations) {
@@ -190,6 +208,7 @@ public class MicronautKotlinSupport {
         }
         PluginsHelper.applyAdditionalProcessors(
             project,
+            condition,
             compilerConfigurations
         );
         var registry = project.
@@ -199,7 +218,7 @@ public class MicronautKotlinSupport {
         var platform = PluginsHelper.findMicronautVersion(project).map(micronautVersion -> resolveMicronautPlatform(dependencyHandler, micronautVersion));
         var knownSourceSets = new HashSet<SourceSet>();
         registry.register(sourceSet -> {
-            configureAdditionalSourceSet(compilerType, project, dependencyHandler, platform, sourceSet);
+            configureAdditionalSourceSet(compilerType, project, dependencyHandler, platform, sourceSet, condition);
             knownSourceSets.add(sourceSet);
         });
         for (String compileConfiguration : compilerConfigurations) {
@@ -211,14 +230,20 @@ public class MicronautKotlinSupport {
         project.afterEvaluate(p -> {
             PluginsHelper.applyAdditionalProcessors(
                 p,
+                condition,
                 compilerConfigurations
             );
-            configureExtraSourceSetsUsingDeprecatedBehavior(compilerType, p, knownSourceSets, dependencyHandler, platform);
+            configureExtraSourceSetsUsingDeprecatedBehavior(compilerType, p, knownSourceSets, dependencyHandler, platform, condition);
         });
 
     }
 
-    private static void configureExtraSourceSetsUsingDeprecatedBehavior(String compilerType, Project p, HashSet<SourceSet> knownSourceSets, DependencyHandler dependencyHandler, Provider<Dependency> platform) {
+    private static void configureExtraSourceSetsUsingDeprecatedBehavior(String compilerType,
+                                                                        Project p,
+                                                                        HashSet<SourceSet> knownSourceSets,
+                                                                        DependencyHandler dependencyHandler,
+                                                                        Provider<Dependency> platform,
+                                                                        BooleanSupplier condition) {
         var micronautExtension = p
             .getExtensions()
             .getByType(MicronautExtension.class);
@@ -232,7 +257,7 @@ public class MicronautKotlinSupport {
                 for (SourceSet sourceSet : configurations) {
                     if (!knownSourceSets.contains(sourceSet)) {
                         AnnotationProcessing.showAdditionalSourceSetDeprecationWarning(sourceSet);
-                        configureAdditionalSourceSet(compilerType, p, dependencyHandler, platform, sourceSet);
+                        configureAdditionalSourceSet(compilerType, p, dependencyHandler, platform, sourceSet, condition);
                     }
                 }
             }
@@ -243,7 +268,8 @@ public class MicronautKotlinSupport {
                                                      Project p,
                                                      DependencyHandler dependencyHandler,
                                                      Provider<Dependency> platform,
-                                                     SourceSet sourceSet) {
+                                                     SourceSet sourceSet,
+                                                     BooleanSupplier condition) {
         String annotationProcessorConfigurationName = compilerType + Strings.capitalize(sourceSet.getName());
         String implementationConfigurationName = sourceSet
             .getImplementationConfigurationName();
@@ -259,22 +285,37 @@ public class MicronautKotlinSupport {
         }
         configureAnnotationProcessors(p,
             implementationConfigurationName,
-            annotationProcessorConfigurationName);
+            annotationProcessorConfigurationName,
+            condition);
         p.getPluginManager().withPlugin("io.micronaut.graalvm", unused ->
             new AutomaticDependency(annotationProcessorConfigurationName,
                 "io.micronaut:micronaut-graal",
-                Optional.of(CORE_VERSION_PROPERTY)).applyTo(p)
+                Optional.of(CORE_VERSION_PROPERTY)).applyTo(p, condition)
         );
     }
 
-    private static void addGraalVmDependencies(String[] compilerConfigurations, Project project) {
+    private static void addGraalVmDependencies(String[] compilerConfigurations, Project project, BooleanSupplier condition) {
         project.getPluginManager().withPlugin("io.micronaut.graalvm", unused -> {
             for (String configuration : compilerConfigurations) {
                 new AutomaticDependency(configuration,
                     "io.micronaut:micronaut-graal",
-                    Optional.of(CORE_VERSION_PROPERTY)).applyTo(project);
+                    Optional.of(CORE_VERSION_PROPERTY)).applyTo(project, condition);
             }
         });
+    }
+
+    private static boolean shouldConfigureMicronautKapt(Project project) {
+        return !(project.getPluginManager().hasPlugin(KAPT_PLUGIN_ID) && project.getPluginManager().hasPlugin(KSP_PLUGIN_ID));
+    }
+
+    private static void warnAboutKspTakingPrecedence(Project project) {
+        if (!shouldConfigureMicronautKapt(project)) {
+            ExtraPropertiesExtension extraProperties = project.getExtensions().getExtraProperties();
+            if (!extraProperties.has(BOTH_KAPT_AND_KSP_WARNING_EMITTED)) {
+                extraProperties.set(BOTH_KAPT_AND_KSP_WARNING_EMITTED, true);
+                LOGGER.warn("Both KSP and KAPT plugins were detected. Micronaut processing will use KSP, and Micronaut-managed KAPT wiring is disabled. KAPT remains available for non-Micronaut processors.");
+            }
+        }
     }
 
     private static void configureAllOpen(Project project) {

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/PluginsHelper.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/PluginsHelper.java
@@ -40,6 +40,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Stream;
 
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME;
@@ -168,26 +169,42 @@ public abstract class PluginsHelper {
             Project project,
             String implementationScope,
             String annotationProcessorConfiguration) {
-        registerAnnotationProcessors(project, annotationProcessorConfiguration);
+        configureAnnotationProcessors(project, implementationScope, annotationProcessorConfiguration, () -> true);
+    }
+
+    static void configureAnnotationProcessors(
+            Project project,
+            String implementationScope,
+            String annotationProcessorConfiguration,
+            BooleanSupplier condition) {
+        registerAnnotationProcessors(project, condition, annotationProcessorConfiguration);
         new AutomaticDependency(
                 implementationScope,
                 "io.micronaut:micronaut-inject",
                 Optional.of(CORE_VERSION_PROPERTY)
-        ).applyTo(project);
+        ).applyTo(project, condition);
     }
 
     static void registerAnnotationProcessors(Project p, String... annotationProcessingConfigurations) {
-        registerAnnotationProcessors(p, ANNOTATION_PROCESSOR_MODULES, annotationProcessingConfigurations);
+        registerAnnotationProcessors(p, () -> true, annotationProcessingConfigurations);
+    }
+
+    static void registerAnnotationProcessors(Project p, BooleanSupplier condition, String... annotationProcessingConfigurations) {
+        registerAnnotationProcessors(p, ANNOTATION_PROCESSOR_MODULES, condition, annotationProcessingConfigurations);
     }
 
     static void registerAnnotationProcessors(Project p, List<String> annotationProcessorModules, String... annotationProcessingConfigurations) {
+        registerAnnotationProcessors(p, annotationProcessorModules, () -> true, annotationProcessingConfigurations);
+    }
+
+    static void registerAnnotationProcessors(Project p, List<String> annotationProcessorModules, BooleanSupplier condition, String... annotationProcessingConfigurations) {
         for (String annotationProcessorModule : annotationProcessorModules) {
             for (String annotationProcessingConfiguration : annotationProcessingConfigurations) {
                 new AutomaticDependency(
                         annotationProcessingConfiguration,
                         "io.micronaut:micronaut-" + annotationProcessorModule,
                         Optional.of(CORE_VERSION_PROPERTY)
-                ).applyTo(p);
+                ).applyTo(p, condition);
             }
         }
     }
@@ -205,9 +222,16 @@ public abstract class PluginsHelper {
     }
 
     static void applyAdditionalProcessors(Project project, String... configurations) {
+        applyAdditionalProcessors(project, () -> true, configurations);
+    }
+
+    static void applyAdditionalProcessors(Project project, BooleanSupplier condition, String... configurations) {
         Stream.of(IMPLEMENTATION_CONFIGURATION_NAME, COMPILE_ONLY_CONFIGURATION_NAME).forEach(config -> {
             // Need to do in an afterEvaluate because this will add dependencies only if the user didn't do it
             project.afterEvaluate(p -> {
+                if (!condition.getAsBoolean()) {
+                    return;
+                }
                 final DependencySet allDependencies = project.getConfigurations().getByName(config)
                         .getAllDependencies();
                 for (var entry : GROUP_TO_PROCESSOR_MAP.entrySet()) {
@@ -215,7 +239,7 @@ public abstract class PluginsHelper {
                     if (hasDep) {
                         for (String configuration : configurations) {
                             AutomaticDependency automaticDependency = entry.getValue();
-                            automaticDependency.withConfiguration(configuration).applyTo(project);
+                            automaticDependency.withConfiguration(configuration).applyTo(project, condition);
                         }
                     }
                 }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/internal/AutomaticDependency.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/internal/AutomaticDependency.java
@@ -27,6 +27,7 @@ import org.gradle.api.provider.Provider;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
 
 /**
  * Represents a dependency which is automatically
@@ -44,6 +45,10 @@ public record AutomaticDependency(
 ) {
 
     public void applyTo(Project p) {
+        applyTo(p, () -> true);
+    }
+
+    public void applyTo(Project p, BooleanSupplier condition) {
         p.getPlugins().withType(MicronautComponentPlugin.class, unused -> {
             p.afterEvaluate(unusedProject -> VersionCatalogLookupCache.get().clear());
             var dependencyHandler = p.getDependencies();
@@ -51,6 +56,9 @@ public record AutomaticDependency(
             var ignoredDependencies = micronautExtension.getIgnoredAutomaticDependencies();
             p.getConfigurations().getByName(configuration).getDependencies().addAllLater(
                 p.getProviders().provider(() -> {
+                    if (!condition.getAsBoolean()) {
+                        return List.of();
+                    }
                     var ignored = ignoredDependencies.getOrElse(Set.of());
                     if (ignored.contains(coordinates)) {
                         return List.of();

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -783,6 +783,8 @@ application {
 }
 ----
 
+If a build applies both `com.google.devtools.ksp` and `org.jetbrains.kotlin.kapt`, Micronaut processing uses KSP and does not also configure Micronaut-managed annotation processors on KAPT. This keeps `kapt` available for unrelated third-party processors without generating duplicate Micronaut bean definitions.
+
 [[native-image]]
 === GraalVM Native Image
 


### PR DESCRIPTION
## Summary
- prefer KSP for Micronaut processing when both `com.google.devtools.ksp` and `org.jetbrains.kotlin.kapt` are applied
- suppress Micronaut-managed KAPT dependency wiring and processor arguments in that dual-plugin case
- add a functional regression test for both plugin application orders and document the behavior

## Release Targeting
- Micronaut organization project: `5.0.0 Release`
- Ambiguity note: the public `5.0.0-M3` project is also open, but QA selected `5.0.0 Release` as the best durable target for this fix

Closes #801

---
###### ✨ This message was AI-generated using gpt-5.4
