### PR TITLE
Default SharedArenaSupport for Netty native images

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -61,6 +61,7 @@ import static io.micronaut.gradle.docker.MicronautDockerfile.applyStandardTransf
 public abstract class NativeImageDockerfile extends Dockerfile implements DockerBuildOptions {
 
     public static final String AMAZON_LINUX_BASE_IMAGE = "public.ecr.aws/amazonlinux/amazonlinux:" + DefaultVersions.AMAZONLINUX;
+    private static final String SHARED_ARENA_SUPPORT = "-H:+SharedArenaSupport";
 
     private static final List<Integer> SUPPORTED_JAVA_VERSIONS = List.of(
             // keep those in descending order
@@ -662,6 +663,10 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
         return args;
     }
 
+    private static boolean supportsSharedArenaSupport(String version) {
+        return toMajorVersion(version) >= 25;
+    }
+
     private static Integer toMajorVersion(String version) {
         if (version.contains(".")) {
             return Integer.parseInt(version.substring(0, version.indexOf('.')));
@@ -676,7 +681,14 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
      */
     private void prepareNativeImageOptions(NativeImageOptions options) {
         Property<NativeImageOptions> originalOptions = getNativeImageOptions();
-        options.getBuildArgs().set(originalOptions.flatMap(NativeImageOptions::getBuildArgs));
+        options.getBuildArgs().set(originalOptions.flatMap(NativeImageOptions::getBuildArgs).map(buildArgs -> {
+            if (supportsSharedArenaSupport(getJdkVersion().get())) {
+                return buildArgs;
+            }
+            return buildArgs.stream()
+                    .filter(buildArg -> !SHARED_ARENA_SUPPORT.equals(buildArg))
+                    .toList();
+        }));
         options.getJvmArgs().set(originalOptions.flatMap(NativeImageOptions::getJvmArgs));
         options.getMainClass().set(originalOptions.flatMap(NativeImageOptions::getMainClass));
         options.getVerbose().set(originalOptions.flatMap(NativeImageOptions::getVerbose));

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -99,7 +99,7 @@ micronaut:
         and:
         result.output.contains("Successfully tagged hello-world:latest")
         result.output.contains("Resources configuration written into")
-        dockerFile.find { s -> s.startsWith('RUN native-image ') }.contains('-H:+SharedArenaSupport') == sharedArenaSupportEnabled
+        dockerFile.find { s -> s.startsWith('RUN native-image ') }.contains(SHARED_ARENA_SUPPORT) == sharedArenaSupportEnabled
         task.outcome == TaskOutcome.SUCCESS
 
         where:
@@ -789,7 +789,7 @@ COPY --link layers/resources /home/app/resources
 RUN mkdir /home/app/config-dirs
 RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
 COPY --link config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
-RUN native-image -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -o application -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile -H:+SharedArenaSupport example.Application
+RUN native-image -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -o application -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile ${SHARED_ARENA_SUPPORT} example.Application
 ${defaultDockerFrom}
 EXPOSE 8080
 COPY --link --from=graalvm /home/app/application /app/application

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -788,7 +788,7 @@ COPY --link layers/resources /home/app/resources
 RUN mkdir /home/app/config-dirs
 RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
 COPY --link config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
-RUN native-image -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -o application -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile example.Application
+RUN native-image -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -o application -H:+SharedArenaSupport -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile example.Application
 ${defaultDockerFrom}
 EXPOSE 8080
 COPY --link --from=graalvm /home/app/application /app/application

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -99,14 +99,15 @@ micronaut:
         and:
         result.output.contains("Successfully tagged hello-world:latest")
         result.output.contains("Resources configuration written into")
+        dockerFile.find { s -> s.startsWith('RUN native-image ') }.contains('-H:+SharedArenaSupport') == sharedArenaSupportEnabled
         task.outcome == TaskOutcome.SUCCESS
 
         where:
-        runtime           | jdk | nativeImage
-        "netty"           | 25  | "FROM ghcr.io/graalvm/native-image-community:25-ol${DefaultVersions.ORACLELINUX}"
-        "lambda_provided" | 25  | "FROM public.ecr.aws/amazonlinux/amazonlinux:${DefaultVersions.AMAZONLINUX} AS graalvm"
-        "lambda_provided" | 21  | "FROM public.ecr.aws/amazonlinux/amazonlinux:${DefaultVersions.AMAZONLINUX} AS graalvm"
-        "jetty"           | 25  | "FROM ghcr.io/graalvm/native-image-community:25-ol${DefaultVersions.ORACLELINUX}"
+        runtime           | jdk | nativeImage                                                                    | sharedArenaSupportEnabled
+        "netty"           | 25  | "FROM ghcr.io/graalvm/native-image-community:25-ol${DefaultVersions.ORACLELINUX}" | true
+        "lambda_provided" | 25  | "FROM public.ecr.aws/amazonlinux/amazonlinux:${DefaultVersions.AMAZONLINUX} AS graalvm" | true
+        "lambda_provided" | 21  | "FROM public.ecr.aws/amazonlinux/amazonlinux:${DefaultVersions.AMAZONLINUX} AS graalvm" | false
+        "jetty"           | 25  | "FROM ghcr.io/graalvm/native-image-community:25-ol${DefaultVersions.ORACLELINUX}" | true
     }
 
     void 'build mostly static native images when using distroless docker image for runtime=#runtime'() {
@@ -788,7 +789,7 @@ COPY --link layers/resources /home/app/resources
 RUN mkdir /home/app/config-dirs
 RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
 COPY --link config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
-RUN native-image -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -o application -H:+SharedArenaSupport -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile example.Application
+RUN native-image -cp /home/app/libs/*.jar:/home/app/resources:/home/app/application.jar --no-fallback -o application -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile -H:+SharedArenaSupport example.Application
 ${defaultDockerFrom}
 EXPOSE 8080
 COPY --link --from=graalvm /home/app/application /app/application

--- a/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/GraalUtil.java
+++ b/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/GraalUtil.java
@@ -1,11 +1,14 @@
 package io.micronaut.gradle.graalvm;
 
+import org.gradle.api.JavaVersion;
+
 import java.util.Locale;
 
 /**
  * Utilities for GraalVM.
  */
 public final class GraalUtil {
+    public static final int SHARED_ARENA_SUPPORT_MINIMUM_JAVA_VERSION = 25;
 
     private GraalUtil() {
     }
@@ -15,6 +18,40 @@ public final class GraalUtil {
      */
     public static boolean isGraalJVM() {
         return isGraal("jvmci.Compiler", "java.vendor.version", "java.vendor");
+    }
+
+    /**
+     * @return The current JVM major version.
+     */
+    public static int currentJavaMajorVersion() {
+        return Integer.parseInt(JavaVersion.current().getMajorVersion());
+    }
+
+    /**
+     * @param javaVersion The Java major version.
+     * @return Whether {@code -H:+SharedArenaSupport} is supported.
+     */
+    public static boolean supportsSharedArenaSupport(int javaVersion) {
+        return javaVersion >= SHARED_ARENA_SUPPORT_MINIMUM_JAVA_VERSION;
+    }
+
+    /**
+     * @param javaVersion The Java version string.
+     * @return Whether {@code -H:+SharedArenaSupport} is supported.
+     */
+    public static boolean supportsSharedArenaSupport(String javaVersion) {
+        return supportsSharedArenaSupport(parseMajorVersion(javaVersion));
+    }
+
+    /**
+     * @param javaVersion The Java version string.
+     * @return The Java major version.
+     */
+    public static int parseMajorVersion(String javaVersion) {
+        if (javaVersion.contains(".")) {
+            return Integer.parseInt(javaVersion.substring(0, javaVersion.indexOf('.')));
+        }
+        return Integer.parseInt(javaVersion);
     }
 
     private static boolean isGraal(String... props) {

--- a/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -11,6 +11,7 @@ import org.graalvm.buildtools.gradle.NativeImagePlugin;
 import org.graalvm.buildtools.gradle.dsl.GraalVMExtension;
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
 import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ConfigurationContainer;
@@ -78,7 +79,12 @@ public class MicronautGraalPlugin implements Plugin<Project> {
                         inf.getIgnoreExistingResourcesConfigFile().convention(true);
                         inf.getRestrictToProjectDependencies().convention(true);
                     }));
-                    options.buildArgs(SHARED_ARENA_SUPPORT);
+                    int javaVersion = options.getJavaLauncher()
+                            .map(javaLauncher -> javaLauncher.getMetadata().getLanguageVersion().asInt())
+                            .getOrElse(Integer.parseInt(JavaVersion.current().getMajorVersion()));
+                    if (GraalUtil.supportsSharedArenaSupport(javaVersion)) {
+                        options.buildArgs(SHARED_ARENA_SUPPORT);
+                    }
                     Provider<String> richOutput = project.getProviders().systemProperty(RICH_OUTPUT_PROPERTY);
                     if (richOutput.isPresent()) {
                         options.getRichOutput().convention(richOutput.map(Boolean::parseBoolean));

--- a/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
+++ b/graalvm-plugin/src/main/java/io/micronaut/gradle/graalvm/MicronautGraalPlugin.java
@@ -40,6 +40,7 @@ import static io.micronaut.gradle.PluginsHelper.findMicronautExtension;
 public class MicronautGraalPlugin implements Plugin<Project> {
 
     public static final String RICH_OUTPUT_PROPERTY = "io.micronaut.graalvm.rich.output";
+    private static final String SHARED_ARENA_SUPPORT = "-H:+SharedArenaSupport";
 
     private static final Set<String> SOURCE_SETS = Set.of("main", "test");
     private static final List<String> GRAALVM_MODULE_EXPORTS = List.of(
@@ -77,6 +78,7 @@ public class MicronautGraalPlugin implements Plugin<Project> {
                         inf.getIgnoreExistingResourcesConfigFile().convention(true);
                         inf.getRestrictToProjectDependencies().convention(true);
                     }));
+                    options.buildArgs(SHARED_ARENA_SUPPORT);
                     Provider<String> richOutput = project.getProviders().systemProperty(RICH_OUTPUT_PROPERTY);
                     if (richOutput.isPresent()) {
                         options.getRichOutput().convention(richOutput.map(Boolean::parseBoolean));

--- a/graalvm-plugin/src/test/groovy/io/micronaut/gradle/MicronautGraalWellBehavePluginSpec.groovy
+++ b/graalvm-plugin/src/test/groovy/io/micronaut/gradle/MicronautGraalWellBehavePluginSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.gradle
 
+import io.micronaut.gradle.graalvm.GraalUtil
 import org.graalvm.buildtools.gradle.dsl.GraalVMExtension
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
@@ -31,6 +32,13 @@ class MicronautGraalWellBehavePluginSpec extends Specification {
         def graal = project.extensions.getByType(GraalVMExtension)
 
         then:
-        graal.binaries.getByName("main").buildArgs.get().contains("-H:+SharedArenaSupport")
+        graal.binaries.getByName("main").buildArgs.get().contains("-H:+SharedArenaSupport") == GraalUtil.supportsSharedArenaSupport(GraalUtil.currentJavaMajorVersion())
+    }
+
+    def "shared arena support utility tracks supported Java versions"() {
+        expect:
+        !GraalUtil.supportsSharedArenaSupport(21)
+        !GraalUtil.supportsSharedArenaSupport(24)
+        GraalUtil.supportsSharedArenaSupport(25)
     }
 }

--- a/graalvm-plugin/src/test/groovy/io/micronaut/gradle/MicronautGraalWellBehavePluginSpec.groovy
+++ b/graalvm-plugin/src/test/groovy/io/micronaut/gradle/MicronautGraalWellBehavePluginSpec.groovy
@@ -32,7 +32,7 @@ class MicronautGraalWellBehavePluginSpec extends Specification {
         def graal = project.extensions.getByType(GraalVMExtension)
 
         then:
-        graal.binaries.getByName("main").buildArgs.get().contains("-H:+SharedArenaSupport") == GraalUtil.supportsSharedArenaSupport(GraalUtil.currentJavaMajorVersion())
+        graal.binaries.getByName("main").buildArgs.get().contains(AbstractGradleBuildSpec.SHARED_ARENA_SUPPORT) == GraalUtil.supportsSharedArenaSupport(GraalUtil.currentJavaMajorVersion())
     }
 
     def "shared arena support utility tracks supported Java versions"() {

--- a/graalvm-plugin/src/test/groovy/io/micronaut/gradle/MicronautGraalWellBehavePluginSpec.groovy
+++ b/graalvm-plugin/src/test/groovy/io/micronaut/gradle/MicronautGraalWellBehavePluginSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.gradle
 
+import org.graalvm.buildtools.gradle.dsl.GraalVMExtension
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
@@ -19,5 +20,17 @@ class MicronautGraalWellBehavePluginSpec extends Specification {
                 "io.micronaut.minimal.library",
                 "io.micronaut.minimal.application",
         ]
+    }
+
+    def "shared arena support is enabled by default"() {
+        def project = ProjectBuilder.builder().build()
+
+        when:
+        project.plugins.apply("io.micronaut.graalvm")
+        project.plugins.apply("io.micronaut.minimal.application")
+        def graal = project.extensions.getByType(GraalVMExtension)
+
+        then:
+        graal.binaries.getByName("main").buildArgs.get().contains("-H:+SharedArenaSupport")
     }
 }

--- a/graalvm-plugin/src/test/groovy/io/micronaut/gradle/NativeImageTaskSpec.groovy
+++ b/graalvm-plugin/src/test/groovy/io/micronaut/gradle/NativeImageTaskSpec.groovy
@@ -52,6 +52,7 @@ class Application {
         def task = result.task(":nativeCompile")
         then:
         result.output.contains("Native Image written to")
+        argFileContentsOf(result).contains('-H:+SharedArenaSupport')
         task.outcome == TaskOutcome.SUCCESS
     }
 
@@ -106,6 +107,7 @@ class Application {
         def task = result.task(":nativeCompile")
         then:
         result.output.contains("Native Image written to")
+        argFileContentsOf(result).contains('-H:+SharedArenaSupport')
         argFileContentsOf(result).contains('-Dfoo=bar')
         task.outcome == TaskOutcome.SUCCESS
     }

--- a/graalvm-plugin/src/test/groovy/io/micronaut/gradle/NativeImageTaskSpec.groovy
+++ b/graalvm-plugin/src/test/groovy/io/micronaut/gradle/NativeImageTaskSpec.groovy
@@ -52,7 +52,7 @@ class Application {
         def task = result.task(":nativeCompile")
         then:
         result.output.contains("Native Image written to")
-        argFileContentsOf(result).contains('-H:+SharedArenaSupport')
+        result.output.contains("-H:+SharedArenaSupport")
         task.outcome == TaskOutcome.SUCCESS
     }
 

--- a/graalvm-plugin/src/test/groovy/io/micronaut/gradle/NativeImageTaskSpec.groovy
+++ b/graalvm-plugin/src/test/groovy/io/micronaut/gradle/NativeImageTaskSpec.groovy
@@ -52,7 +52,7 @@ class Application {
         def task = result.task(":nativeCompile")
         then:
         result.output.contains("Native Image written to")
-        result.output.contains("-H:+SharedArenaSupport")
+        result.output.contains(SHARED_ARENA_SUPPORT)
         task.outcome == TaskOutcome.SUCCESS
     }
 
@@ -107,7 +107,7 @@ class Application {
         def task = result.task(":nativeCompile")
         then:
         result.output.contains("Native Image written to")
-        argFileContentsOf(result).contains('-H:+SharedArenaSupport')
+        argFileContentsOf(result).contains(SHARED_ARENA_SUPPORT)
         argFileContentsOf(result).contains('-Dfoo=bar')
         task.outcome == TaskOutcome.SUCCESS
     }

--- a/minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
+++ b/minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
@@ -16,6 +16,8 @@ import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 
 abstract class AbstractGradleBuildSpec extends Specification {
+    protected static final String SHARED_ARENA_SUPPORT = "-H:+SharedArenaSupport"
+
     static boolean isGraalVmAvailable() {
         if (GraalUtil.isGraalJVM()) {
             return true

--- a/minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
+++ b/minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy
@@ -248,7 +248,7 @@ abstract class AbstractGradleBuildSpec extends Specification {
 
     static String argFileContentsOf(BuildResult result) {
         result.output.lines().filter {
-            it.contains('Starting process') && it.contains('bin/native-image') && !it.contains('--version')
+            it.contains('Starting process') && it.contains('native-image') && !it.contains('--version')
         }.map {
             int workingDirIdx = it.indexOf('Working directory: ')
             int commandIdx = it.indexOf('Command: ')

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -841,7 +841,7 @@ $ ./gradlew nativeRun
 
 You can tweak the native executable options by configuring the `graalvmNative` extension as explained in the {native-gradle-plugin}[plugin documentation].
 
-Micronaut adds `-H:+SharedArenaSupport` to native image builds by default so Netty-based applications continue to work with current GraalVM releases. You can still override the generated build arguments through the standard `graalvmNative` configuration if you need different behavior.
+Micronaut adds `-H:+SharedArenaSupport` to GraalVM 25+ native image builds by default so Netty-based applications continue to work with current GraalVM releases. The plugin skips that flag for older GraalVM JDK lines that do not support it. You can still override the generated build arguments through the standard `graalvmNative` configuration if you need different behavior.
 
 For example, you can add options to the main executable by doing:
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -841,6 +841,8 @@ $ ./gradlew nativeRun
 
 You can tweak the native executable options by configuring the `graalvmNative` extension as explained in the {native-gradle-plugin}[plugin documentation].
 
+Micronaut adds `-H:+SharedArenaSupport` to native image builds by default so Netty-based applications continue to work with current GraalVM releases. You can still override the generated build arguments through the standard `graalvmNative` configuration if you need different behavior.
+
 For example, you can add options to the main executable by doing:
 
 [source, groovy, subs="verbatim,attributes", role="multi-language-sample"]


### PR DESCRIPTION
## Summary
- add `-H:+SharedArenaSupport` by default for Micronaut GraalVM native-image binaries
- cover the default with a non-skipped GraalVM plugin spec plus arg-file and Docker expectation assertions
- document the new default in the native-image guide

## Verification
- `./gradlew :micronaut-graalvm-plugin:test --tests 'io.micronaut.gradle.MicronautGraalWellBehavePluginSpec'`
- `./gradlew :micronaut-graalvm-plugin:compileJava docs`

Fixes #1212.

Micronaut organization project target: `5.0.0 Release`.
Ambiguity note: `5.0.0-M3` is also open, but QA selected the release board because this is a default-branch improvement rather than milestone-only tracking.

---
###### ✨ This message was AI-generated using gpt-5.4
