### PR TITLE
Allow multiple test runtimes [DEV-84]

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -140,15 +140,17 @@ public class MicronautComponentPlugin implements Plugin<Project> {
     private void configureTesting(Project project, MicronautExtension micronautExtension, TaskProvider<ApplicationClasspathInspector> inspectRuntimeClasspath) {
         project.getTasks().withType(Test.class).configureEach(t -> {
             t.dependsOn(inspectRuntimeClasspath);
-            if (micronautExtension.getTestRuntime().get().isUsingJunitPlatform()) {
-                t.useJUnitPlatform();
-            }
         });
         project.afterEvaluate(p -> {
             DependencyHandler dependencyHandler = project.getDependencies();
-            MicronautTestRuntime testRuntime = micronautExtension.getTestRuntime().get();
+            List<MicronautTestRuntime> testRuntimes = micronautExtension.resolveTestRuntimes();
+            MicronautTestRuntime.validateSelection(testRuntimes);
 
-            testRuntime.getDependencies().forEach((scope, dependencies) -> {
+            if (MicronautTestRuntime.isUsingJunitPlatform(testRuntimes)) {
+                project.getTasks().withType(Test.class).configureEach(Test::useJUnitPlatform);
+            }
+
+            MicronautTestRuntime.collectDependencies(testRuntimes).forEach((scope, dependencies) -> {
                 for (String dependency : dependencies) {
                     dependencyHandler.add(scope, dependency);
                 }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
@@ -3,10 +3,14 @@ package io.micronaut.gradle;
 import org.gradle.api.Action;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -25,6 +29,7 @@ public abstract class MicronautExtension implements ExtensionAware {
     private final Property<Boolean> enableNativeImage;
     private final Property<MicronautRuntime> runtime;
     private final Property<MicronautTestRuntime> testRuntime;
+    private final ListProperty<MicronautTestRuntime> testRuntimes;
 
     /**
      * If set to false, then the Micronaut Gradle plugins will not automatically
@@ -55,6 +60,8 @@ public abstract class MicronautExtension implements ExtensionAware {
                                     .convention(MicronautRuntime.NONE);
         this.testRuntime = objectFactory.property(MicronautTestRuntime.class)
                                         .convention(MicronautTestRuntime.NONE);
+        this.testRuntimes = objectFactory.listProperty(MicronautTestRuntime.class)
+                                         .convention(Collections.emptyList());
         getImportMicronautPlatform().convention(true);
     }
 
@@ -63,6 +70,13 @@ public abstract class MicronautExtension implements ExtensionAware {
      */
     public Property<MicronautTestRuntime> getTestRuntime() {
         return testRuntime;
+    }
+
+    /**
+     * @return The test runtimes to use in addition to the legacy single-value path.
+     */
+    public ListProperty<MicronautTestRuntime> getTestRuntimes() {
+        return testRuntimes;
     }
 
     /**
@@ -152,6 +166,61 @@ public abstract class MicronautExtension implements ExtensionAware {
             this.testRuntime.set(testRuntime);
         }
         return this;
+    }
+
+    /**
+     * Configures multiple test runtimes to use.
+     *
+     * @param runtimes The micronaut test runtime types
+     * @return This extension
+     * @since 5.0.0
+     */
+    public MicronautExtension testRuntimes(MicronautTestRuntime... runtimes) {
+        if (runtimes != null) {
+            for (MicronautTestRuntime runtime : runtimes) {
+                if (runtime != null) {
+                    this.testRuntimes.add(runtime);
+                }
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Configures multiple test runtimes to use.
+     *
+     * @param runtimes The micronaut test runtime types
+     * @return This extension
+     * @since 5.0.0
+     */
+    public MicronautExtension testRuntimes(String... runtimes) {
+        if (runtimes != null) {
+            for (String runtime : runtimes) {
+                if (runtime != null) {
+                    this.testRuntimes.add(MicronautTestRuntime.parse(runtime));
+                }
+            }
+        }
+        return this;
+    }
+
+    List<MicronautTestRuntime> resolveTestRuntimes() {
+        List<MicronautTestRuntime> configured = new ArrayList<>();
+        configured.add(testRuntime.get());
+        configured.addAll(testRuntimes.getOrElse(Collections.emptyList()));
+
+        boolean hasSelectedRuntime = configured.stream().anyMatch(runtime -> runtime != null && runtime != MicronautTestRuntime.NONE);
+        var resolved = new LinkedHashSet<MicronautTestRuntime>();
+        for (MicronautTestRuntime runtime : configured) {
+            if (runtime == null) {
+                continue;
+            }
+            if (runtime == MicronautTestRuntime.NONE && hasSelectedRuntime) {
+                continue;
+            }
+            resolved.add(runtime);
+        }
+        return List.copyOf(resolved);
     }
 
     /**

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
@@ -3,6 +3,8 @@ package io.micronaut.gradle;
 import org.gradle.api.plugins.JavaPlugin;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -20,7 +22,7 @@ public enum MicronautTestRuntime {
     JUNIT_5(MicronautExtension.mapOf(
             JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, List.of("org.junit.jupiter:junit-jupiter-api", "io.micronaut.test:micronaut-test-junit5"),
             JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME, List.of("org.junit.jupiter:junit-jupiter-engine", "org.junit.platform:junit-platform-launcher")
-    ), true),
+    ), true, "junit"),
     /**
      * Spock 2.
      */
@@ -34,7 +36,7 @@ public enum MicronautTestRuntime {
                     "org.apache.groovy:groovy",
                     "org.junit.platform:junit-platform-launcher"
             )
-    ), true),
+    ), true, "spock"),
     /**
      * Kotest 4.
      */
@@ -49,7 +51,7 @@ public enum MicronautTestRuntime {
             ),
             JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME,
             Collections.singletonList("io.kotest:kotest-runner-junit5-jvm")
-    ), true),
+    ), true, "kotest"),
 
     /**
      * Kotest 5.
@@ -65,7 +67,7 @@ public enum MicronautTestRuntime {
             ),
             JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME,
             Collections.singletonList("io.kotest:kotest-runner-junit5-jvm")
-    ), true),
+    ), true, "kotest"),
     /**
      * No test runtime.
      */
@@ -73,15 +75,18 @@ public enum MicronautTestRuntime {
 
     private final Map<String, List<String>> implementation;
     private final boolean usesJunitPlatform;
+    private final String family;
 
     MicronautTestRuntime() {
         this.implementation = Collections.singletonMap(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, Collections.emptyList());
         this.usesJunitPlatform = false;
+        this.family = null;
     }
 
-    MicronautTestRuntime(Map<String, List<String>> implementation, boolean usesJunitPlatform) {
+    MicronautTestRuntime(Map<String, List<String>> implementation, boolean usesJunitPlatform, String family) {
         this.implementation = implementation;
         this.usesJunitPlatform = usesJunitPlatform;
+        this.family = family;
     }
 
     public Map<String, List<String>> getDependencies() {
@@ -111,5 +116,36 @@ public enum MicronautTestRuntime {
 
     public boolean isUsingJunitPlatform() {
         return usesJunitPlatform;
+    }
+
+    public static boolean isUsingJunitPlatform(List<MicronautTestRuntime> runtimes) {
+        return runtimes.stream().anyMatch(MicronautTestRuntime::isUsingJunitPlatform);
+    }
+
+    public static Map<String, List<String>> collectDependencies(List<MicronautTestRuntime> runtimes) {
+        Map<String, LinkedHashSet<String>> collected = new LinkedHashMap<>();
+        for (MicronautTestRuntime runtime : runtimes) {
+            runtime.getDependencies().forEach((scope, dependencies) ->
+                collected.computeIfAbsent(scope, ignored -> new LinkedHashSet<>()).addAll(dependencies)
+            );
+        }
+        Map<String, List<String>> answer = new LinkedHashMap<>();
+        collected.forEach((scope, dependencies) -> answer.put(scope, List.copyOf(dependencies)));
+        return answer;
+    }
+
+    public static void validateSelection(List<MicronautTestRuntime> runtimes) {
+        Map<String, LinkedHashSet<MicronautTestRuntime>> families = new LinkedHashMap<>();
+        for (MicronautTestRuntime runtime : runtimes) {
+            if (runtime.family == null) {
+                continue;
+            }
+            families.computeIfAbsent(runtime.family, ignored -> new LinkedHashSet<>()).add(runtime);
+        }
+        families.forEach((family, selectedRuntimes) -> {
+            if (selectedRuntimes.size() > 1) {
+                throw new IllegalArgumentException("Incompatible Micronaut test runtimes selected for family '" + family + "': " + selectedRuntimes);
+            }
+        });
     }
 }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautTestRuntime.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * An enum with the different supported test runtimes.
@@ -144,7 +145,8 @@ public enum MicronautTestRuntime {
         }
         families.forEach((family, selectedRuntimes) -> {
             if (selectedRuntimes.size() > 1) {
-                throw new IllegalArgumentException("Incompatible Micronaut test runtimes selected for family '" + family + "': " + selectedRuntimes);
+                String renderedRuntimes = selectedRuntimes.stream().map(Enum::name).collect(Collectors.joining(", "));
+                throw new IllegalArgumentException("Incompatible Micronaut test runtimes selected for family '" + family + "': " + renderedRuntimes + ". Select only one runtime from this family.");
             }
         });
     }

--- a/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMixedTestRuntimeSpec.groovy
+++ b/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMixedTestRuntimeSpec.groovy
@@ -86,7 +86,11 @@ class MicronautMixedTestRuntimeSpec extends AbstractGradleBuildSpec {
             ${getRepositoriesBlock('kotlin')}
         """
 
-        expect:
+        when:
+        def result = build('dependencies', '--configuration', 'testRuntimeClasspath')
+
+        then:
+        result.task(":dependencies").outcome == TaskOutcome.SUCCESS
         containsDependency("io.micronaut.test:micronaut-test-junit5", "testImplementation")
         containsDependency("org.spockframework:spock-core", "testImplementation")
         containsDependency("org.junit.jupiter:junit-jupiter-engine", "testRuntimeOnly")

--- a/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMixedTestRuntimeSpec.groovy
+++ b/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMixedTestRuntimeSpec.groovy
@@ -1,0 +1,161 @@
+package io.micronaut.gradle
+
+import org.gradle.testkit.runner.TaskOutcome
+
+class MicronautMixedTestRuntimeSpec extends AbstractGradleBuildSpec {
+
+    def "legacy single junit 5 runtime still works"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.library"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                testRuntime "junit5"
+            }
+
+            $repositoriesBlock
+        """
+        writeSupportBean()
+        writeJunitTest()
+
+        when:
+        def result = build('test')
+
+        then:
+        result.task(":test").outcome == TaskOutcome.SUCCESS
+        containsDependency("io.micronaut.test:micronaut-test-junit5", "testImplementation")
+        containsDependency("org.junit.jupiter:junit-jupiter-engine", "testRuntimeOnly")
+    }
+
+    def "test mixed junit 5 and spock test runtimes"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.library"
+                id "groovy"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                testRuntime "junit5"
+                testRuntimes "spock2"
+            }
+
+            $repositoriesBlock
+        """
+        writeSupportBean()
+        writeJunitTest()
+        writeSpockTest()
+
+        when:
+        def result = build('test')
+
+        then:
+        result.task(":test").outcome == TaskOutcome.SUCCESS
+        file("build/test-results/test/TEST-example.ExampleJUnitTest.xml").exists()
+        file("build/test-results/test/TEST-example.ExampleSpockSpec.xml").exists()
+        containsDependency("io.micronaut.test:micronaut-test-junit5", "testImplementation")
+        containsDependency("org.junit.jupiter:junit-jupiter-api", "testImplementation")
+        containsDependency("org.spockframework:spock-core", "testImplementation")
+        containsDependency("io.micronaut.test:micronaut-test-spock", "testImplementation")
+        containsDependency("org.junit.jupiter:junit-jupiter-engine", "testRuntimeOnly")
+        containsDependency("org.junit.platform:junit-platform-launcher", "testRuntimeOnly")
+    }
+
+    def "test mixed test runtimes with kotlin dsl"() {
+        given:
+        settingsFile << "rootProject.name = \"hello-world\""
+        kotlinBuildFile << """
+            import io.micronaut.gradle.MicronautTestRuntime
+
+            plugins {
+                id("io.micronaut.minimal.library")
+                id("groovy")
+            }
+
+            micronaut {
+                version.set("$micronautVersion")
+                testRuntimes(MicronautTestRuntime.JUNIT_5, MicronautTestRuntime.SPOCK_2)
+            }
+
+            ${getRepositoriesBlock('kotlin')}
+        """
+
+        expect:
+        containsDependency("io.micronaut.test:micronaut-test-junit5", "testImplementation")
+        containsDependency("org.spockframework:spock-core", "testImplementation")
+        containsDependency("org.junit.jupiter:junit-jupiter-engine", "testRuntimeOnly")
+    }
+
+    private void writeSupportBean() {
+        def javaFile = file("src/main/java/example/GreetingService.java")
+        javaFile.parentFile.mkdirs()
+        javaFile << """
+package example;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class GreetingService {
+
+    public String greet() {
+        return "ok";
+    }
+}
+"""
+    }
+
+    private void writeJunitTest() {
+        def javaFile = file("src/test/java/example/ExampleJUnitTest.java")
+        javaFile.parentFile.mkdirs()
+        javaFile << """
+package example;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@MicronautTest
+public class ExampleJUnitTest {
+
+    @Inject
+    GreetingService greetingService;
+
+    @Test
+    void testItWorks() {
+        Assertions.assertEquals("ok", greetingService.greet());
+    }
+}
+"""
+    }
+
+    private void writeSpockTest() {
+        def groovyFile = file("src/test/groovy/example/ExampleSpockSpec.groovy")
+        groovyFile.parentFile.mkdirs()
+        groovyFile << """
+package example
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class ExampleSpockSpec extends Specification {
+
+    @Inject
+    GreetingService greetingService
+
+    def "test spock works"() {
+        expect:
+        greetingService.greet() == "ok"
+    }
+}
+"""
+    }
+}

--- a/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautTestRuntimeSpec.groovy
+++ b/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautTestRuntimeSpec.groovy
@@ -1,0 +1,64 @@
+package io.micronaut.gradle
+
+import org.gradle.api.ProjectConfigurationException
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class MicronautTestRuntimeSpec extends Specification {
+
+    def "resolves and deduplicates configured test runtimes"() {
+        given:
+        def extension = newExtension()
+
+        when:
+        extension.testRuntime("junit5")
+        extension.testRuntimes("junit5", "spock2", "none")
+
+        then:
+        extension.resolveTestRuntimes() == [MicronautTestRuntime.JUNIT_5, MicronautTestRuntime.SPOCK_2]
+    }
+
+    def "rejects incompatible runtime combinations from the same family"() {
+        given:
+        def project = ProjectBuilder.builder().build()
+        project.extensions.add('micronautVersion', 'any')
+        project.pluginManager.apply(MicronautMinimalLibraryPlugin)
+        def extension = project.extensions.getByType(MicronautExtension)
+        extension.testRuntimes(MicronautTestRuntime.KOTEST_4, MicronautTestRuntime.KOTEST_5)
+
+        when:
+        project.evaluate()
+
+        then:
+        def e = thrown(ProjectConfigurationException)
+        e.cause instanceof IllegalArgumentException
+        e.cause.message.contains("family 'kotest'")
+    }
+
+    def "collects dependency unions without duplicates per configuration"() {
+        expect:
+        MicronautTestRuntime.collectDependencies([MicronautTestRuntime.JUNIT_5, MicronautTestRuntime.SPOCK_2]) == [
+            (JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME): [
+                "org.junit.jupiter:junit-jupiter-api",
+                "io.micronaut.test:micronaut-test-junit5",
+                "org.spockframework:spock-core",
+                "io.micronaut.test:micronaut-test-spock",
+                "org.apache.groovy:groovy",
+                "org.junit.platform:junit-platform-launcher"
+            ],
+            (JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME): [
+                "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher"
+            ],
+            (JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME): [
+                "io.micronaut:micronaut-inject-groovy"
+            ]
+        ]
+    }
+
+    private static MicronautExtension newExtension() {
+        def project = ProjectBuilder.builder().build()
+        project.objects.newInstance(MicronautExtension, new SourceSetConfigurerRegistry())
+    }
+}

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -711,6 +711,48 @@ application {
 }
 ----
 
+=== Multiple Test Runtimes
+
+The existing single-runtime configuration remains valid:
+
+[source, groovy]
+----
+micronaut {
+    testRuntime "junit5"
+}
+----
+
+If you need the plugin to auto-configure more than one supported test framework, use `testRuntimes` in addition to the legacy `testRuntime` path. The plugin merges the selected runtime dependencies and keeps JUnit Platform enabled when any selected runtime needs it.
+
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+plugins {
+    id 'groovy'
+    id 'io.micronaut.application' version '{gradle-project-version}'
+}
+
+micronaut {
+    version = "{micronaut-version}"
+    testRuntime "junit5"
+    testRuntimes "spock2"
+}
+----
+
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+import io.micronaut.gradle.MicronautTestRuntime
+
+plugins {
+    groovy
+    id("io.micronaut.application") version "{gradle-project-version}"
+}
+
+micronaut {
+    version.set("{micronaut-version}")
+    testRuntimes(MicronautTestRuntime.JUNIT_5, MicronautTestRuntime.SPOCK_2)
+}
+----
+
 === Kotlin Support
 
 The most simple Kotlin build using a `build.gradle(.kts)` file looks like:

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -722,7 +722,7 @@ micronaut {
 }
 ----
 
-If you need the plugin to auto-configure more than one supported test framework, use `testRuntimes` in addition to the legacy `testRuntime` path. The plugin merges the selected runtime dependencies and keeps JUnit Platform enabled when any selected runtime needs it.
+If you need the plugin to auto-configure more than one supported test framework, use `testRuntimes` either by itself or alongside the legacy `testRuntime` path. The plugin merges the selected runtime dependencies and keeps JUnit Platform enabled when any selected runtime needs it.
 
 [source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
 ----


### PR DESCRIPTION
## Summary
- add an additive `testRuntimes(...)` DSL alongside the legacy single-runtime `testRuntime(...)` path
- merge runtime dependency wiring, JUnit Platform activation, and incompatible-family validation across the selected test runtimes
- cover mixed JUnit 5 + Spock 2 usage with focused tests and document the new multi-runtime configuration path

## Verification
- `./gradlew :micronaut-minimal-plugin:test --rerun-tasks --tests 'io.micronaut.gradle.MicronautTestRuntimeSpec' --tests 'io.micronaut.gradle.MicronautMixedTestRuntimeSpec'`
- `./gradlew docs --rerun-tasks`

No matching open public Micronaut organization project is currently visible for the `5.0.0` line, so no organization project was linked.

Closes #919
---
###### ✨ This message was AI-generated using gpt-5.4
