### PR TITLE
Fix native Dockerfile metadata expectations

### DIFF
--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -76,13 +76,31 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
             COPY --link layers/app /home/app/
             RUN mkdir /home/app/config-dirs
             RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
+            RUN mkdir -p /home/app/config-dirs/org.reactivestreams/reactive-streams/4.0.0
+            RUN mkdir -p /home/app/config-dirs/org.slf4j/slf4j-api/4.0.0
+            RUN mkdir -p /home/app/config-dirs/jakarta.inject/jakarta.inject-api/4.0.0
+            RUN mkdir -p /home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0
             RUN mkdir -p /home/app/config-dirs/io.netty/netty-common/4.0.0.Final
             RUN mkdir -p /home/app/config-dirs/io.netty/netty-transport/4.0.0.Final
+            RUN mkdir -p /home/app/config-dirs/com.fasterxml.jackson.core/jackson-annotations/4.0.0
+            RUN mkdir -p /home/app/config-dirs/com.fasterxml.jackson.core/jackson-core/4.0.0
+            RUN mkdir -p /home/app/config-dirs/org.yaml/snakeyaml/1.32
+            RUN mkdir -p /home/app/config-dirs/jakarta.validation/jakarta.validation-api/4.0.0
             RUN mkdir -p /home/app/config-dirs/ch.qos.logback/logback-classic/4.0.0
+            RUN mkdir -p /home/app/config-dirs/ch.qos.logback/logback-core/4.0.0
             COPY --link config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
+            COPY --link config-dirs/org.reactivestreams/reactive-streams/4.0.0 /home/app/config-dirs/org.reactivestreams/reactive-streams/4.0.0
+            COPY --link config-dirs/org.slf4j/slf4j-api/4.0.0 /home/app/config-dirs/org.slf4j/slf4j-api/4.0.0
+            COPY --link config-dirs/jakarta.inject/jakarta.inject-api/4.0.0 /home/app/config-dirs/jakarta.inject/jakarta.inject-api/4.0.0
+            COPY --link config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0 /home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0
             COPY --link config-dirs/io.netty/netty-common/4.0.0.Final /home/app/config-dirs/io.netty/netty-common/4.0.0.Final
             COPY --link config-dirs/io.netty/netty-transport/4.0.0.Final /home/app/config-dirs/io.netty/netty-transport/4.0.0.Final
+            COPY --link config-dirs/com.fasterxml.jackson.core/jackson-annotations/4.0.0 /home/app/config-dirs/com.fasterxml.jackson.core/jackson-annotations/4.0.0
+            COPY --link config-dirs/com.fasterxml.jackson.core/jackson-core/4.0.0 /home/app/config-dirs/com.fasterxml.jackson.core/jackson-core/4.0.0
+            COPY --link config-dirs/org.yaml/snakeyaml/1.32 /home/app/config-dirs/org.yaml/snakeyaml/1.32
+            COPY --link config-dirs/jakarta.validation/jakarta.validation-api/4.0.0 /home/app/config-dirs/jakarta.validation/jakarta.validation-api/4.0.0
             COPY --link config-dirs/ch.qos.logback/logback-classic/4.0.0 /home/app/config-dirs/ch.qos.logback/logback-classic/4.0.0
+            COPY --link config-dirs/ch.qos.logback/logback-core/4.0.0 /home/app/config-dirs/ch.qos.logback/logback-core/4.0.0
             RUN native-image
             FROM cgr.dev/chainguard/wolfi-base:latest
             EXPOSE 8080

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -664,9 +664,17 @@ micronaut:
             COPY --link layers/resources /home/alternate/resources
             RUN mkdir /home/alternate/config-dirs
             RUN mkdir -p /home/alternate/config-dirs/generateResourcesConfigFile
+            RUN mkdir -p /home/alternate/config-dirs/org.slf4j/slf4j-api/4.0.0
+            RUN mkdir -p /home/alternate/config-dirs/jakarta.inject/jakarta.inject-api/4.0.0
+            RUN mkdir -p /home/alternate/config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0
+            RUN mkdir -p /home/alternate/config-dirs/org.reactivestreams/reactive-streams/4.0.0
             RUN mkdir -p /home/alternate/config-dirs/io.netty/netty-common/4.0.0.Final
             RUN mkdir -p /home/alternate/config-dirs/io.netty/netty-transport/4.0.0.Final
             COPY --link config-dirs/generateResourcesConfigFile /home/alternate/config-dirs/generateResourcesConfigFile
+            COPY --link config-dirs/org.slf4j/slf4j-api/4.0.0 /home/alternate/config-dirs/org.slf4j/slf4j-api/4.0.0
+            COPY --link config-dirs/jakarta.inject/jakarta.inject-api/4.0.0 /home/alternate/config-dirs/jakarta.inject/jakarta.inject-api/4.0.0
+            COPY --link config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0 /home/alternate/config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0
+            COPY --link config-dirs/org.reactivestreams/reactive-streams/4.0.0 /home/alternate/config-dirs/org.reactivestreams/reactive-streams/4.0.0
             COPY --link config-dirs/io.netty/netty-common/4.0.0.Final /home/alternate/config-dirs/io.netty/netty-common/4.0.0.Final
             COPY --link config-dirs/io.netty/netty-transport/4.0.0.Final /home/alternate/config-dirs/io.netty/netty-transport/4.0.0.Final
             RUN native-image
@@ -788,8 +796,14 @@ COPY --link layers/app /home/app/
 COPY --link layers/resources /home/app/resources
 RUN mkdir /home/app/config-dirs
 RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
+RUN mkdir -p /home/app/config-dirs/org.slf4j/slf4j-api/1.7.36
+RUN mkdir -p /home/app/config-dirs/jakarta.inject/jakarta.inject-api/2.0.0
+RUN mkdir -p /home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/1.3.3
 COPY --link config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
-RUN native-image -cp '/home/app/libs/*.jar:/home/app/resources:/home/app/application.jar' --no-fallback -o application -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile ${SHARED_ARENA_SUPPORT} example.Application
+COPY --link config-dirs/org.slf4j/slf4j-api/1.7.36 /home/app/config-dirs/org.slf4j/slf4j-api/1.7.36
+COPY --link config-dirs/jakarta.inject/jakarta.inject-api/2.0.0 /home/app/config-dirs/jakarta.inject/jakarta.inject-api/2.0.0
+COPY --link config-dirs/jakarta.annotation/jakarta.annotation-api/1.3.3 /home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/1.3.3
+RUN native-image -cp '/home/app/libs/*.jar:/home/app/resources:/home/app/application.jar' --no-fallback -o application -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile,/home/app/config-dirs/org.slf4j/slf4j-api/1.7.36,/home/app/config-dirs/jakarta.inject/jakarta.inject-api/2.0.0,/home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/1.3.3 ${SHARED_ARENA_SUPPORT} example.Application
 ${defaultDockerFrom}
 EXPOSE 8080
 COPY --link --from=graalvm /home/app/application /app/application


### PR DESCRIPTION
This splits the native Docker expectation fix out onto a clean `master`-based branch so the current Java CI baseline blocker can be reviewed independently of #1267.

The generated native Dockerfiles now include additional reachability metadata configuration directories from the current dependency set, so the functional test expectations need to include the matching `RUN mkdir`, `COPY --link`, and native-image configuration directory entries.

Verification:

```bash
./gradlew :functional-tests:test --tests 'io.micronaut.gradle.docker.DockerNativeFunctionalTest.can configure an alternate working directory' --tests 'io.micronaut.gradle.docker.DockerNativeFunctionalTest.can tweak the generated docker file' --tests 'io.micronaut.gradle.aot.MicronautAOTDockerSpec.generates a native optimized docker image' --no-daemon
```

Result: `BUILD SUCCESSFUL`, 3 selected tests passed.

Unblocks #1267.

---
###### ✨ This message was AI-generated using gpt-5.5
