### PR TITLE
Fix incremental Groovy compilation with Micronaut plugin

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -282,6 +282,11 @@ public class MicronautComponentPlugin implements Plugin<Project> {
     private void configureGroovy(Project project, TaskContainer tasks, MicronautExtension micronautExtension) {
         project.getPluginManager().withPlugin("groovy", plugin -> {
             tasks.withType(GroovyCompile.class).configureEach(groovyCompile -> groovyCompile.getGroovyOptions().setParameters(true));
+            project.afterEvaluate(unused -> tasks.withType(GroovyCompile.class).configureEach(groovyCompile -> {
+                if (groovyCompile.getOptions().isIncremental()) {
+                    groovyCompile.getOptions().setAnnotationProcessorPath(project.files());
+                }
+            }));
             var javaPluginExtension = PluginsHelper.javaPluginExtensionOf(project);
             configureDefaultGroovySourceSet(
                     project,

--- a/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMinimalLibraryPluginSpec.groovy
+++ b/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMinimalLibraryPluginSpec.groovy
@@ -475,6 +475,48 @@ class Foo {}
         ).exists()
     }
 
+    def "test groovy incremental compilation works with automatic dependencies"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            import org.gradle.api.tasks.compile.GroovyCompile
+
+            plugins {
+                id "io.micronaut.minimal.library"
+                id "groovy"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+            }
+
+            $repositoriesBlock
+
+            tasks.withType(GroovyCompile).configureEach {
+                options.incremental = true
+            }
+        """
+        testProjectDir.newFolder("src", "main", "groovy", "example")
+        def groovyFile = testProjectDir.newFile("src/main/groovy/example/Foo.groovy")
+        groovyFile.parentFile.mkdirs()
+        groovyFile << """
+package example;
+
+@jakarta.inject.Singleton
+class Foo {}
+"""
+
+        when:
+        def result = build('compileGroovy')
+
+        then:
+        result.task(":compileGroovy").outcome == TaskOutcome.SUCCESS
+        new File(
+                testProjectDir.getRoot(),
+                'build/classes/groovy/main/example/$Foo$Definition.class'
+        ).exists()
+    }
+
     def "test add openapi processing - groovy"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"


### PR DESCRIPTION
## Summary
- clear the Java annotation processor path on incremental `GroovyCompile` tasks so Gradle no longer rejects Micronaut Groovy builds
- keep Micronaut Groovy processing on the existing `micronaut-inject-groovy` path
- add a regression test that enables incremental Groovy compilation with automatic Micronaut dependencies

## Issue
Related to #906

## Project
- Linked Micronaut org project: `5.0.0 Release`
- Ambiguity note preserved from QA intake: `5.0.0-M3` is also open/public, but `5.0.0 Release` is the better fit for `master` on `5.0.0-SNAPSHOT`

---
###### ✨ This message was AI-generated using gpt-5.5
