### PR TITLE
Document developmentOnly dependencies

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -649,6 +649,51 @@ To run an application with continuous build use the `run` task with the `-t` par
 $ ./gradlew run -t
 ----
 
+=== Development-only Dependencies
+
+The application plugin creates a `developmentOnly` configuration for dependencies that are needed only while running the application locally.
+The `run` task uses a `developmentRuntimeClasspath` that extends the regular `runtimeClasspath` with `developmentOnly`, so those dependencies are available to local development runs without being added to the application's production runtime classpath.
+
+The plugin also adds some `developmentOnly` dependencies automatically:
+
+|===
+|Condition |Development-only dependencies
+
+|Running on macOS
+|`io.micronaut:micronaut-runtime-osx`
+
+|`micronaut.runtime("lambda_java")` or `micronaut.runtime("lambda_provided")`
+|`io.micronaut.aws:micronaut-function-aws-api-proxy-test`
+
+|`micronaut.runtime("oracle_function")`
+|`io.micronaut.oraclecloud:micronaut-oraclecloud-function-http-test`
+
+|`micronaut.runtime("google_function")`
+|`com.google.cloud.functions:functions-framework-api`, `io.micronaut.gcp:micronaut-gcp-function-http-test`
+
+|`micronaut.runtime("azure_function")`
+|`io.micronaut.azure:micronaut-azure-function-http-test`
+|===
+
+You can add your own local-only dependencies to `developmentOnly`:
+
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+dependencies {
+    developmentOnly("com.example:local-development-helper")
+}
+----
+
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+dependencies {
+    developmentOnly("com.example:local-development-helper")
+}
+----
+
+Gradle continuous mode is currently required for automatic restart on source and resource changes.
+Use `./gradlew run -t` when you want the plugin to enable Micronaut file watching and restart support for local development.
+
 === Minimal Build
 
 With the `io.micronaut.application` plugin applied a minimal build to get started with a Micronaut server application that is written in Java and tested with JUnit 5 looks like:


### PR DESCRIPTION
## Summary
- document the `developmentOnly` configuration for local-only runtime dependencies
- list the automatic development-only dependencies added for macOS and supported function runtimes
- clarify that `./gradlew run -t` is currently required for file watching and restart support

Fixes #467

## Verification
- `./gradlew docs`
- `git diff --check origin/master...HEAD`

---
###### ✨ This message was AI-generated using gpt-5
