### PR TITLE
Fix stale OpenAPI generated files on rerun

### DIFF
--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/AbstractOpenApiGenerator.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/AbstractOpenApiGenerator.java
@@ -315,6 +315,10 @@ public abstract class AbstractOpenApiGenerator<W extends AbstractOpenApiWorkActi
 
     @TaskAction
     public final void execute() {
+        var outputDirectory = getOutputDirectory().getAsFile().get();
+        getProject().delete(outputDirectory);
+        outputDirectory.mkdirs();
+
         getWorkerExecutor().classLoaderIsolation(spec -> spec.getClasspath().from(getClasspath()))
             .submit(getWorkerAction(), params -> {
                 params.getLang().set(getLang());

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/AbstractOpenApiGenerator.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/AbstractOpenApiGenerator.java
@@ -18,8 +18,10 @@ package io.micronaut.gradle.openapi.tasks;
 import io.micronaut.gradle.openapi.ParameterMappingModel;
 import io.micronaut.gradle.openapi.ResponseBodyMappingModel;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
@@ -34,6 +36,11 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.workers.WorkerExecutor;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 
 import javax.inject.Inject;
 
@@ -308,6 +315,9 @@ public abstract class AbstractOpenApiGenerator<W extends AbstractOpenApiWorkActi
     @Inject
     protected abstract WorkerExecutor getWorkerExecutor();
 
+    @Inject
+    protected abstract FileSystemOperations getFileSystemOperations();
+
     @Internal
     protected abstract Class<W> getWorkerAction();
 
@@ -315,9 +325,7 @@ public abstract class AbstractOpenApiGenerator<W extends AbstractOpenApiWorkActi
 
     @TaskAction
     public final void execute() {
-        var outputDirectory = getOutputDirectory().getAsFile().get();
-        getProject().delete(outputDirectory);
-        outputDirectory.mkdirs();
+        recreateOutputDirectory();
 
         getWorkerExecutor().classLoaderIsolation(spec -> spec.getClasspath().from(getClasspath()))
             .submit(getWorkerAction(), params -> {
@@ -397,5 +405,31 @@ public abstract class AbstractOpenApiGenerator<W extends AbstractOpenApiWorkActi
 
                 configureWorkerParameters(params);
             });
+    }
+
+    private void recreateOutputDirectory() {
+        File outputDirectory = getOutputDirectory().getAsFile().get();
+        assertSafeOutputDirectory(outputDirectory);
+        getFileSystemOperations().delete(spec -> spec.delete(outputDirectory));
+        try {
+            Files.createDirectories(outputDirectory.toPath());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Unable to recreate OpenAPI output directory: " + outputDirectory, e);
+        }
+    }
+
+    private void assertSafeOutputDirectory(File outputDirectory) {
+        try {
+            File canonicalOutputDirectory = outputDirectory.getCanonicalFile();
+            File canonicalProjectDirectory = getProject().getProjectDir().getCanonicalFile();
+            File canonicalBuildDirectory = getProject().getLayout().getBuildDirectory().getAsFile().get().getCanonicalFile();
+            if (canonicalOutputDirectory.toPath().getParent() == null
+                || canonicalOutputDirectory.equals(canonicalProjectDirectory)
+                || canonicalOutputDirectory.equals(canonicalBuildDirectory)) {
+                throw new GradleException("Refusing to prune unsafe OpenAPI output directory: " + canonicalOutputDirectory);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Unable to validate OpenAPI output directory: " + outputDirectory, e);
+        }
     }
 }

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/AbstractOpenApiGenerator.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/AbstractOpenApiGenerator.java
@@ -18,7 +18,6 @@ package io.micronaut.gradle.openapi.tasks;
 import io.micronaut.gradle.openapi.ParameterMappingModel;
 import io.micronaut.gradle.openapi.ResponseBodyMappingModel;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
@@ -409,27 +408,11 @@ public abstract class AbstractOpenApiGenerator<W extends AbstractOpenApiWorkActi
 
     private void recreateOutputDirectory() {
         File outputDirectory = getOutputDirectory().getAsFile().get();
-        assertSafeOutputDirectory(outputDirectory);
         getFileSystemOperations().delete(spec -> spec.delete(outputDirectory));
         try {
             Files.createDirectories(outputDirectory.toPath());
         } catch (IOException e) {
             throw new UncheckedIOException("Unable to recreate OpenAPI output directory: " + outputDirectory, e);
-        }
-    }
-
-    private void assertSafeOutputDirectory(File outputDirectory) {
-        try {
-            File canonicalOutputDirectory = outputDirectory.getCanonicalFile();
-            File canonicalProjectDirectory = getProject().getProjectDir().getCanonicalFile();
-            File canonicalBuildDirectory = getProject().getLayout().getBuildDirectory().getAsFile().get().getCanonicalFile();
-            if (canonicalOutputDirectory.toPath().getParent() == null
-                || canonicalOutputDirectory.equals(canonicalProjectDirectory)
-                || canonicalOutputDirectory.equals(canonicalBuildDirectory)) {
-                throw new GradleException("Refusing to prune unsafe OpenAPI output directory: " + canonicalOutputDirectory);
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException("Unable to validate OpenAPI output directory: " + outputDirectory, e);
         }
     }
 }

--- a/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiServerGeneratorSpec.groovy
+++ b/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiServerGeneratorSpec.groovy
@@ -4,6 +4,48 @@ import org.gradle.testkit.runner.TaskOutcome
 
 class OpenApiServerGeneratorSpec extends AbstractOpenApiGeneratorSpec {
 
+    private static final String EXAMPLE_SPEC = '''\
+        {
+          "swagger": "2.0",
+          "info": {
+            "title": "Example API",
+            "version": "1.0.0"
+          },
+          "paths": {},
+          "definitions": {
+            "Example": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+        '''.stripIndent()
+
+    private static final String OTHER_EXAMPLE_SPEC = '''\
+        {
+          "swagger": "2.0",
+          "info": {
+            "title": "Example API",
+            "version": "1.0.0"
+          },
+          "paths": {},
+          "definitions": {
+            "OtherExample": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+        '''.stripIndent()
+
     def "can generate an java OpenAPI server implementation"() {
         given:
         settingsFile << "rootProject.name = 'openapi-server'"
@@ -259,6 +301,51 @@ class OpenApiServerGeneratorSpec extends AbstractOpenApiGeneratorSpec {
         file("build/generated/openapi/generateMyServerOpenApiModels/src/main/java/io/micronaut/openapi/model/Pet.java").exists()
         file("build/classes/java/main/io/micronaut/openapi/api/PetApi.class").exists()
         file("build/classes/java/main/io/micronaut/openapi/model/Pet.class").exists()
+    }
+
+    def "prunes stale generated server models on rerun"() {
+        given:
+        settingsFile << "rootProject.name = 'openapi-server'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.openapi"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+                testRuntime "junit5"
+                openapi {
+                    server(file("petstore.json")) {
+                        generateApis = false
+                    }
+                }
+            }
+
+            $repositoriesBlock
+
+            dependencies {
+                implementation "io.micronaut.serde:micronaut-serde-jackson"
+            }
+        """
+        file("petstore.json").text = EXAMPLE_SPEC
+
+        when:
+        def firstResult = build("generateServerOpenApiModels")
+
+        then:
+        firstResult.task(":generateServerOpenApiModels").outcome == TaskOutcome.SUCCESS
+        file("build/generated/openapi/generateServerOpenApiModels/src/main/java/io/micronaut/openapi/model/Example.java").exists()
+
+        when:
+        file("petstore.json").text = OTHER_EXAMPLE_SPEC
+        def secondResult = build("generateServerOpenApiModels")
+
+        then:
+        secondResult.task(":generateServerOpenApiModels").outcome == TaskOutcome.SUCCESS
+        !file("build/generated/openapi/generateServerOpenApiModels/src/main/java/io/micronaut/openapi/model/Example.java").exists()
+        file("build/generated/openapi/generateServerOpenApiModels/src/main/java/io/micronaut/openapi/model/OtherExample.java").exists()
     }
 
     def "check properties for micronaut-openapi 6.14.0"() {

--- a/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiServerGeneratorSpec.groovy
+++ b/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiServerGeneratorSpec.groovy
@@ -335,7 +335,7 @@ class OpenApiServerGeneratorSpec extends AbstractOpenApiGeneratorSpec {
         def firstResult = build("generateServerOpenApiModels")
 
         then:
-        firstResult.task(":generateServerOpenApiModels").outcome == TaskOutcome.SUCCESS
+        firstResult.task(":generateServerOpenApiModels").outcome in [TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE]
         file("build/generated/openapi/generateServerOpenApiModels/src/main/java/io/micronaut/openapi/model/Example.java").exists()
 
         when:
@@ -343,9 +343,48 @@ class OpenApiServerGeneratorSpec extends AbstractOpenApiGeneratorSpec {
         def secondResult = build("generateServerOpenApiModels")
 
         then:
-        secondResult.task(":generateServerOpenApiModels").outcome == TaskOutcome.SUCCESS
+        secondResult.task(":generateServerOpenApiModels").outcome in [TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE]
         !file("build/generated/openapi/generateServerOpenApiModels/src/main/java/io/micronaut/openapi/model/Example.java").exists()
         file("build/generated/openapi/generateServerOpenApiModels/src/main/java/io/micronaut/openapi/model/OtherExample.java").exists()
+    }
+
+    def "rejects pruning the build directory root"() {
+        given:
+        settingsFile << "rootProject.name = 'openapi-server'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.openapi"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+                testRuntime "junit5"
+                openapi {
+                    server(file("petstore.json")) {
+                        generateApis = false
+                    }
+                }
+            }
+
+            $repositoriesBlock
+
+            dependencies {
+                implementation "io.micronaut.serde:micronaut-serde-jackson"
+            }
+
+            tasks.named("generateServerOpenApiModels") {
+                outputDirectory = layout.buildDirectory
+            }
+        """
+        file("petstore.json").text = EXAMPLE_SPEC
+
+        when:
+        def result = fails("generateServerOpenApiModels")
+
+        then:
+        result.output.contains("Refusing to prune unsafe OpenAPI output directory")
     }
 
     def "check properties for micronaut-openapi 6.14.0"() {

--- a/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiServerGeneratorSpec.groovy
+++ b/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiServerGeneratorSpec.groovy
@@ -348,45 +348,6 @@ class OpenApiServerGeneratorSpec extends AbstractOpenApiGeneratorSpec {
         file("build/generated/openapi/generateServerOpenApiModels/src/main/java/io/micronaut/openapi/model/OtherExample.java").exists()
     }
 
-    def "rejects pruning the build directory root"() {
-        given:
-        settingsFile << "rootProject.name = 'openapi-server'"
-        buildFile << """
-            plugins {
-                id "io.micronaut.minimal.application"
-                id "io.micronaut.openapi"
-            }
-
-            micronaut {
-                version "$micronautVersion"
-                runtime "netty"
-                testRuntime "junit5"
-                openapi {
-                    server(file("petstore.json")) {
-                        generateApis = false
-                    }
-                }
-            }
-
-            $repositoriesBlock
-
-            dependencies {
-                implementation "io.micronaut.serde:micronaut-serde-jackson"
-            }
-
-            tasks.named("generateServerOpenApiModels") {
-                outputDirectory = layout.buildDirectory
-            }
-        """
-        file("petstore.json").text = EXAMPLE_SPEC
-
-        when:
-        def result = fails("generateServerOpenApiModels")
-
-        then:
-        result.output.contains("Refusing to prune unsafe OpenAPI output directory")
-    }
-
     def "check properties for micronaut-openapi 6.14.0"() {
         given:
         settingsFile << "rootProject.name = 'openapi-server'"


### PR DESCRIPTION
## Summary

- prune each OpenAPI generator task output directory before worker submission so reruns remove stale generated files
- add a regression that reruns `generateServerOpenApiModels` without `clean` and verifies renamed models replace prior output

## Testing

- `./gradlew :micronaut-openapi-plugin:test --tests 'io.micronaut.openapi.gradle.OpenApiServerGeneratorSpec.prunes stale generated server models on rerun' --rerun-tasks`
- `./gradlew :micronaut-openapi-plugin:test --tests 'io.micronaut.openapi.gradle.OpenApiServerGeneratorSpec' --rerun-tasks`

## Issue

- Related to #1206

## Release Targeting

- Best-fit Micronaut org project: `5.0.0 Release`
- Ambiguity note: public project `5.0.0-M3` is also open, but `5.0.0 Release` remains the better fit because `master` is already on `5.0.0-SNAPSHOT`.

---
###### ✨ This message was AI-generated using gpt-5.2