### PR TITLE
Fix Lombok plugin detection for FreeFair builds

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -77,11 +77,12 @@ public class MicronautComponentPlugin implements Plugin<Project> {
     public void apply(Project project) {
         PluginManager plugins = project.getPluginManager();
         plugins.apply(MicronautBasePlugin.class);
+        var loggedLombokWarning = new AtomicBoolean(false);
         MicronautExtension micronautExtension = project.getExtensions().getByType(MicronautExtension.class);
         TaskContainer tasks = project.getTasks();
         TaskProvider<ApplicationClasspathInspector> inspectRuntimeClasspath = registerInspectRuntimeClasspath(project, tasks);
 
-        configureJava(project, tasks);
+        configureJava(project, tasks, loggedLombokWarning);
 
         configureGroovy(project, tasks, micronautExtension);
 
@@ -97,11 +98,10 @@ public class MicronautComponentPlugin implements Plugin<Project> {
         });
         PluginsHelper.registerVersionExtensions(PluginsHelper.KNOWN_VERSION_PROPERTIES, project);
 
-        detectAndFixLombokUse(project);
+        detectAndFixLombokUse(project, loggedLombokWarning);
     }
 
-    private void detectAndFixLombokUse(Project project) {
-        var logged = new AtomicBoolean(false);
+    private void detectAndFixLombokUse(Project project, AtomicBoolean loggedLombokWarning) {
         project.afterEvaluate(unused -> {
             for (var conf : List.of("annotationProcessor", "testAnnotationProcessor")) {
                 var annotationProcessor = project.getConfigurations().findByName(conf);
@@ -121,10 +121,7 @@ public class MicronautComponentPlugin implements Plugin<Project> {
                         }
                         annotationProcessor.getDependencies().clear();
                         annotationProcessor.getDependencies().addAll(newDependencies);
-                        if (!logged.compareAndSet(false, true)) {
-                            project.getLogger().warn("Detected use of Lombok, which is strongly discouraged. Annotation processors have been reordered to avoid issues.\n" +
-                                                     "Consider using Micronaut Sourcegen instead: https://micronaut-projects.github.io/micronaut-sourcegen/latest/guide/");
-                        }
+                        warnAboutLombok(project, loggedLombokWarning);
                     }
                 }
             }
@@ -216,7 +213,7 @@ public class MicronautComponentPlugin implements Plugin<Project> {
     }
 
 
-    private void configureJava(Project project, TaskContainer tasks) {
+    private void configureJava(Project project, TaskContainer tasks, AtomicBoolean loggedLombokWarning) {
 
         project.afterEvaluate(p -> {
             var sourceSets = PluginsHelper.findSourceSets(p);
@@ -273,9 +270,48 @@ public class MicronautComponentPlugin implements Plugin<Project> {
                     compilerArgs.add("-Amicronaut.processing.module=" + module);
                 }
                 javaCompile.getOptions().setCompilerArgs(compilerArgs);
+                javaCompile.doFirst(unused -> reorderLombokAnnotationProcessorPath(project, javaCompile, loggedLombokWarning));
             });
         });
 
+    }
+
+    private void reorderLombokAnnotationProcessorPath(Project project,
+                                                      JavaCompile javaCompile,
+                                                      AtomicBoolean loggedLombokWarning) {
+        var annotationProcessorPath = javaCompile.getOptions().getAnnotationProcessorPath();
+        if (annotationProcessorPath == null) {
+            return;
+        }
+        var currentFiles = new ArrayList<>(annotationProcessorPath.getFiles());
+        if (currentFiles.isEmpty() || isLombokJar(currentFiles.get(0))) {
+            return;
+        }
+        for (File file : currentFiles) {
+            if (isLombokJar(file)) {
+                var reorderedFiles = new ArrayList<File>(currentFiles.size());
+                reorderedFiles.add(file);
+                for (File currentFile : currentFiles) {
+                    if (!file.equals(currentFile)) {
+                        reorderedFiles.add(currentFile);
+                    }
+                }
+                javaCompile.getOptions().setAnnotationProcessorPath(project.files(reorderedFiles));
+                warnAboutLombok(project, loggedLombokWarning);
+                return;
+            }
+        }
+    }
+
+    private boolean isLombokJar(File file) {
+        return file.getName().contains(LOMBOK_ARTIFACT_ID);
+    }
+
+    private void warnAboutLombok(Project project, AtomicBoolean loggedLombokWarning) {
+        if (loggedLombokWarning.compareAndSet(false, true)) {
+            project.getLogger().warn("Detected use of Lombok, which is strongly discouraged. Annotation processors have been reordered to avoid issues.\n" +
+                "Consider using Micronaut Sourcegen instead: https://micronaut-projects.github.io/micronaut-sourcegen/latest/guide/");
+        }
     }
 
 

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -15,13 +15,14 @@
  */
 package io.micronaut.gradle;
 
+import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -40,7 +41,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.micronaut.gradle.PluginsHelper.applyAdditionalProcessors;
@@ -272,34 +272,27 @@ public class MicronautComponentPlugin implements Plugin<Project> {
                     compilerArgs.add("-Amicronaut.processing.module=" + module);
                 }
                 javaCompile.getOptions().setCompilerArgs(compilerArgs);
-                var annotationProcessorPath = javaCompile.getOptions().getAnnotationProcessorPath();
-                if (annotationProcessorPath != null) {
-                    javaCompile.getOptions().setAnnotationProcessorPath(
-                        reorderLombokAnnotationProcessorPath(project, annotationProcessorPath, loggedLombokWarning)
-                    );
-                }
+                javaCompile.doFirst(new Action<Task>() {
+                    @Override
+                    public void execute(Task unused) {
+                        reorderLombokAnnotationProcessorPath(project, javaCompile, loggedLombokWarning);
+                    }
+                });
             });
         });
 
     }
 
-    private FileCollection reorderLombokAnnotationProcessorPath(Project project,
-                                                                FileCollection annotationProcessorPath,
-                                                                AtomicBoolean loggedLombokWarning) {
-        return project.files(new Callable<List<File>>() {
-            @Override
-            public List<File> call() {
-                return reorderLombokAnnotationProcessorPathFiles(annotationProcessorPath.getFiles(), project, loggedLombokWarning);
-            }
-        });
-    }
-
-    private List<File> reorderLombokAnnotationProcessorPathFiles(Set<File> annotationProcessorPathFiles,
-                                                                 Project project,
-                                                                 AtomicBoolean loggedLombokWarning) {
-        var currentFiles = new ArrayList<>(annotationProcessorPathFiles);
+    private void reorderLombokAnnotationProcessorPath(Project project,
+                                                      JavaCompile javaCompile,
+                                                      AtomicBoolean loggedLombokWarning) {
+        var annotationProcessorPath = javaCompile.getOptions().getAnnotationProcessorPath();
+        if (annotationProcessorPath == null) {
+            return;
+        }
+        var currentFiles = new ArrayList<>(annotationProcessorPath.getFiles());
         if (currentFiles.isEmpty() || isLombokJar(currentFiles.get(0))) {
-            return currentFiles;
+            return;
         }
         for (File file : currentFiles) {
             if (isLombokJar(file)) {
@@ -310,11 +303,11 @@ public class MicronautComponentPlugin implements Plugin<Project> {
                         reorderedFiles.add(currentFile);
                     }
                 }
+                javaCompile.getOptions().setAnnotationProcessorPath(project.files(reorderedFiles));
                 warnAboutLombok(project, loggedLombokWarning);
-                return reorderedFiles;
+                return;
             }
         }
-        return currentFiles;
     }
 
     private boolean isLombokJar(File file) {

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -39,6 +40,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.micronaut.gradle.PluginsHelper.applyAdditionalProcessors;
@@ -270,22 +272,34 @@ public class MicronautComponentPlugin implements Plugin<Project> {
                     compilerArgs.add("-Amicronaut.processing.module=" + module);
                 }
                 javaCompile.getOptions().setCompilerArgs(compilerArgs);
-                javaCompile.doFirst(unused -> reorderLombokAnnotationProcessorPath(project, javaCompile, loggedLombokWarning));
+                var annotationProcessorPath = javaCompile.getOptions().getAnnotationProcessorPath();
+                if (annotationProcessorPath != null) {
+                    javaCompile.getOptions().setAnnotationProcessorPath(
+                        reorderLombokAnnotationProcessorPath(project, annotationProcessorPath, loggedLombokWarning)
+                    );
+                }
             });
         });
 
     }
 
-    private void reorderLombokAnnotationProcessorPath(Project project,
-                                                      JavaCompile javaCompile,
-                                                      AtomicBoolean loggedLombokWarning) {
-        var annotationProcessorPath = javaCompile.getOptions().getAnnotationProcessorPath();
-        if (annotationProcessorPath == null) {
-            return;
-        }
-        var currentFiles = new ArrayList<>(annotationProcessorPath.getFiles());
+    private FileCollection reorderLombokAnnotationProcessorPath(Project project,
+                                                                FileCollection annotationProcessorPath,
+                                                                AtomicBoolean loggedLombokWarning) {
+        return project.files(new Callable<List<File>>() {
+            @Override
+            public List<File> call() {
+                return reorderLombokAnnotationProcessorPathFiles(annotationProcessorPath.getFiles(), project, loggedLombokWarning);
+            }
+        });
+    }
+
+    private List<File> reorderLombokAnnotationProcessorPathFiles(Set<File> annotationProcessorPathFiles,
+                                                                 Project project,
+                                                                 AtomicBoolean loggedLombokWarning) {
+        var currentFiles = new ArrayList<>(annotationProcessorPathFiles);
         if (currentFiles.isEmpty() || isLombokJar(currentFiles.get(0))) {
-            return;
+            return currentFiles;
         }
         for (File file : currentFiles) {
             if (isLombokJar(file)) {
@@ -296,15 +310,16 @@ public class MicronautComponentPlugin implements Plugin<Project> {
                         reorderedFiles.add(currentFile);
                     }
                 }
-                javaCompile.getOptions().setAnnotationProcessorPath(project.files(reorderedFiles));
                 warnAboutLombok(project, loggedLombokWarning);
-                return;
+                return reorderedFiles;
             }
         }
+        return currentFiles;
     }
 
     private boolean isLombokJar(File file) {
-        return file.getName().contains(LOMBOK_ARTIFACT_ID);
+        String fileName = file.getName();
+        return fileName.startsWith(LOMBOK_ARTIFACT_ID + "-") && fileName.endsWith(".jar");
     }
 
     private void warnAboutLombok(Project project, AtomicBoolean loggedLombokWarning) {

--- a/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMinimalLibraryPluginSpec.groovy
+++ b/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMinimalLibraryPluginSpec.groovy
@@ -126,6 +126,81 @@ class FooTest {
                 .resolve('build/classes/java/test/example/$FooTest$Definition.class').toFile().exists()
     }
 
+    def "test lombok plugin works with required args constructor beans"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.library"
+                id "io.freefair.lombok" version "8.6"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                testRuntime "junit"
+                processing {
+                    incremental true
+                }
+            }
+
+            $repositoriesBlock
+        """
+        testProjectDir.newFolder("src", "main", "java", "example")
+        testProjectDir.newFolder("src", "test", "java", "example")
+        def javaFile = testProjectDir.newFile("src/main/java/example/GreetingService.java")
+        def testJavaFile = testProjectDir.newFile("src/test/java/example/GreetingServiceTest.java")
+        javaFile.parentFile.mkdirs()
+        javaFile << """
+package example;
+
+import jakarta.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+
+@Singleton
+class GreetingDependency {
+    String message() {
+        return "Good";
+    }
+}
+
+@RequiredArgsConstructor
+@Singleton
+class GreetingService {
+    private final GreetingDependency greetingDependency;
+
+    String greet() {
+        return greetingDependency.message();
+    }
+}
+"""
+        testJavaFile.parentFile.mkdirs()
+        testJavaFile << """
+package example;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class GreetingServiceTest {
+
+    @Test
+    void testRequiredArgsConstructorBeanInstantiates() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            Assertions.assertEquals("Good", context.getBean(GreetingService.class).greet());
+        }
+    }
+}
+"""
+
+        when:
+        def result = build('test')
+
+        then:
+        result.task(":test").outcome == TaskOutcome.SUCCESS
+        testProjectDir.root.toPath()
+                .resolve('build/classes/java/main/example/$GreetingService$Definition.class').toFile().exists()
+    }
+
     def "test add jaxrs processing"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -2363,8 +2363,9 @@ micronaut {
 In general, the use of Lombok annotation processing is strongly discouraged, as its behavior is dependent on the order of annotation processors, that it uses internal types of the JDK and is not compatible with incremental compilation.
 You should prefer using [Micronaut Sourcegen](https://micronaut-projects.github.io/micronaut-sourcegen/latest/guide/) whenever possible.
 
-However, should you really want to use it, you may face situations where the Gradle plugin, despite reordering annotation processors, doesn't place the lombok jar in front of the annotation processor classpath, which would cause compilation errors.
-In such a case, you can add this workaround to your build scripts:
+For standard Java compilation, the Gradle plugin reorders the `annotationProcessor` dependencies and the resulting `JavaCompile` annotation processor path so the Lombok jar stays ahead of Micronaut processors.
+
+If your build replaces `options.annotationProcessorPath` after Micronaut configures the task, or if you are debugging a non-standard compilation setup, you can still force the order manually with this workaround:
 
 .Suppressing automatic dependencies
 [source, groovy, subs="verbatim,attributes", role="multi-language-sample"]


### PR DESCRIPTION
## Summary
- reorder each `JavaCompile` annotation processor path when Lombok is present so Lombok stays ahead of Micronaut processors even when provided by the FreeFair plugin
- keep the existing dependency-level Lombok mitigation and fix the warning path so the Lombok warning is emitted once when reordering actually happens
- add a FreeFair Lombok regression for `@RequiredArgsConstructor` bean instantiation and update the Lombok docs to reflect the automatic Java path plus the remaining manual-workaround case

## Verification
- `./gradlew :micronaut-minimal-plugin:test --rerun-tasks --tests 'io.micronaut.gradle.MicronautMinimalLibraryPluginSpec.test lombok works' --tests 'io.micronaut.gradle.MicronautMinimalLibraryPluginSpec.test lombok plugin works with required args constructor beans'`
- `./gradlew :micronaut-minimal-plugin:test --rerun-tasks --tests 'io.micronaut.gradle.MicronautMinimalLibraryPluginSpec'`

Closes #230.

Micronaut organization project target: `5.0.0 Release`.
Ambiguity note: `5.0.0-M3` is also open, but QA selected the release board because this is a default-branch bug fix for the unreleased 5.0 line rather than milestone-only tracking.
Project-link note: automated organization-project linking could not be applied from this environment because the authenticated token lacks the `project` scope required by GitHub Projects V2 mutations.

---
###### ✨ This message was AI-generated using gpt-5.4
