### PR TITLE
Add CacheConfig to Kotlin all-open support

### DIFF
--- a/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
@@ -4,6 +4,9 @@ import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Shared
 
+import java.lang.reflect.Modifier
+import java.net.URLClassLoader
+
 class KotlinLibraryFunctionalTest extends AbstractEagerConfiguringFunctionalTest {
 
     @Shared
@@ -165,5 +168,68 @@ class Foo {}
         plugin            | kotlin
         'library'         | kotlin2Version
         'minimal.library' | kotlin2Version
+    }
+
+    def "test all-open support keeps Around meta-annotations and opens CacheConfig classes"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile.delete()
+        kotlinBuildFile << """
+            plugins {
+                id("org.jetbrains.kotlin.jvm") version("$kotlin2Version")
+                id("org.jetbrains.kotlin.kapt") version("$kotlin2Version")
+                id("org.jetbrains.kotlin.plugin.allopen") version("$kotlin2Version")
+                id("io.micronaut.minimal.library")
+            }
+
+            micronaut {
+                version("$micronautVersion")
+                processing {
+                    incremental(true)
+                }
+            }
+
+            ${getRepositoriesBlock('kotlin')}
+
+            dependencies {
+                implementation("io.micronaut:micronaut-aop")
+                implementation("io.micronaut.cache:micronaut-cache-core")
+            }
+        """
+        testProjectDir.newFolder("src", "main", "kotlin", "example")
+        def kotlinSource = testProjectDir.newFile("src/main/kotlin/example/Services.kt")
+        kotlinSource.parentFile.mkdirs()
+        kotlinSource << """
+package example
+
+import io.micronaut.aop.Around
+import io.micronaut.cache.annotation.CacheConfig
+
+@Around
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+annotation class OpenAround
+
+@OpenAround
+class AroundService
+
+@CacheConfig("books")
+class CachedService
+"""
+
+        when:
+        def result = build('compileKotlin')
+
+        then:
+        result.task(":compileKotlin").outcome == TaskOutcome.SUCCESS
+        def classesDir = file("build/classes/kotlin/main")
+        classesDir.directory
+        URLClassLoader classLoader = new URLClassLoader([classesDir.toURI().toURL()] as URL[], (ClassLoader) this.class.classLoader)
+        try {
+            !Modifier.isFinal(classLoader.loadClass("example.AroundService").modifiers)
+            !Modifier.isFinal(classLoader.loadClass("example.CachedService").modifiers)
+        } finally {
+            classLoader.close()
+        }
     }
 }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/kotlin/KotlinLibraryFunctionalTest.groovy
@@ -198,7 +198,6 @@ class Foo {}
         """
         testProjectDir.newFolder("src", "main", "kotlin", "example")
         def kotlinSource = testProjectDir.newFile("src/main/kotlin/example/Services.kt")
-        kotlinSource.parentFile.mkdirs()
         kotlinSource << """
 package example
 
@@ -224,10 +223,16 @@ class CachedService
         result.task(":compileKotlin").outcome == TaskOutcome.SUCCESS
         def classesDir = file("build/classes/kotlin/main")
         classesDir.directory
-        URLClassLoader classLoader = new URLClassLoader([classesDir.toURI().toURL()] as URL[], (ClassLoader) this.class.classLoader)
+        def classesDirUrl = classesDir.toURI().toURL()
+        URLClassLoader classLoader = new URLClassLoader([classesDirUrl] as URL[], (ClassLoader) this.class.classLoader)
         try {
-            !Modifier.isFinal(classLoader.loadClass("example.AroundService").modifiers)
-            !Modifier.isFinal(classLoader.loadClass("example.CachedService").modifiers)
+            def aroundServiceClass = classLoader.loadClass("example.AroundService")
+            def cachedServiceClass = classLoader.loadClass("example.CachedService")
+
+            aroundServiceClass.protectionDomain.codeSource.location == classesDirUrl
+            cachedServiceClass.protectionDomain.codeSource.location == classesDirUrl
+            !Modifier.isFinal(aroundServiceClass.modifiers)
+            !Modifier.isFinal(cachedServiceClass.modifiers)
         } finally {
             classLoader.close()
         }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautKotlinSupport.java
@@ -280,6 +280,7 @@ public class MicronautKotlinSupport {
     private static void configureAllOpen(Project project) {
         AllOpenExtension allOpen = project.getExtensions().getByType(AllOpenExtension.class);
         allOpen.annotation("io.micronaut.aop.Around");
+        allOpen.annotation("io.micronaut.cache.annotation.CacheConfig");
     }
 
 }


### PR DESCRIPTION
## Summary
- add `io.micronaut.cache.annotation.CacheConfig` to the existing Kotlin all-open registration
- add a focused Kotlin functional regression covering both `@CacheConfig` and existing `@Around` meta-annotation behavior
- target Micronaut org project `5.0.0 Release` (#47); preserve QA ambiguity note that `5.0.0-M3` (#143) only applies if maintainers want this tracked as milestone-scoped work

## Linked Issue
Closes #311

## Verification
- `./gradlew :functional-tests:test --tests io.micronaut.gradle.kotlin.KotlinLibraryFunctionalTest`

---
###### ✨ This message was AI-generated using gpt-5
