### PR TITLE
Make the Micronaut Platform Catalog plugin compatible with BuildSrc

### DIFF
--- a/functional-tests/src/test/groovy/io/micronaut/gradle/settings/BuildSrcCatalogFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/settings/BuildSrcCatalogFunctionalTest.groovy
@@ -1,0 +1,126 @@
+package io.micronaut.gradle.settings
+
+import io.micronaut.gradle.fixtures.AbstractFunctionalTest
+
+class BuildSrcCatalogFunctionalTest extends AbstractFunctionalTest {
+    def "can resolve the Micronaut catalog from the owning build version catalog when applied in buildSrc"() {
+        given:
+        writeBuildSrcCatalogBuild()
+        file('gradle').mkdirs()
+        file('gradle/libs.versions.toml') << """
+[versions]
+micronaut = "$micronautVersion"
+"""
+
+        when:
+        def result = buildBuildSrc('resolveCatalog')
+
+        then:
+        result.output.contains('micronaut-inject-java')
+    }
+
+    def "can use the owning build gradle properties and override file when applied in buildSrc"() {
+        given:
+        writeBuildSrcCatalogBuild()
+        file('gradle.properties') << """
+micronautVersion=$micronautVersion
+"""
+        file('gradle').mkdirs()
+        file('gradle/mn-override.versions.toml') << """
+[versions]
+micronaut-core = "2048"
+"""
+
+        when:
+        def result = failsBuildSrc('resolveCatalog')
+
+        then:
+        result.output.contains('Could not find io.micronaut:micronaut-inject-java:2048')
+    }
+
+    def "buildSrc local catalog inputs win over the owning build fallback"() {
+        given:
+        writeBuildSrcCatalogBuild()
+        file('gradle.properties') << """
+micronautVersion=$micronautVersion
+"""
+        file('buildSrc/gradle.properties') << """
+micronautVersion=2048
+"""
+
+        when:
+        def result = failsBuildSrc('resolveCatalog')
+
+        then:
+        result.output.contains('Could not find io.micronaut.platform:micronaut-platform:2048')
+    }
+
+    private void writeBuildSrcCatalogBuild() {
+        file('buildSrc').mkdirs()
+        file('buildSrc/settings.gradle') << """
+            pluginManagement {
+                repositories {
+                    mavenCentral()
+                    maven {
+                        url = "${System.getProperty("internal.plugin.repo")}"
+                    }
+                    gradlePluginPortal()
+                }
+                plugins {
+                    id 'io.micronaut.platform.catalog' version '${System.getProperty('project.version')}'
+                }
+            }
+
+            plugins {
+                id 'io.micronaut.platform.catalog'
+            }
+
+            rootProject.name = 'buildSrc'
+        """
+        file('buildSrc/build.gradle') << """
+            plugins {
+                id 'groovy-gradle-plugin'
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            configurations {
+                verify
+            }
+
+            dependencies {
+                verify mn.micronaut.inject.java
+            }
+
+            tasks.register('resolveCatalog') {
+                doLast {
+                    println configurations.verify.files*.name.sort().join(',')
+                }
+            }
+        """
+    }
+
+    private def buildBuildSrc(String... args) {
+        withBuildSrcBaseDir {
+            build(args)
+        }
+    }
+
+    private def failsBuildSrc(String... args) {
+        withBuildSrcBaseDir {
+            fails(args)
+        }
+    }
+
+    private def withBuildSrcBaseDir(Closure action) {
+        def originalBaseDir = baseDir
+        baseDir = file('buildSrc').toPath()
+        try {
+            action.call()
+        } finally {
+            baseDir = originalBaseDir
+        }
+    }
+}

--- a/platform-catalog-plugin/src/main/java/io/micronaut/gradle/catalog/MicronautCatalogSettingsPlugin.java
+++ b/platform-catalog-plugin/src/main/java/io/micronaut/gradle/catalog/MicronautCatalogSettingsPlugin.java
@@ -31,6 +31,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Properties;
 
@@ -128,6 +129,9 @@ public abstract class MicronautCatalogSettingsPlugin implements Plugin<Settings>
     private Provider<String> readFromVersionCatalog(Settings settings) {
         ProviderFactory providers = settings.getProviders();
         var catalogFile = resolveCatalogInputFile(settings, "gradle/libs.versions.toml");
+        if (!catalogFile.exists()) {
+            return providers.provider(() -> null);
+        }
         return providers.fileContents(getDefaultGradleVersionCatalogFile().fileValue(catalogFile))
                 .getAsBytes()
                 .map(libsFile -> {
@@ -142,7 +146,7 @@ public abstract class MicronautCatalogSettingsPlugin implements Plugin<Settings>
                         }
                         return null;
                     } catch (IOException e) {
-                        return null;
+                        throw new UncheckedIOException("Failed to read Micronaut version catalog from " + catalogFile, e);
                     }
                 });
     }
@@ -156,7 +160,7 @@ public abstract class MicronautCatalogSettingsPlugin implements Plugin<Settings>
             properties.load(in);
             return properties.getProperty("micronautVersion");
         } catch (IOException e) {
-            return null;
+            throw new UncheckedIOException("Failed to read Micronaut version from " + gradlePropertiesFile, e);
         }
     }
 

--- a/platform-catalog-plugin/src/main/java/io/micronaut/gradle/catalog/MicronautCatalogSettingsPlugin.java
+++ b/platform-catalog-plugin/src/main/java/io/micronaut/gradle/catalog/MicronautCatalogSettingsPlugin.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
 
 public abstract class MicronautCatalogSettingsPlugin implements Plugin<Settings> {
     private static final Logger LOGGER = Logging.getLogger(MicronautCatalogSettingsPlugin.class);
@@ -62,7 +63,7 @@ public abstract class MicronautCatalogSettingsPlugin implements Plugin<Settings>
                             drm.versionCatalogs(vcs -> {
                                 vcs.create("mn", catalog -> catalog.from("io.micronaut.platform:micronaut-platform:" + micronautVersion));
                                 vcs.configureEach(catalog -> {
-                                    var catalogOverrideFile = new File(settings.getSettingsDir(), "gradle/" + catalog.getName() + "-" + OVERRIDE_VERSIONS_TOML_FILE);
+                                    var catalogOverrideFile = resolveCatalogInputFile(settings, "gradle/" + catalog.getName() + "-" + OVERRIDE_VERSIONS_TOML_FILE);
                                     if (catalogOverrideFile.exists()) {
                                         var parser = new LenientVersionCatalogParser();
                                         try (var in = new FileInputStream(catalogOverrideFile)) {
@@ -117,6 +118,7 @@ public abstract class MicronautCatalogSettingsPlugin implements Plugin<Settings>
 
     private Provider<String> createMicronautVersionProvider(Settings settings, ProviderFactory providers) {
         return providers.gradleProperty("micronautVersion")
+                .orElse(providers.provider(() -> readMicronautVersionFromGradleProperties(resolveCatalogInputFile(settings, "gradle.properties"))))
                 .orElse(readFromVersionCatalog(settings))
                 .orElse(providers.provider(() -> {
                     throw new IllegalStateException("Micronaut version must either be declared in `gradle.properties`, in `gradle/libs.versions.toml`");
@@ -125,7 +127,7 @@ public abstract class MicronautCatalogSettingsPlugin implements Plugin<Settings>
 
     private Provider<String> readFromVersionCatalog(Settings settings) {
         ProviderFactory providers = settings.getProviders();
-        var catalogFile = new File(settings.getSettingsDir(), "gradle/libs.versions.toml");
+        var catalogFile = resolveCatalogInputFile(settings, "gradle/libs.versions.toml");
         return providers.fileContents(getDefaultGradleVersionCatalogFile().fileValue(catalogFile))
                 .getAsBytes()
                 .map(libsFile -> {
@@ -143,5 +145,31 @@ public abstract class MicronautCatalogSettingsPlugin implements Plugin<Settings>
                         return null;
                     }
                 });
+    }
+
+    private static String readMicronautVersionFromGradleProperties(File gradlePropertiesFile) {
+        if (!gradlePropertiesFile.exists()) {
+            return null;
+        }
+        var properties = new Properties();
+        try (var in = new FileInputStream(gradlePropertiesFile)) {
+            properties.load(in);
+            return properties.getProperty("micronautVersion");
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private static File resolveCatalogInputFile(Settings settings, String relativePath) {
+        var settingsDir = settings.getSettingsDir();
+        var localFile = new File(settingsDir, relativePath);
+        if (localFile.exists() || !isBuildSrcSettings(settingsDir)) {
+            return localFile;
+        }
+        return new File(settingsDir.getParentFile(), relativePath);
+    }
+
+    private static boolean isBuildSrcSettings(File settingsDir) {
+        return "buildSrc".equals(settingsDir.getName()) && settingsDir.getParentFile() != null;
     }
 }

--- a/platform-catalog-plugin/src/test/groovy/io/micronaut/gradle/settings/CatalogPluginFunctionalTest.groovy
+++ b/platform-catalog-plugin/src/test/groovy/io/micronaut/gradle/settings/CatalogPluginFunctionalTest.groovy
@@ -60,6 +60,23 @@ micronaut = "$micronautVersion"
                 .resolve('build/classes/java/test/example/$ExampleTest$Definition.class').toFile().exists()
     }
 
+    def "fails with the expected message when no Micronaut version input exists"() {
+        given:
+        settingsFile << """
+            plugins {
+                id 'io.micronaut.platform.catalog'
+            }
+
+            rootProject.name = 'hello-world'
+            """
+
+        when:
+        def result = fails('help')
+
+        then:
+        result.output.contains('Micronaut version must either be declared in `gradle.properties`, in `gradle/libs.versions.toml`')
+    }
+
 
     private File writeExampleClass() {
         def javaFile = testProjectDir.newFile("src/test/java/example/ExampleTest.java")

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -317,6 +317,7 @@ This plugin will automatically import the Micronaut version catalog, which provi
 
 [IMPORTANT]
 This is a **settings** plugin, which means that it **must** be applied to your `settings.gradle(.kts)` file, not `build.gradle(.kts)`.
+The same settings plugin can also be applied from `buildSrc/settings.gradle(.kts)`; when you do, it reuses the owning build's `gradle.properties`, `gradle/libs.versions.toml`, and `gradle/mn-override.versions.toml` files if `buildSrc` does not provide local copies.
 
 Add the plugin to your `settings.gradle(.kts)` file:
 


### PR DESCRIPTION
## Summary

- add a narrow `buildSrc` fallback so the platform catalog plugin can reuse the owning build's root catalog inputs when `buildSrc` does not provide local copies
- keep resolution local-first and limited to the immediate parent of `buildSrc`, with focused functional coverage and a docs note

## Testing

- `./gradlew :micronaut-platform-catalog-plugin:test --tests 'io.micronaut.gradle.settings.CatalogPluginFunctionalTest'`
- `./gradlew :functional-tests:test --tests 'io.micronaut.gradle.settings.BuildSrcCatalogFunctionalTest'`

Closes #985

## Release Targeting

- QA-selected Micronaut organization project: `5.0.0-M3`
- Ambiguity note: the earliest Micronaut Platform release that consumes this plugin fix could still slip to a later `5.0` milestone or GA, but `5.0.0-M3` remains the best-fit open public project from QA intake.
- Live project-link result at PR creation time: GitHub org-project lookup/linking could not be applied from this run because the available token lacks the org-read scope needed to enumerate the Micronaut organization project surface.

---
###### ✨ This message was AI-generated using gpt-5.2
