### PR TITLE
Use Groovy AST transform classpath for Micronaut processors

### DIFF
--- a/gradle-plugin/src/test/groovy/io/micronaut/gradle/MicronautLibraryPluginSpec.groovy
+++ b/gradle-plugin/src/test/groovy/io/micronaut/gradle/MicronautLibraryPluginSpec.groovy
@@ -431,7 +431,10 @@ class Foo {
 
     def "test custom sourceSets for micronaut-library and groovy"() {
         given:
-        settingsFile << "rootProject.name = 'hello-world'"
+        settingsFile << """
+            rootProject.name = 'hello-world'
+            enableFeaturePreview('GROOVY_COMPILATION_AVOIDANCE')
+        """
         buildFile << """
             plugins {
                 id "io.micronaut.library"
@@ -460,6 +463,16 @@ class Foo {
             dependencies {
                 customImplementation("org.apache.groovy:groovy")
             }
+            tasks.register("verifyCustomGroovyAstTransformationClasspath") {
+                dependsOn("compileCustomGroovy")
+                doLast {
+                    def astClasspath = tasks.named("compileCustomGroovy").get().astTransformationClasspath.files*.name
+                    assert astClasspath.any { it.startsWith("micronaut-inject-groovy-") }
+                    assert !configurations.customCompileOnly.incoming.dependencies.any {
+                        it.group == "io.micronaut" && it.name == "micronaut-inject-groovy"
+                    }
+                }
+            }
         """
         testProjectDir.newFolder("src", "custom", "groovy", "example")
         def javaFile = testProjectDir.newFile("src/custom/groovy/example/Foo.groovy")
@@ -472,10 +485,11 @@ class Foo {}
 """
 
         when:
-        def result = build('compileCustomGroovy')
+        def result = build('verifyCustomGroovyAstTransformationClasspath')
 
         then:
         result.task(":compileCustomGroovy").outcome == TaskOutcome.SUCCESS
+        result.task(":verifyCustomGroovyAstTransformationClasspath").outcome == TaskOutcome.SUCCESS
         new File(
                 testProjectDir.getRoot(),
                 'build/classes/groovy/custom/example/Foo.class'
@@ -488,7 +502,10 @@ class Foo {}
 
     def "test apply defaults for micronaut-library and groovy"() {
         given:
-        settingsFile << "rootProject.name = 'hello-world'"
+        settingsFile << """
+            rootProject.name = 'hello-world'
+            enableFeaturePreview('GROOVY_COMPILATION_AVOIDANCE')
+        """
         buildFile << """
             plugins {
                 id "io.micronaut.library"
@@ -500,6 +517,21 @@ class Foo {}
             }
             
             $repositoriesBlock
+
+            dependencies {
+                implementation("org.apache.groovy:groovy")
+            }
+
+            tasks.register("verifyGroovyAstTransformationClasspath") {
+                dependsOn("compileGroovy")
+                doLast {
+                    def astClasspath = tasks.named("compileGroovy").get().astTransformationClasspath.files*.name
+                    assert astClasspath.any { it.startsWith("micronaut-inject-groovy-") }
+                    assert !configurations.compileOnly.incoming.dependencies.any {
+                        it.group == "io.micronaut" && it.name == "micronaut-inject-groovy"
+                    }
+                }
+            }
             
         """
         testProjectDir.newFolder("src", "main", "groovy", "example")
@@ -513,10 +545,11 @@ class Foo {}
 """
 
         when:
-        def result = build('assemble')
+        def result = build('verifyGroovyAstTransformationClasspath')
 
         then:
-        result.task(":assemble").outcome == TaskOutcome.SUCCESS
+        result.task(":compileGroovy").outcome == TaskOutcome.SUCCESS
+        result.task(":verifyGroovyAstTransformationClasspath").outcome == TaskOutcome.SUCCESS
         new File(
                 testProjectDir.getRoot(),
                 'build/classes/groovy/main/example/$Foo$Definition.class'
@@ -525,7 +558,10 @@ class Foo {}
 
     def "test add openapi processing - groovy"() {
         given:
-        settingsFile << "rootProject.name = 'hello-world'"
+        settingsFile << """
+            rootProject.name = 'hello-world'
+            enableFeaturePreview('GROOVY_COMPILATION_AVOIDANCE')
+        """
         buildFile << """
             plugins {
                 id "groovy"
@@ -539,10 +575,25 @@ class Foo {}
             $repositoriesBlock
             
             dependencies {
+                implementation "org.apache.groovy:groovy"
                 compileOnly "io.micronaut.openapi:micronaut-openapi"
                 compileOnly "io.swagger.core.v3:swagger-annotations"
                 compileOnly("io.micronaut:micronaut-http") {
                     because "The Micronaut OpenAPI processor needs Micronaut HTTP at compile time"
+                }
+            }
+            tasks.register("verifyOpenApiGroovyAstTransformationClasspath") {
+                dependsOn("compileGroovy")
+                doLast {
+                    def astClasspath = tasks.named("compileGroovy").get().astTransformationClasspath.files*.name
+                    assert astClasspath.any { it.startsWith("micronaut-inject-groovy-") }
+                    assert astClasspath.any { it.startsWith("micronaut-openapi-") }
+                    assert configurations.compileOnly.incoming.dependencies.any {
+                        it.group == "io.swagger.core.v3" && it.name == "swagger-annotations"
+                    }
+                    assert configurations.compileOnly.incoming.dependencies.any {
+                        it.group == "io.micronaut.openapi" && it.name == "micronaut-openapi"
+                    }
                 }
             }
             
@@ -567,10 +618,11 @@ class Foo {}
 """
 
         when:
-        def result = build('assemble')
+        def result = build('verifyOpenApiGroovyAstTransformationClasspath')
 
         then:
-        result.task(":assemble").outcome == TaskOutcome.SUCCESS
+        result.task(":compileGroovy").outcome == TaskOutcome.SUCCESS
+        result.task(":verifyOpenApiGroovyAstTransformationClasspath").outcome == TaskOutcome.SUCCESS
         new File(
                 testProjectDir.getRoot(),
                 'build/classes/groovy/main/example/$Foo$Definition.class'

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -49,7 +49,6 @@ import static org.gradle.api.plugins.JavaPlugin.API_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.TEST_ANNOTATION_PROCESSOR_CONFIGURATION_NAME;
-import static org.gradle.api.plugins.JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME;
 
 /**
  * A base plugin which configures Micronaut components, which are either a Micronaut
@@ -286,13 +285,11 @@ public class MicronautComponentPlugin implements Plugin<Project> {
             configureDefaultGroovySourceSet(
                     project,
                     javaPluginExtension,
-                    COMPILE_ONLY_CONFIGURATION_NAME,
                     "main"
             );
             configureDefaultGroovySourceSet(
                     project,
                     javaPluginExtension,
-                    TEST_COMPILE_ONLY_CONFIGURATION_NAME,
                     "test"
             );
             project.afterEvaluate(p -> {
@@ -301,11 +298,11 @@ public class MicronautComponentPlugin implements Plugin<Project> {
                 for (String defaultSourceSetName : SOURCESETS) {
                     var sourceSet = PluginsHelper.findSourceSets(p).findByName(defaultSourceSetName);
                     if (sourceSet != null) {
-                        String configName = sourceSet.getCompileOnlyConfigurationName();
                         Optional<File> groovySrcDir = findGroovySrcDir(sourceSet);
                         if (groovySrcDir.isPresent()) {
+                            Configuration astTransformationClasspath = configureGroovyAstTransformationClasspath(project, tasks, sourceSet);
                             dependencyHandler.add(
-                                    configName,
+                                    astTransformationClasspath.getName(),
                                     "io.micronaut:micronaut-inject-groovy"
                             );
                         }
@@ -316,14 +313,14 @@ public class MicronautComponentPlugin implements Plugin<Project> {
                 if (additionalSourceSets.isPresent()) {
                     List<SourceSet> sourceSets = additionalSourceSets.get();
                     for (SourceSet sourceSet : sourceSets) {
-                        String configName = sourceSet.getCompileOnlyConfigurationName();
                         Optional<File> groovySrcDir = findGroovySrcDir(sourceSet);
                         if (groovySrcDir.isPresent()) {
+                            Configuration astTransformationClasspath = configureGroovyAstTransformationClasspath(project, tasks, sourceSet);
                             dependencyHandler.add(
-                                    configName,
+                                    astTransformationClasspath.getName(),
                                     "io.micronaut:micronaut-inject-groovy"
                             );
-                            PluginsHelper.applyAdditionalProcessors(project, configName);
+                            PluginsHelper.applyAdditionalProcessorsNow(project, sourceSet, astTransformationClasspath.getName());
                         }
                     }
                 }
@@ -336,13 +333,36 @@ public class MicronautComponentPlugin implements Plugin<Project> {
 
     private void configureDefaultGroovySourceSet(Project p,
                                                  JavaPluginExtension javaPluginExtension,
-                                                 String scope,
                                                  String sourceSetName) {
         SourceSet groovySourceSet = javaPluginExtension.getSourceSets().findByName(sourceSetName);
         if (groovySourceSet != null) {
             Optional<File> groovySrc = findGroovySrcDir(groovySourceSet);
-            groovySrc.ifPresent((f -> applyAdditionalProcessors(p, scope)));
+            groovySrc.ifPresent((f -> {
+                Configuration astTransformationClasspath = configureGroovyAstTransformationClasspath(p, p.getTasks(), groovySourceSet);
+                applyAdditionalProcessors(p, groovySourceSet, astTransformationClasspath.getName());
+            }));
         }
+    }
+
+    private Configuration configureGroovyAstTransformationClasspath(Project project, TaskContainer tasks, SourceSet sourceSet) {
+        String configurationName = sourceSet.getTaskName("micronaut", "AstTransformationClasspath");
+        Configuration configuration = project.getConfigurations().findByName(configurationName);
+        if (configuration == null) {
+            configuration = project.getConfigurations().create(configurationName, conf -> {
+                conf.setCanBeConsumed(false);
+                conf.setCanBeResolved(true);
+                conf.setDescription("Micronaut AST transformation classpath for the " + sourceSet.getName() + " Groovy source set.");
+                conf.extendsFrom(project.getConfigurations().getByName(MICRONAUT_BOMS_CONFIGURATION));
+            });
+        }
+        Configuration astTransformationClasspath = configuration;
+        String compileTaskName = sourceSet.getCompileTaskName("groovy");
+        tasks.withType(GroovyCompile.class).configureEach(groovyCompile -> {
+            if (compileTaskName.equals(groovyCompile.getName())) {
+                groovyCompile.getAstTransformationClasspath().from(astTransformationClasspath);
+            }
+        });
+        return configuration;
     }
 
     private static TaskProvider<ApplicationClasspathInspector> registerInspectRuntimeClasspath(Project project, TaskContainer tasks) {

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/PluginsHelper.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/PluginsHelper.java
@@ -205,22 +205,43 @@ public abstract class PluginsHelper {
     }
 
     static void applyAdditionalProcessors(Project project, String... configurations) {
-        Stream.of(IMPLEMENTATION_CONFIGURATION_NAME, COMPILE_ONLY_CONFIGURATION_NAME).forEach(config -> {
+        applyAdditionalProcessors(project, Stream.of(IMPLEMENTATION_CONFIGURATION_NAME, COMPILE_ONLY_CONFIGURATION_NAME), configurations);
+    }
+
+    static void applyAdditionalProcessors(Project project, SourceSet sourceSet, String... configurations) {
+        applyAdditionalProcessors(project, Stream.of(sourceSet.getImplementationConfigurationName(), sourceSet.getCompileOnlyConfigurationName()), configurations);
+    }
+
+    static void applyAdditionalProcessorsNow(Project project, SourceSet sourceSet, String... configurations) {
+        Stream.of(sourceSet.getImplementationConfigurationName(), sourceSet.getCompileOnlyConfigurationName()).forEach(config -> {
+            applyAdditionalProcessorsFromConfiguration(project, config, configurations);
+        });
+    }
+
+    private static void applyAdditionalProcessors(Project project, Stream<String> sourceConfigurations, String... configurations) {
+        sourceConfigurations.forEach(config -> {
             // Need to do in an afterEvaluate because this will add dependencies only if the user didn't do it
             project.afterEvaluate(p -> {
-                final DependencySet allDependencies = project.getConfigurations().getByName(config)
-                        .getAllDependencies();
-                for (var entry : GROUP_TO_PROCESSOR_MAP.entrySet()) {
-                    boolean hasDep = !allDependencies.matching(dependency -> Objects.equals(dependency.getGroup(), entry.getKey())).isEmpty();
-                    if (hasDep) {
-                        for (String configuration : configurations) {
-                            AutomaticDependency automaticDependency = entry.getValue();
-                            automaticDependency.withConfiguration(configuration).applyTo(project);
-                        }
-                    }
-                }
+                applyAdditionalProcessorsFromConfiguration(project, config, configurations);
             });
         });
+    }
+
+    private static void applyAdditionalProcessorsFromConfiguration(Project project, String sourceConfiguration, String... targetConfigurations) {
+        Configuration configuration = project.getConfigurations().findByName(sourceConfiguration);
+        if (configuration == null) {
+            return;
+        }
+        final DependencySet allDependencies = configuration.getAllDependencies();
+        for (var entry : GROUP_TO_PROCESSOR_MAP.entrySet()) {
+            boolean hasDep = !allDependencies.matching(dependency -> Objects.equals(dependency.getGroup(), entry.getKey())).isEmpty();
+            if (hasDep) {
+                for (String targetConfiguration : targetConfigurations) {
+                    AutomaticDependency automaticDependency = entry.getValue();
+                    automaticDependency.withConfiguration(targetConfiguration).applyTo(project);
+                }
+            }
+        }
     }
 
     public static MicronautRuntime resolveRuntime(Project p) {

--- a/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMinimalLibraryPluginSpec.groovy
+++ b/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMinimalLibraryPluginSpec.groovy
@@ -382,7 +382,10 @@ class Foo {
 
     def "test custom sourceSets for micronaut-library and groovy"() {
         given:
-        settingsFile << "rootProject.name = 'hello-world'"
+        settingsFile << """
+            rootProject.name = 'hello-world'
+            enableFeaturePreview('GROOVY_COMPILATION_AVOIDANCE')
+        """
         buildFile << """
             plugins {
                 id "io.micronaut.minimal.library"
@@ -411,6 +414,16 @@ class Foo {
             dependencies {
                 customImplementation("org.apache.groovy:groovy")
             }
+            tasks.register("verifyCustomGroovyAstTransformationClasspath") {
+                dependsOn("compileCustomGroovy")
+                doLast {
+                    def astClasspath = tasks.named("compileCustomGroovy").get().astTransformationClasspath.files*.name
+                    assert astClasspath.any { it.startsWith("micronaut-inject-groovy-") }
+                    assert !configurations.customCompileOnly.incoming.dependencies.any {
+                        it.group == "io.micronaut" && it.name == "micronaut-inject-groovy"
+                    }
+                }
+            }
             $withSerde
         """
         testProjectDir.newFolder("src", "custom", "groovy", "example")
@@ -424,10 +437,11 @@ class Foo {}
 """
 
         when:
-        def result = build('compileCustomGroovy')
+        def result = build('verifyCustomGroovyAstTransformationClasspath')
 
         then:
         result.task(":compileCustomGroovy").outcome == TaskOutcome.SUCCESS
+        result.task(":verifyCustomGroovyAstTransformationClasspath").outcome == TaskOutcome.SUCCESS
         new File(
                 testProjectDir.getRoot(),
                 'build/classes/groovy/custom/example/Foo.class'
@@ -440,7 +454,10 @@ class Foo {}
 
     def "test apply defaults for micronaut-library and groovy"() {
         given:
-        settingsFile << "rootProject.name = 'hello-world'"
+        settingsFile << """
+            rootProject.name = 'hello-world'
+            enableFeaturePreview('GROOVY_COMPILATION_AVOIDANCE')
+        """
         buildFile << """
             plugins {
                 id "io.micronaut.minimal.library"
@@ -452,7 +469,21 @@ class Foo {}
             }
             
             $repositoriesBlock
+
+            dependencies {
+                implementation("org.apache.groovy:groovy")
+            }
             
+            tasks.register("verifyGroovyAstTransformationClasspath") {
+                dependsOn("compileGroovy")
+                doLast {
+                    def astClasspath = tasks.named("compileGroovy").get().astTransformationClasspath.files*.name
+                    assert astClasspath.any { it.startsWith("micronaut-inject-groovy-") }
+                    assert !configurations.compileOnly.incoming.dependencies.any {
+                        it.group == "io.micronaut" && it.name == "micronaut-inject-groovy"
+                    }
+                }
+            }
         """
         testProjectDir.newFolder("src", "main", "groovy", "example")
         def javaFile = testProjectDir.newFile("src/main/groovy/example/Foo.groovy")
@@ -465,10 +496,11 @@ class Foo {}
 """
 
         when:
-        def result = build('assemble')
+        def result = build('verifyGroovyAstTransformationClasspath')
 
         then:
-        result.task(":assemble").outcome == TaskOutcome.SUCCESS
+        result.task(":compileGroovy").outcome == TaskOutcome.SUCCESS
+        result.task(":verifyGroovyAstTransformationClasspath").outcome == TaskOutcome.SUCCESS
         new File(
                 testProjectDir.getRoot(),
                 'build/classes/groovy/main/example/$Foo$Definition.class'
@@ -477,7 +509,10 @@ class Foo {}
 
     def "test add openapi processing - groovy"() {
         given:
-        settingsFile << "rootProject.name = 'hello-world'"
+        settingsFile << """
+            rootProject.name = 'hello-world'
+            enableFeaturePreview('GROOVY_COMPILATION_AVOIDANCE')
+        """
         buildFile << """
             plugins {
                 id "groovy"
@@ -491,11 +526,26 @@ class Foo {}
             $repositoriesBlock
             
             dependencies {
+                implementation "org.apache.groovy:groovy"
                 compileOnly "io.micronaut.openapi:micronaut-openapi"
                 compileOnly("io.micronaut:micronaut-http") {
                     because "The Micronaut OpenAPI processor needs Micronaut HTTP at compile time"
                 }
                 compileOnly "io.swagger.core.v3:swagger-annotations"
+            }
+            tasks.register("verifyOpenApiGroovyAstTransformationClasspath") {
+                dependsOn("compileGroovy")
+                doLast {
+                    def astClasspath = tasks.named("compileGroovy").get().astTransformationClasspath.files*.name
+                    assert astClasspath.any { it.startsWith("micronaut-inject-groovy-") }
+                    assert astClasspath.any { it.startsWith("micronaut-openapi-") }
+                    assert configurations.compileOnly.incoming.dependencies.any {
+                        it.group == "io.swagger.core.v3" && it.name == "swagger-annotations"
+                    }
+                    assert configurations.compileOnly.incoming.dependencies.any {
+                        it.group == "io.micronaut.openapi" && it.name == "micronaut-openapi"
+                    }
+                }
             }
             
         """
@@ -519,10 +569,11 @@ class Foo {}
 """
 
         when:
-        def result = build('assemble')
+        def result = build('verifyOpenApiGroovyAstTransformationClasspath')
 
         then:
-        result.task(":assemble").outcome == TaskOutcome.SUCCESS
+        result.task(":compileGroovy").outcome == TaskOutcome.SUCCESS
+        result.task(":verifyOpenApiGroovyAstTransformationClasspath").outcome == TaskOutcome.SUCCESS
         new File(
                 testProjectDir.getRoot(),
                 'build/classes/groovy/main/example/$Foo$Definition.class'

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -531,6 +531,37 @@ micronaut {
 
 NOTE: The Micronaut Library plugin also supports Groovy and Kotlin sources.
 
+=== Groovy Support
+
+For Groovy sources, apply Gradle's `groovy` plugin and declare the Groovy dependency needed by Gradle's Groovy compiler.
+Micronaut's Groovy AST transformations are configured on Gradle's `astTransformationClasspath` and are not added to the source set compile classpath automatically.
+
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+plugins {
+    id "groovy"
+    id "io.micronaut.library" version "{gradle-project-version}"
+}
+
+dependencies {
+    implementation("org.apache.groovy:groovy")
+}
+----
+
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+plugins {
+    id("groovy")
+    id("io.micronaut.library") version "{gradle-project-version}"
+}
+
+dependencies {
+    implementation("org.apache.groovy:groovy")
+}
+----
+
+For additional Groovy source sets, declare Groovy on the matching source set implementation configuration, such as `customImplementation("org.apache.groovy:groovy")`.
+
 === Kotlin Support
 
 For Kotlin, the Kotlin `jvm` and `kapt` plugins must be configured:


### PR DESCRIPTION
## Summary
- Wire Micronaut-owned Groovy processor dependencies through source-set-specific `GroovyCompile.astTransformationClasspath` configurations.
- Stop automatically adding `micronaut-inject-groovy` to Groovy source-set `compileOnly` configurations.
- Keep additional Micronaut Groovy processors such as OpenAPI on the AST transform classpath while preserving user-declared compile-only dependencies.

Closes #645

## Verification
- `./gradlew :micronaut-minimal-plugin:test --tests "io.micronaut.gradle.MicronautMinimalLibraryPluginSpec" --rerun-tasks`
- `./gradlew :micronaut-gradle-plugin:test --tests "io.micronaut.gradle.MicronautLibraryPluginSpec" --rerun-tasks`

## Release Tracking
- Target: `master` / 5.0.0 line
- Projects: `5.0.0-M3` and `5.0.0 Release`

---
###### ✨ This message was AI-generated using GPT-5