### PR TITLE
Add Docker Buildx tasks for multi-platform images

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/DockerBuildx.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/DockerBuildx.java
@@ -3,7 +3,9 @@ package io.micronaut.gradle.docker;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
@@ -27,34 +29,68 @@ import java.util.List;
  * @since 5.0.0
  */
 public abstract class DockerBuildx extends DefaultTask {
+    private final ListProperty<String> platforms;
+    private final ListProperty<String> images;
+    private final Property<String> builder;
+    private final RegularFileProperty dockerFile;
+    private final DirectoryProperty inputDir;
+    private final Property<String> dockerExecutable;
 
     public DockerBuildx() {
         setGroup(BasePlugin.BUILD_GROUP);
-        getDockerExecutable().convention("docker");
-        getPlatforms().convention(List.of());
-        getImages().convention(List.of());
+        ObjectFactory objects = getProject().getObjects();
+        this.platforms = objects.listProperty(String.class).convention(List.of());
+        this.images = objects.listProperty(String.class).convention(List.of());
+        this.builder = objects.property(String.class);
+        this.dockerFile = objects.fileProperty();
+        this.inputDir = objects.directoryProperty();
+        this.dockerExecutable = objects.property(String.class).convention("docker");
     }
 
     @Input
-    public abstract ListProperty<String> getPlatforms();
+    public ListProperty<String> getPlatforms() {
+        return platforms;
+    }
+
+    public void setPlatforms(List<String> platforms) {
+        getPlatforms().set(requireNoNullValues("platforms", platforms));
+    }
 
     @Input
-    public abstract ListProperty<String> getImages();
+    public ListProperty<String> getImages() {
+        return images;
+    }
+
+    public void setImages(List<String> images) {
+        getImages().set(requireNoNullValues("images", images));
+    }
 
     @Input
     @Optional
-    public abstract Property<String> getBuilder();
+    public Property<String> getBuilder() {
+        return builder;
+    }
 
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
-    public abstract RegularFileProperty getDockerFile();
+    public RegularFileProperty getDockerFile() {
+        return dockerFile;
+    }
+
+    public void setDockerFile(RegularFile dockerFile) {
+        getDockerFile().set(dockerFile);
+    }
 
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
-    public abstract DirectoryProperty getInputDir();
+    public DirectoryProperty getInputDir() {
+        return inputDir;
+    }
 
     @Internal
-    public abstract Property<String> getDockerExecutable();
+    public Property<String> getDockerExecutable() {
+        return dockerExecutable;
+    }
 
     @Inject
     protected abstract ExecOperations getExecOperations();
@@ -91,12 +127,16 @@ public abstract class DockerBuildx extends DefaultTask {
     }
 
     private static void validate(String propertyName, List<String> values) {
-        List<String> trimmedValues = trimmedValuesOf(values);
-        if (trimmedValues.isEmpty()) {
+        if (values.isEmpty()) {
             throw new GradleException("Property '" + propertyName + "' must not be empty.");
         }
-        if (trimmedValues.size() != values.size()) {
-            throw new GradleException("Property '" + propertyName + "' must not contain blank values.");
+        for (String value : values) {
+            if (value == null) {
+                throw new GradleException("Property '" + propertyName + "' must not contain null values.");
+            }
+            if (value.trim().isEmpty()) {
+                throw new GradleException("Property '" + propertyName + "' must not contain blank values.");
+            }
         }
     }
 
@@ -105,5 +145,17 @@ public abstract class DockerBuildx extends DefaultTask {
             .map(String::trim)
             .filter(value -> !value.isEmpty())
             .toList();
+    }
+
+    private static List<String> requireNoNullValues(String propertyName, List<String> values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (value == null) {
+                throw new GradleException("Property '" + propertyName + "' must not contain null values.");
+            }
+        }
+        return values;
     }
 }

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/DockerBuildx.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/DockerBuildx.java
@@ -1,0 +1,109 @@
+package io.micronaut.gradle.docker;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.process.ExecOperations;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Executes {@code docker buildx build} for multi-platform image builds.
+ *
+ * @since 5.0.0
+ */
+public abstract class DockerBuildx extends DefaultTask {
+
+    public DockerBuildx() {
+        setGroup(BasePlugin.BUILD_GROUP);
+        getDockerExecutable().convention("docker");
+        getPlatforms().convention(List.of());
+        getImages().convention(List.of());
+    }
+
+    @Input
+    public abstract ListProperty<String> getPlatforms();
+
+    @Input
+    public abstract ListProperty<String> getImages();
+
+    @Input
+    @Optional
+    public abstract Property<String> getBuilder();
+
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract RegularFileProperty getDockerFile();
+
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract DirectoryProperty getInputDir();
+
+    @Internal
+    public abstract Property<String> getDockerExecutable();
+
+    @Inject
+    protected abstract ExecOperations getExecOperations();
+
+    @TaskAction
+    void buildImage() {
+        validate("platforms", getPlatforms().get());
+        validate("images", getImages().get());
+        getExecOperations().exec(spec -> {
+            spec.executable(getDockerExecutable().get());
+            spec.args(buildCommandLine());
+        });
+    }
+
+    List<String> buildCommandLine() {
+        var args = new ArrayList<String>();
+        args.add("buildx");
+        args.add("build");
+        if (getBuilder().isPresent() && !getBuilder().get().trim().isEmpty()) {
+            args.add("--builder");
+            args.add(getBuilder().get().trim());
+        }
+        args.add("--platform");
+        args.add(String.join(",", trimmedValuesOf(getPlatforms().get())));
+        for (String image : trimmedValuesOf(getImages().get())) {
+            args.add("--tag");
+            args.add(image);
+        }
+        args.add("--push");
+        args.add("--file");
+        args.add(getDockerFile().get().getAsFile().getAbsolutePath());
+        args.add(getInputDir().get().getAsFile().getAbsolutePath());
+        return args;
+    }
+
+    private static void validate(String propertyName, List<String> values) {
+        List<String> trimmedValues = trimmedValuesOf(values);
+        if (trimmedValues.isEmpty()) {
+            throw new GradleException("Property '" + propertyName + "' must not be empty.");
+        }
+        if (trimmedValues.size() != values.size()) {
+            throw new GradleException("Property '" + propertyName + "' must not contain blank values.");
+        }
+    }
+
+    private static List<String> trimmedValuesOf(List<String> values) {
+        return values.stream()
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .toList();
+    }
+}

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
@@ -178,6 +178,10 @@ public class MicronautDockerPlugin implements Plugin<Project> {
                 buildStrategy.ifPresent(bs -> it.getBuildStrategy().set(buildStrategy.get()));
                 it.setupNativeImageTaskPostEvaluate();
             }));
+            withBuildStrategy(project, buildStrategy -> tasks.named(adaptTaskName("dockerfileBuildxNative", imageName), NativeImageDockerfile.class).configure(it -> {
+                buildStrategy.ifPresent(bs -> it.getBuildStrategy().set(buildStrategy.get()));
+                it.setupNativeImageTaskPostEvaluate();
+            }));
         });
         withBuildStrategy(project, buildStrategy -> dockerFileTask.ifPresent(t -> t.configure(it -> {
             buildStrategy.ifPresent(bs -> it.getBuildStrategy().set(buildStrategy.get()));
@@ -269,6 +273,12 @@ public class MicronautDockerPlugin implements Plugin<Project> {
             task.getImages().set(Collections.singletonList(project.getName()));
             task.getInputDir().set(dockerFileTask.flatMap(Dockerfile::getDestDir));
         });
+        tasks.register(adaptTaskName("dockerBuildx", imageName), DockerBuildx.class, task -> {
+            task.dependsOn(buildLayersTask);
+            task.setDescription("Builds and pushes a multi-platform Docker image using Docker Buildx (image " + imageName + ")");
+            task.getDockerFile().convention(dockerFileTask.flatMap(Dockerfile::getDestFile));
+            task.getInputDir().set(dockerFileTask.flatMap(Dockerfile::getDestDir));
+        });
 
         TaskProvider<DockerPushImage> pushDockerImage = tasks.register(adaptTaskName("dockerPush", imageName), DockerPushImage.class, task -> {
             task.dependsOn(dockerBuildTask);
@@ -311,6 +321,31 @@ public class MicronautDockerPlugin implements Plugin<Project> {
                 task.getLayers().convention(buildLayersTask.flatMap(BuildLayersTask::getLayers));
             });
         }
+        TaskProvider<NativeImageDockerfile> buildxDockerFileTask;
+        String buildxDockerfileNativeTaskName = adaptTaskName("dockerfileBuildxNative", imageName);
+        Provider<RegularFile> buildxTargetDockerFile = project.getLayout().getBuildDirectory().file("docker/native-" + imageName + "/DockerfileBuildxNative");
+        if (f.exists()) {
+            buildxDockerFileTask = tasks.register(buildxDockerfileNativeTaskName, NativeImageDockerfile.class, task -> {
+                task.setGroup(BasePlugin.BUILD_GROUP);
+                task.setDescription("Builds a Native Docker File for multi-platform Buildx image " + imageName);
+                try {
+                    task.instructionsFromTemplate(f);
+                } catch (IOException e) {
+                    throw new GradleException("Unable to configure docker task for image " + imageName, e);
+                }
+                task.getDestFile().set(buildxTargetDockerFile);
+                task.getLayers().convention(buildLayersTask.flatMap(BuildLayersTask::getLayers));
+                task.getUseBuildxTargetArch().set(true);
+            });
+        } else {
+            buildxDockerFileTask = tasks.register(buildxDockerfileNativeTaskName, NativeImageDockerfile.class, task -> {
+                task.setGroup(BasePlugin.BUILD_GROUP);
+                task.setDescription("Builds a Native Docker File for multi-platform Buildx image " + imageName);
+                task.getDestFile().set(buildxTargetDockerFile);
+                task.getLayers().convention(buildLayersTask.flatMap(BuildLayersTask::getLayers));
+                task.getUseBuildxTargetArch().set(true);
+            });
+        }
         TaskProvider<PrepareDockerContext> prepareContext = tasks.register(adaptTaskName("dockerPrepareContext", imageName), PrepareDockerContext.class, context -> {
             // Because docker requires all files to be found in the build context we need to
             // copy the configuration file directories into the build context
@@ -329,6 +364,15 @@ public class MicronautDockerPlugin implements Plugin<Project> {
             task.getImages().set(Collections.singletonList(project.getName()));
             task.dependsOn(buildLayersTask);
             task.getInputDir().set(dockerFileTask.flatMap(Dockerfile::getDestDir));
+        });
+        tasks.register(adaptTaskName("dockerBuildxNative", imageName), DockerBuildx.class, task -> {
+            task.setDescription("Builds and pushes a multi-platform native Docker image using Docker Buildx (image " + imageName + ")");
+            task.getInputs().files(prepareContext)
+                .withPropertyName("preparedDockerContext")
+                .withPathSensitivity(PathSensitivity.RELATIVE);
+            task.dependsOn(buildLayersTask);
+            task.getDockerFile().convention(buildxDockerFileTask.flatMap(Dockerfile::getDestFile));
+            task.getInputDir().set(buildxDockerFileTask.flatMap(Dockerfile::getDestDir));
         });
 
         TaskProvider<DockerPushImage> pushDockerImage = tasks.register(adaptTaskName("dockerPushNative", imageName), DockerPushImage.class);

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -189,6 +189,14 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
     @Optional
     public abstract Property<Boolean> getUseCopyLink();
 
+    /**
+     * If true, BuildKit target architecture metadata is used to resolve the GraalVM distribution.
+     * @return whether to use Buildx target architecture mapping
+     */
+    @Input
+    @Optional
+    public abstract Property<Boolean> getUseBuildxTargetArch();
+
     public NativeImageDockerfile() {
         Project project = getProject();
         JavaPluginExtension javaExtension = PluginsHelper.javaPluginExtensionOf(project);
@@ -209,15 +217,10 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
         getGraalArch().convention(ARM_ARCH.equals(osArch) ? ARM_ARCH : X86_64_ARCH);
         getTargetWorkingDirectory().convention(DEFAULT_WORKING_DIR);
         getExposedPorts().convention(Collections.singletonList(8080));
+        getUseBuildxTargetArch().convention(false);
         getGraalImage().convention(getJdkVersion().map(NativeImageDockerfile::toGraalVMBaseImageName));
         getGraalReleasesUrl().convention(GRAALVM_DOWNLOAD_BASE_URL);
-        var distributionPath = getJdkVersion().zip(getGraalArch(), (jdk, arch) -> {
-            if ("17".equals(jdk)) {
-                getLogger().warn("You are using the latest release of GraalVM available under the GraalVM Free Terms and Conditions (GFTC) licence (" + GRAALVM_FOR_JDK17 + "). Consider upgrading to Java 21.");
-                return GRAALVM_DISTRIBUTION_PATH.formatted(jdk, "archive", GRAALVM_FOR_JDK17, arch);
-            }
-            return GRAALVM_DISTRIBUTION_PATH.formatted(jdk, "latest", jdk, arch);
-        });
+        var distributionPath = getJdkVersion().zip(getGraalArch(), this::distributionPathFor);
         getGraalVMDistributionUrl().convention(
             getGraalReleasesUrl().zip(distributionPath, (base, path) -> base + path)
         );
@@ -486,10 +489,18 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
             environmentVariable("LANG", "en_US.UTF-8");
             runCommand("dnf update -y && dnf install -y gcc glibc-devel zlib-devel libstdc++-static tar && dnf clean all && rm -rf /var/cache/dnf");
             String jdkVersion = getJdkVersion().get();
-            String graalArch = getGraalArch().get();
-            // https://download.oracle.com/graalvm/17/latest/graalvm-jdk-17_linux-aarch64_bin.tar.gz
-            String fileName = "graalvm-jdk-" + jdkVersion + "_linux-" + graalArch + "_bin.tar.gz";
-            String graalvmDistributionUrl = getGraalVMDistributionUrl().get();
+            String fileName;
+            String graalvmDistributionUrl;
+            if (getUseBuildxTargetArch().get()) {
+                arg("TARGETARCH");
+                String graalArch = "$(" + graalArchResolutionCommand() + ")";
+                fileName = "graalvm-jdk-" + jdkVersion + "_linux-" + graalArch + "_bin.tar.gz";
+                graalvmDistributionUrl = getGraalReleasesUrl().get() + distributionPathFor(jdkVersion, graalArch);
+            } else {
+                String graalArch = getGraalArch().get();
+                fileName = "graalvm-jdk-" + jdkVersion + "_linux-" + graalArch + "_bin.tar.gz";
+                graalvmDistributionUrl = getGraalVMDistributionUrl().get();
+            }
             runCommand("curl -4 -L " + graalvmDistributionUrl + " -o /tmp/" + fileName);
             runCommand("tar -zxf /tmp/" + fileName + " -C /tmp && ls -d /tmp/graalvm-jdk-"+ jdkVersion + "* | grep -v \"tar.gz\" | xargs -I_ mv _ /usr/lib/graalvm");
             runCommand("rm -rf /tmp/*");
@@ -667,6 +678,18 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
             return Integer.parseInt(version.substring(0, version.indexOf('.')));
         }
         return Integer.parseInt(version);
+    }
+
+    private String distributionPathFor(String jdkVersion, String graalArch) {
+        if ("17".equals(jdkVersion)) {
+            getLogger().warn("You are using the latest release of GraalVM available under the GraalVM Free Terms and Conditions (GFTC) licence (" + GRAALVM_FOR_JDK17 + "). Consider upgrading to Java 21.");
+            return GRAALVM_DISTRIBUTION_PATH.formatted(jdkVersion, "archive", GRAALVM_FOR_JDK17, graalArch);
+        }
+        return GRAALVM_DISTRIBUTION_PATH.formatted(jdkVersion, "latest", jdkVersion, graalArch);
+    }
+
+    private static String graalArchResolutionCommand() {
+        return "case \"${TARGETARCH}\" in amd64) printf x64 ;; arm64) printf aarch64 ;; *) printf '%s' \"${TARGETARCH}\" ;; esac";
     }
 
     /**

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
@@ -496,6 +496,79 @@ class Application {
         useCopyLink << [false, true]
     }
 
+    @IgnoreIf({ os.windows })
+    def "can build a docker buildx command with generated dockerfile and context"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """import io.micronaut.gradle.docker.DockerBuildx
+
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.docker"
+            }
+
+            version = "0.1"
+
+            micronaut {
+                version "$micronautVersion"
+            }
+
+            $repositoriesBlock
+
+            application { mainClass = "example.Application" }
+
+            tasks.named("dockerBuildx", DockerBuildx) {
+                dockerExecutable = file("fake-docker.sh").absolutePath
+                platforms = ["linux/amd64", "linux/arm64"]
+                images = ["example.com/demo/app:0.1", "example.com/demo/app:latest"]
+                builder = "multiarch-builder"
+            }
+        """
+        testProjectDir.newFolder("src", "main", "java", "example")
+        def javaFile = testProjectDir.newFile("src/main/java/example/Application.java")
+        javaFile.parentFile.mkdirs()
+        javaFile << """
+package example;
+
+class Application {
+    public static void main(String... args) {
+    }
+}
+"""
+        def fakeDocker = file("fake-docker.sh")
+        fakeDocker.text = """#!/bin/sh
+set -eu
+mkdir -p "\$PWD/build"
+printf '%s\\n' "\$@" > "\$PWD/build/buildx-args.txt"
+"""
+        fakeDocker.setExecutable(true)
+
+        when:
+        def result = build('dockerBuildx')
+
+        then:
+        result.task(":dockerBuildx").outcome == TaskOutcome.SUCCESS
+
+        and:
+        file("build/docker/main/Dockerfile").exists()
+        file("build/buildx-args.txt").readLines() == [
+                "buildx",
+                "build",
+                "--builder",
+                "multiarch-builder",
+                "--platform",
+                "linux/amd64,linux/arm64",
+                "--tag",
+                "example.com/demo/app:0.1",
+                "--tag",
+                "example.com/demo/app:latest",
+                "--push",
+                "--file",
+                file("build/docker/main/Dockerfile").absolutePath,
+                file("build/docker/main").absolutePath
+        ]
+    }
+
     private static String getSnapshotMetadata() {
         DockerBuildTaskSpec.getResourceAsStream("/dummy-metadata.xml").text
     }

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
@@ -569,6 +569,94 @@ printf '%s\\n' "\$@" > "\$PWD/build/buildx-args.txt"
         ]
     }
 
+    def "docker buildx fails with a clear error when platforms contain null"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """import io.micronaut.gradle.docker.DockerBuildx
+
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.docker"
+            }
+
+            version = "0.1"
+
+            micronaut {
+                version "$micronautVersion"
+            }
+
+            $repositoriesBlock
+
+            application { mainClass = "example.Application" }
+
+            tasks.named("dockerBuildx", DockerBuildx) {
+                platforms = ["linux/amd64", null]
+                images = ["example.com/demo/app:0.1"]
+            }
+        """
+        testProjectDir.newFolder("src", "main", "java", "example")
+        def javaFile = testProjectDir.newFile("src/main/java/example/Application.java")
+        javaFile.parentFile.mkdirs()
+        javaFile << """
+package example;
+
+class Application {
+    public static void main(String... args) {
+    }
+}
+"""
+
+        when:
+        def result = fails('dockerBuildx')
+
+        then:
+        result.output.contains("Property 'platforms' must not contain null values.")
+    }
+
+    def "docker buildx fails with a clear error when images contain null"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """import io.micronaut.gradle.docker.DockerBuildx
+
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.docker"
+            }
+
+            version = "0.1"
+
+            micronaut {
+                version "$micronautVersion"
+            }
+
+            $repositoriesBlock
+
+            application { mainClass = "example.Application" }
+
+            tasks.named("dockerBuildx", DockerBuildx) {
+                platforms = ["linux/amd64", "linux/arm64"]
+                images = ["example.com/demo/app:0.1", null]
+            }
+        """
+        testProjectDir.newFolder("src", "main", "java", "example")
+        def javaFile = testProjectDir.newFile("src/main/java/example/Application.java")
+        javaFile.parentFile.mkdirs()
+        javaFile << """
+package example;
+
+class Application {
+    public static void main(String... args) {
+    }
+}
+"""
+
+        when:
+        def result = fails('dockerBuildx')
+
+        then:
+        result.output.contains("Property 'images' must not contain null values.")
+    }
+
     private static String getSnapshotMetadata() {
         DockerBuildTaskSpec.getResourceAsStream("/dummy-metadata.xml").text
     }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/lambda/LambdaNativeImageSpec.groovy
@@ -410,4 +410,88 @@ class LambdaNativeImageSpec extends AbstractFunctionalTest {
         'API_GATEWAY_V2' | 'io.micronaut.function.aws.runtime.APIGatewayV2HTTPEventMicronautLambdaRuntime'
         'ALB'            | 'io.micronaut.function.aws.runtime.ApplicationLoadBalancerMicronautLambdaRuntime'
     }
+
+    void 'docker buildx native task uses target architecture mapping for lambda images'() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """import io.micronaut.gradle.docker.DockerBuildx
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.graalvm"
+                id "io.micronaut.docker"
+            }
+
+            version = "0.1"
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "lambda_provided"
+            }
+
+            $repositoriesBlock
+
+            application {
+                mainClass.set("com.example.Application")
+            }
+
+            java {
+                sourceCompatibility = JavaVersion.toVersion('25')
+                targetCompatibility = JavaVersion.toVersion('25')
+            }
+
+            tasks.named("dockerBuildxNative", DockerBuildx) {
+                dockerExecutable = file("fake-docker.sh").absolutePath
+                platforms = ["linux/amd64", "linux/arm64"]
+                images = ["example.com/demo/native:0.1"]
+                builder = "multiarch-builder"
+            }
+        """
+        testProjectDir.newFolder("src", "main", "java", "com", "example")
+        def javaFile = testProjectDir.newFile("src/main/java/com/example/Application.java")
+        javaFile.parentFile.mkdirs()
+        javaFile << """
+package com.example;
+
+class Application {
+    public static void main(String... args) {
+    }
+}
+"""
+        def fakeDocker = file("fake-docker.sh")
+        fakeDocker.text = """#!/bin/sh
+set -eu
+mkdir -p "\$PWD/build"
+printf '%s\\n' "\$@" > "\$PWD/build/buildx-native-args.txt"
+"""
+        fakeDocker.setExecutable(true)
+
+        when:
+        def result = build('dockerBuildxNative')
+
+        then:
+        result.task(':dockerBuildxNative').outcome == TaskOutcome.SUCCESS
+
+        and:
+        def dockerfileBuildxNative = file('build/docker/native-main/DockerfileBuildxNative').text
+        dockerfileBuildxNative.contains('ARG TARGETARCH')
+        dockerfileBuildxNative.contains('amd64) printf x64')
+        dockerfileBuildxNative.contains('arm64) printf aarch64')
+        dockerfileBuildxNative.contains('graalvm-jdk-25_linux-$(case "${TARGETARCH}" in amd64) printf x64 ;; arm64) printf aarch64 ;; *) printf \'%s\' "${TARGETARCH}" ;; esac)_bin.tar.gz')
+
+        and:
+        file("build/buildx-native-args.txt").readLines() == [
+                "buildx",
+                "build",
+                "--builder",
+                "multiarch-builder",
+                "--platform",
+                "linux/amd64,linux/arm64",
+                "--tag",
+                "example.com/demo/native:0.1",
+                "--push",
+                "--file",
+                file("build/docker/native-main/DockerfileBuildxNative").absolutePath,
+                file("build/docker/native-main").absolutePath
+        ]
+    }
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -633,8 +633,10 @@ The following additional tasks are provided by this plugin:
 * `buildLayers` - Builds application layers for use in a Docker container
 * `dockerfile` - Builds a Docker File for a Micronaut application
 * `dockerBuild` - Builds a Docker Image using the https://github.com/bmuschko/gradle-docker-plugin[Docker Gradle plugin]
+* `dockerBuildx` - Builds and pushes a multi-platform Docker image using Docker Buildx
 * `dockerfileNative` - Builds a Docker File for GraalVM Native Image
 * `dockerBuildNative` - Builds a Native Docker Image using GraalVM Native Image
+* `dockerBuildxNative` - Builds and pushes a multi-platform Native Docker image using Docker Buildx
 * `dockerBuildCrac` - Builds a docker Image containing a CRaC enabled JDK and a pre-warmed, checkpointed application.
 * `dockerFileCrac` - Builds a Docker File for a CRaC checkpointed image.
 * `nativeCompile` - Builds a GraalVM Native Executable
@@ -921,6 +923,13 @@ To build a regular Java application into a Docker container that is ready to be 
 $ ./gradlew dockerBuild
 ----
 
+For multi-platform images, use Docker Buildx instead of `dockerBuild`:
+
+[source, bash]
+----
+$ ./gradlew dockerBuildx
+----
+
 The default uses an `{default-docker-image}` base image, however you can easily switch the base image to use with the `baseImage` property of the `dockerfile` task:
 
 [source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
@@ -944,6 +953,13 @@ To build the application into a Native Executable you can run:
 [source,bash]
 ----
 $ ./gradlew dockerBuildNative
+----
+
+For multi-platform native images, use Docker Buildx instead of `dockerBuildNative`:
+
+[source, bash]
+----
+$ ./gradlew dockerBuildxNative
 ----
 
 Note that for this to work you must build the application with the same GraalVM SDK as used to build the executable.
@@ -997,6 +1013,54 @@ tasks.named<DockerBuildImage>("dockerBuildCrac") {
 ----
 
 Notice that you can supply two different image names to push to for the JVM version and the native version of the application.
+
+==== Multi-platform images with Docker Buildx
+
+The `dockerBuildx` and `dockerBuildxNative` tasks provide first-class multi-platform Docker image support for Micronaut applications.
+They reuse the same generated build contexts as `dockerBuild` and `dockerBuildNative`, but invoke `docker buildx build` and always publish the result with `--push`.
+
+`dockerBuildx` and `dockerBuildxNative` require:
+
+* Docker Buildx support in your Docker installation
+* a configured builder when your environment does not use the default builder
+* explicit `platforms` and `images` configuration, because multi-platform builds are intended for registry publication
+
+Existing `dockerBuild` and `dockerBuildNative` tasks remain the single-platform default workflow.
+CRaC multi-platform images are not part of this feature and there is no `dockerBuildxCrac` task.
+
+For example, the following configuration publishes both JVM and native images for `linux/amd64` and `linux/arm64`:
+
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+tasks.named("dockerBuildx") {
+    platforms = ["linux/amd64", "linux/arm64"]
+    images = ["registry.example.com/apps/my-app:$project.version"]
+    builder = "container-builder"
+}
+
+tasks.named("dockerBuildxNative") {
+    platforms = ["linux/amd64", "linux/arm64"]
+    images = ["registry.example.com/apps/my-app-native:$project.version"]
+    builder = "container-builder"
+}
+----
+
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+tasks.named<io.micronaut.gradle.docker.DockerBuildx>("dockerBuildx") {
+    platforms.set(listOf("linux/amd64", "linux/arm64"))
+    images.set(listOf("registry.example.com/apps/my-app:$project.version"))
+    builder.set("container-builder")
+}
+
+tasks.named<io.micronaut.gradle.docker.DockerBuildx>("dockerBuildxNative") {
+    platforms.set(listOf("linux/amd64", "linux/arm64"))
+    images.set(listOf("registry.example.com/apps/my-app-native:$project.version"))
+    builder.set("container-builder")
+}
+----
+
+For AWS Lambda custom-runtime native images, `dockerBuildxNative` maps Docker Buildx target architectures to the correct GraalVM download automatically.
 
 ==== Customized docker files
 


### PR DESCRIPTION
## Summary
- add additive `dockerBuildx` and `dockerBuildxNative` tasks for multi-platform image publishing
- keep existing `dockerBuild` and `dockerBuildNative` behavior unchanged while adding Buildx-specific native `TARGETARCH` mapping
- document the Buildx workflow and cover it with focused JVM and native tests

Closes #220.

Micronaut org project: `5.0.0-M3`.
Ambiguity note: `5.0.0 Release` remains the broader umbrella project for the same line.

## Verification
- `./gradlew :micronaut-docker-plugin:test --tests 'io.micronaut.gradle.DockerBuildTaskSpec.can build a docker buildx command with generated dockerfile and context'`
- `GRAALVM_HOME=<temporary fake GraalVM home> ./gradlew :functional-tests:test --tests 'io.micronaut.gradle.lambda.LambdaNativeImageSpec.docker buildx native task uses target architecture mapping for lambda images'`
- `./gradlew docs`
- `./gradlew check`

---
###### ✨ This message was AI-generated using gpt-5.4
