### PR TITLE
Support GraalVM community archives in Lambda Dockerfiles

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -491,7 +491,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
             String fileName = "graalvm-jdk-" + jdkVersion + "_linux-" + graalArch + "_bin.tar.gz";
             String graalvmDistributionUrl = getGraalVMDistributionUrl().get();
             runCommand("curl -4 -L " + graalvmDistributionUrl + " -o /tmp/" + fileName);
-            runCommand("tar -zxf /tmp/" + fileName + " -C /tmp && ls -d /tmp/graalvm-jdk-"+ jdkVersion + "* | grep -v \"tar.gz\" | xargs -I_ mv _ /usr/lib/graalvm");
+            runCommand("archive_dir=\"$(tar -tzf /tmp/" + fileName + " | sed -n 's#^\\\\./##;s#/.*##;/^$/d;p;q')\" && test -n \"$archive_dir\" && tar -zxf /tmp/" + fileName + " -C /tmp && mv \"/tmp/${archive_dir}\" /usr/lib/graalvm");
             runCommand("rm -rf /tmp/*");
             if (toMajorVersion(jdkVersion) < 21) {
                 // The GraalVM Updater was removed in GraalVM for JDK 21

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -491,7 +491,7 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
             String fileName = "graalvm-jdk-" + jdkVersion + "_linux-" + graalArch + "_bin.tar.gz";
             String graalvmDistributionUrl = getGraalVMDistributionUrl().get();
             runCommand("curl -4 -L " + graalvmDistributionUrl + " -o /tmp/" + fileName);
-            runCommand("archive_dir=\"$(tar -tzf /tmp/" + fileName + " | sed -n 's#^\\\\./##;s#/.*##;/^$/d;p;q')\" && test -n \"$archive_dir\" && tar -zxf /tmp/" + fileName + " -C /tmp && mv \"/tmp/${archive_dir}\" /usr/lib/graalvm");
+            runCommand("archive_dir=\"$(tar -tzf /tmp/" + fileName + " | sed -n 's#^\\\\./##;s#/.*##;/^$/d;p;q')\" && test -n \"$archive_dir\" && tar -zxf /tmp/" + fileName + " -C /tmp && test -d \"/tmp/${archive_dir}\" && mv \"/tmp/${archive_dir}\" /usr/lib/graalvm");
             runCommand("rm -rf /tmp/*");
             if (toMajorVersion(jdkVersion) < 21) {
                 // The GraalVM Updater was removed in GraalVM for JDK 21

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/docker/editor/DefaultEditorTest.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/docker/editor/DefaultEditorTest.groovy
@@ -36,7 +36,7 @@ class DefaultEditorTest extends Specification {
               ENV LANG=en_US.UTF-8
               RUN dnf update -y && dnf install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf
               RUN curl -4 -L https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_linux-x64_bin.tar.gz -o /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz
-              RUN archive_dir="$(tar -tzf /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz | sed -n 's#^\\./##;s#/.*##;/^$/d;p;q')" && test -n "$archive_dir" && tar -zxf /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz -C /tmp && mv "/tmp/${archive_dir}" /usr/lib/graalvm
+              RUN archive_dir="$(tar -tzf /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz | sed -n 's#^\\./##;s#/.*##;/^$/d;p;q')" && test -n "$archive_dir" && tar -zxf /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz -C /tmp && test -d "/tmp/${archive_dir}" && mv "/tmp/${archive_dir}" /usr/lib/graalvm
               RUN rm -rf /tmp/*
               CMD ["/usr/lib/graalvm/bin/native-image"]
               ENV PATH=/usr/lib/graalvm/bin:${PATH}
@@ -68,7 +68,7 @@ class DefaultEditorTest extends Specification {
               WORKDIR /function
               RUN dnf install -y zip
               COPY --link --from=builder /home/app/application /function/func
-              RUN echo "#!/bin/sh" >> bootstrap && echo "set -euo pipefail" >> bootstrap && echo "./func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=$(pwd)" >> bootstrap
+              RUN echo "#!/bin/sh" >> bootstrap && echo "set -euo pipefail" >> bootstrap && echo "./func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=\$(pwd)" >> bootstrap
               RUN chmod 777 bootstrap
               RUN chmod 777 func
               RUN zip -j function.zip bootstrap func
@@ -86,7 +86,7 @@ class DefaultEditorTest extends Specification {
                 ENV LANG=en_US.UTF-8
                 RUN dnf update -y && dnf install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf
                 RUN curl -4 -L https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_linux-x64_bin.tar.gz -o /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz
-                RUN archive_dir="$(tar -tzf /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz | sed -n 's#^\\./##;s#/.*##;/^$/d;p;q')" && test -n "$archive_dir" && tar -zxf /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz -C /tmp && mv "/tmp/${archive_dir}" /usr/lib/graalvm
+                RUN archive_dir="$(tar -tzf /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz | sed -n 's#^\\./##;s#/.*##;/^$/d;p;q')" && test -n "$archive_dir" && tar -zxf /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz -C /tmp && test -d "/tmp/${archive_dir}" && mv "/tmp/${archive_dir}" /usr/lib/graalvm
                 RUN rm -rf /tmp/*
                 CMD ["/usr/lib/graalvm/bin/native-image"]
                 ENV PATH=/usr/lib/graalvm/bin:${PATH}
@@ -119,7 +119,7 @@ class DefaultEditorTest extends Specification {
                 WORKDIR /function
                 RUN dnf install -y zip
                 COPY --link --from=builder /home/app/application /function/func
-                RUN echo "#!/bin/sh" >> bootstrap && echo "set -euo pipefail" >> bootstrap && echo "./func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=$(pwd)" >> bootstrap
+                RUN echo "#!/bin/sh" >> bootstrap && echo "set -euo pipefail" >> bootstrap && echo "./func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=\$(pwd)" >> bootstrap
                 RUN chmod 777 bootstrap
                 RUN chmod 777 func
                 RUN zip -j function.zip bootstrap func

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/docker/editor/DefaultEditorTest.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/docker/editor/DefaultEditorTest.groovy
@@ -31,15 +31,15 @@ class DefaultEditorTest extends Specification {
     }
 
     void "can insert before a specific line"() {
-        withText """
+        withText '''
               FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal AS graalvm
               ENV LANG=en_US.UTF-8
               RUN dnf update -y && dnf install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf
               RUN curl -4 -L https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_linux-x64_bin.tar.gz -o /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz
-              RUN tar -zxf /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz -C /tmp && ls -d /tmp/graalvm-jdk-21* | grep -v "tar.gz" | xargs -I_ mv _ /usr/lib/graalvm
+              RUN archive_dir="$(tar -tzf /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz | sed -n 's#^\\./##;s#/.*##;/^$/d;p;q')" && test -n "$archive_dir" && tar -zxf /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz -C /tmp && mv "/tmp/${archive_dir}" /usr/lib/graalvm
               RUN rm -rf /tmp/*
               CMD ["/usr/lib/graalvm/bin/native-image"]
-              ENV PATH=/usr/lib/graalvm/bin:\${PATH}
+              ENV PATH=/usr/lib/graalvm/bin:${PATH}
               FROM graalvm AS builder
               RUN dnf update -y && dnf install -y zip && dnf clean all
               WORKDIR /home/app
@@ -68,12 +68,12 @@ class DefaultEditorTest extends Specification {
               WORKDIR /function
               RUN dnf install -y zip
               COPY --link --from=builder /home/app/application /function/func
-              RUN echo "#!/bin/sh" >> bootstrap && echo "set -euo pipefail" >> bootstrap && echo "./func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=\$(pwd)" >> bootstrap
+              RUN echo "#!/bin/sh" >> bootstrap && echo "set -euo pipefail" >> bootstrap && echo "./func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=$(pwd)" >> bootstrap
               RUN chmod 777 bootstrap
               RUN chmod 777 func
               RUN zip -j function.zip bootstrap func
               ENTRYPOINT ["/function/func"]
-        """
+        '''
 
         when:
         editor.before("FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal") {
@@ -81,15 +81,15 @@ class DefaultEditorTest extends Specification {
         }
 
         then:
-        hasUpdatedText """
+        hasUpdatedText '''
                 FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal AS graalvm
                 ENV LANG=en_US.UTF-8
                 RUN dnf update -y && dnf install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf
                 RUN curl -4 -L https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_linux-x64_bin.tar.gz -o /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz
-                RUN tar -zxf /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz -C /tmp && ls -d /tmp/graalvm-jdk-21* | grep -v "tar.gz" | xargs -I_ mv _ /usr/lib/graalvm
+                RUN archive_dir="$(tar -tzf /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz | sed -n 's#^\\./##;s#/.*##;/^$/d;p;q')" && test -n "$archive_dir" && tar -zxf /tmp/graalvm-jdk-21_linux-x64_bin.tar.gz -C /tmp && mv "/tmp/${archive_dir}" /usr/lib/graalvm
                 RUN rm -rf /tmp/*
                 CMD ["/usr/lib/graalvm/bin/native-image"]
-                ENV PATH=/usr/lib/graalvm/bin:\${PATH}
+                ENV PATH=/usr/lib/graalvm/bin:${PATH}
                 FROM graalvm AS builder
                 RUN dnf update -y && dnf install -y zip && dnf clean all
                 WORKDIR /home/app
@@ -119,12 +119,12 @@ class DefaultEditorTest extends Specification {
                 WORKDIR /function
                 RUN dnf install -y zip
                 COPY --link --from=builder /home/app/application /function/func
-                RUN echo "#!/bin/sh" >> bootstrap && echo "set -euo pipefail" >> bootstrap && echo "./func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=\$(pwd)" >> bootstrap
+                RUN echo "#!/bin/sh" >> bootstrap && echo "set -euo pipefail" >> bootstrap && echo "./func -XX:MaximumHeapSizePercent=80 -Dio.netty.allocator.numDirectArenas=0 -Dio.netty.noPreferDirect=true -Djava.library.path=$(pwd)" >> bootstrap
                 RUN chmod 777 bootstrap
                 RUN chmod 777 func
                 RUN zip -j function.zip bootstrap func
                 ENTRYPOINT ["/function/func"]
-        """
+        '''
     }
 
     void "can insert after a specific line and before another specific line"() {

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
@@ -94,6 +94,9 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
 
         and:
         dockerFileNative.find { it ==~ /.*graalvm-jdk-\d+_linux-${archset}_bin\.tar\.gz.*/ }
+        dockerFileNative.find { it.contains('archive_dir="$(tar -tzf /tmp/graalvm-jdk-25_linux-' + archset + '_bin.tar.gz') }
+        dockerFileNative.find { it.contains('mv "/tmp/${archive_dir}" /usr/lib/graalvm') }
+        !dockerFileNative.find { it.contains('ls -d /tmp/graalvm-jdk-25') }
 
         where:
         archset   | desc
@@ -353,6 +356,54 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
         and:
         !dockerFileNative.find() { it.contains('https://github.com/graalvm/graalvm-ce-builds/releases/download') }
         dockerFileNative.find() { it.contains('https://releases.company.com/downloads') }
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/915")
+    void 'it is possible to define the GraalVM distribution URL for a lambda community archive'() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.graalvm"
+                id "io.micronaut.docker"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "lambda_provided"
+            }
+
+            $repositoriesBlock
+
+            application {
+                mainClass.set("com.example.Application")
+            }
+
+            java {
+                sourceCompatibility = JavaVersion.toVersion('25')
+                targetCompatibility = JavaVersion.toVersion('25')
+            }
+
+            tasks.named("dockerfileNative") {
+                graalVMDistributionUrl = "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-25.0.2/graalvm-community-jdk-25.0.2_linux-x64_bin.tar.gz"
+            }
+        """
+
+        when:
+        def result = build('dockerfileNative')
+
+        def dockerfileNativeTask = result.task(':dockerfileNative')
+        def dockerFileNative = new File(testProjectDir.root, 'build/docker/native-main/DockerfileNative').readLines('UTF-8')
+
+        then:
+        dockerfileNativeTask.outcome == TaskOutcome.SUCCESS
+
+        and:
+        dockerFileNative.find() { it.contains('https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-25.0.2/graalvm-community-jdk-25.0.2_linux-x64_bin.tar.gz') }
+        dockerFileNative.find() { it.contains('archive_dir="$(tar -tzf /tmp/graalvm-jdk-25_linux-x64_bin.tar.gz') }
+        dockerFileNative.find() { it.contains('mv "/tmp/${archive_dir}" /usr/lib/graalvm') }
+        !dockerFileNative.find() { it.contains('ls -d /tmp/graalvm-jdk-25') }
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/753")

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
@@ -95,6 +95,8 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
         and:
         dockerFileNative.find { it ==~ /.*graalvm-jdk-\d+_linux-${archset}_bin\.tar\.gz.*/ }
         dockerFileNative.find { it.contains('archive_dir="$(tar -tzf /tmp/graalvm-jdk-25_linux-' + archset + '_bin.tar.gz') }
+        dockerFileNative.find { it.contains('test -n "$archive_dir"') }
+        dockerFileNative.find { it.contains('test -d "/tmp/${archive_dir}"') }
         dockerFileNative.find { it.contains('mv "/tmp/${archive_dir}" /usr/lib/graalvm') }
         !dockerFileNative.find { it.contains('ls -d /tmp/graalvm-jdk-25') }
 
@@ -402,6 +404,8 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
         and:
         dockerFileNative.find() { it.contains('https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-25.0.2/graalvm-community-jdk-25.0.2_linux-x64_bin.tar.gz') }
         dockerFileNative.find() { it.contains('archive_dir="$(tar -tzf /tmp/graalvm-jdk-25_linux-x64_bin.tar.gz') }
+        dockerFileNative.find() { it.contains('test -n "$archive_dir"') }
+        dockerFileNative.find() { it.contains('test -d "/tmp/${archive_dir}"') }
         dockerFileNative.find() { it.contains('mv "/tmp/${archive_dir}" /usr/lib/graalvm') }
         !dockerFileNative.find() { it.contains('ls -d /tmp/graalvm-jdk-25') }
     }


### PR DESCRIPTION
## Summary
- generalize the Lambda GraalVM archive install step so `dockerfileNative` no longer assumes an Oracle-only extracted directory name
- keep the existing Oracle default download behavior and current `graalReleasesUrl` / `graalVMDistributionUrl` DSL surface
- add targeted assertions for the generic extraction command and a GraalVM Community distribution override

## Verification
- `./gradlew :micronaut-docker-plugin:test --tests io.micronaut.gradle.docker.editor.DefaultEditorTest functional-tests:test --tests io.micronaut.gradle.lambda.LambdaNativeImageSpec`

Closes #915.

Micronaut organization project target: `5.0.0 Release`.
Ambiguity note: `5.0.0-M3` is also open, but QA selected the release board because this is a default-branch improvement on the unreleased 5.0 line rather than milestone-only tracking.

---
###### ✨ This message was AI-generated using gpt-5.4
