### PR TITLE
Add release vulnerability audit

### DIFF
--- a/.github/scripts/vulnerability-audit-filter.py
+++ b/.github/scripts/vulnerability-audit-filter.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+import argparse
+import collections
+import json
+import sys
+from urllib.parse import parse_qs, urlparse
+
+
+DEFAULT_UPSTREAM_GROUP_PREFIXES = ("io.micronaut",)
+
+
+def load_json(path):
+    with open(path, "r", encoding="utf-8") as json_file:
+        return json.load(json_file)
+
+
+def component_ref(component):
+    return component.get("bom-ref") or component.get("purl")
+
+
+def component_group_name(component):
+    group = component.get("group")
+    name = component.get("name")
+    if group and name:
+        return f"{group}:{name}"
+    return name
+
+
+def purl_has_project_path(component):
+    purl = component.get("purl") or component.get("bom-ref") or ""
+    parsed = urlparse(purl)
+    query = parse_qs(parsed.query)
+    return "project_path" in query
+
+
+def parse_prefixes(value):
+    prefixes = []
+    for prefix in value.split(","):
+        prefix = prefix.strip()
+        if prefix:
+            prefixes.append(prefix)
+    return tuple(prefixes)
+
+
+class AuditGraph:
+    def __init__(self, bom, upstream_group_prefixes):
+        metadata_component = bom.get("metadata", {}).get("component", {})
+        self.components = []
+        if metadata_component:
+            self.components.append(metadata_component)
+        self.components.extend(bom.get("components", []))
+
+        self.component_by_ref = {
+            component_ref(component): component
+            for component in self.components
+            if component_ref(component)
+        }
+        self.refs_by_package = collections.defaultdict(list)
+        for component in self.components:
+            group_name = component_group_name(component)
+            version = component.get("version")
+            ref = component_ref(component)
+            if group_name and version and ref:
+                self.refs_by_package[(group_name, version)].append(ref)
+
+        self.dependencies = collections.defaultdict(set)
+        for dependency in bom.get("dependencies", []):
+            ref = dependency.get("ref")
+            if ref:
+                self.dependencies[ref].update(dependency.get("dependsOn", []))
+
+        self.local_roots = {
+            component_ref(component)
+            for component in self.components
+            if component_ref(component) and purl_has_project_path(component)
+        }
+        if not self.local_roots and component_ref(metadata_component):
+            self.local_roots.add(component_ref(metadata_component))
+
+        self.upstream_group_prefixes = upstream_group_prefixes
+
+    def is_upstream_component(self, ref):
+        component = self.component_by_ref.get(ref)
+        if not component or purl_has_project_path(component):
+            return False
+        group = component.get("group", "")
+        return any(
+            group == prefix or group.startswith(f"{prefix}.")
+            for prefix in self.upstream_group_prefixes
+        )
+
+    def classify_package(self, package_name, version):
+        targets = set(self.refs_by_package.get((package_name, version), []))
+        if not targets:
+            return {
+                "classification": "actionable",
+                "reason": "package was not found in the CycloneDX dependency graph",
+                "via": [],
+            }
+        if not self.local_roots:
+            return {
+                "classification": "actionable",
+                "reason": "no local project roots were found in the CycloneDX dependency graph",
+                "via": [],
+            }
+
+        path_count = 0
+        upstream_via = set()
+        actionable_reasons = set()
+
+        for root in sorted(self.local_roots):
+            queue = collections.deque()
+            for child in sorted(self.dependencies.get(root, ())):
+                if child in targets:
+                    path_count += 1
+                    if self.is_upstream_component(child):
+                        upstream_via.add(child)
+                    else:
+                        actionable_reasons.add("direct local dependency")
+                    continue
+                first_upstream = child if self.is_upstream_component(child) else None
+                external_before_owner = child not in self.local_roots and first_upstream is None
+                queue.append((child, first_upstream, external_before_owner, {root, child}))
+
+            while queue:
+                node, first_upstream, external_before_owner, seen = queue.popleft()
+                children = self.dependencies.get(node, ())
+                if not children:
+                    continue
+                for child in sorted(children):
+                    if child in seen:
+                        continue
+                    child_first_upstream = first_upstream
+                    child_external_before_owner = external_before_owner
+                    if child_first_upstream is None and child not in self.local_roots:
+                        if self.is_upstream_component(child):
+                            child_first_upstream = child
+                        else:
+                            child_external_before_owner = True
+                    if child in targets:
+                        path_count += 1
+                        if child_first_upstream and not child_external_before_owner:
+                            upstream_via.add(child_first_upstream)
+                        else:
+                            actionable_reasons.add(
+                                "dependency path reaches a non-local, non-upstream component before a configured upstream owner"
+                            )
+                    else:
+                        queue.append((child, child_first_upstream, child_external_before_owner, seen | {child}))
+
+        if path_count == 0:
+            return {
+                "classification": "actionable",
+                "reason": "package was present but unreachable from local project roots",
+                "via": [],
+            }
+        if actionable_reasons:
+            return {
+                "classification": "actionable",
+                "reason": "; ".join(sorted(actionable_reasons)),
+                "via": sorted(upstream_via),
+            }
+        return {
+            "classification": "upstream",
+            "reason": "all dependency paths enter configured upstream Micronaut components before other external components",
+            "via": sorted(upstream_via),
+        }
+
+
+def vulnerability_ids(package):
+    ids = []
+    for group in package.get("groups", []):
+        ids.extend(group.get("ids", []))
+    if not ids:
+        ids.extend(vulnerability.get("id") for vulnerability in package.get("vulnerabilities", []))
+    return sorted({vulnerability_id for vulnerability_id in ids if vulnerability_id})
+
+
+def fixed_versions(package):
+    fixed = set()
+    for vulnerability in package.get("vulnerabilities", []):
+        for affected in vulnerability.get("affected", []):
+            for version_range in affected.get("ranges", []):
+                for event in version_range.get("events", []):
+                    if "fixed" in event:
+                        fixed.add(event["fixed"])
+    return sorted(fixed)
+
+
+def iter_packages(osv_results):
+    for result in osv_results.get("results", []):
+        source = result.get("source", {})
+        for package in result.get("packages", []):
+            yield source, package
+
+
+def print_finding(prefix, finding):
+    ids = ", ".join(finding["ids"]) if finding["ids"] else "unknown vulnerability"
+    fixed = ", ".join(finding["fixed_versions"]) if finding["fixed_versions"] else "unknown fixed version"
+    print(f"- {finding['name']}:{finding['version']} ({ids}; fixed: {fixed})")
+    print(f"  {prefix}: {finding['reason']}")
+    if finding["via"]:
+        print(f"  Via: {', '.join(finding['via'])}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Filter OSV findings that are owned by upstream Micronaut components.")
+    parser.add_argument("--sbom", required=True, help="CycloneDX JSON SBOM path")
+    parser.add_argument("--osv", required=True, help="OSV-Scanner JSON output path")
+    parser.add_argument(
+        "--upstream-group-prefixes",
+        default=",".join(DEFAULT_UPSTREAM_GROUP_PREFIXES),
+        help="Comma-separated Maven group prefixes treated as upstream-owned",
+    )
+    args = parser.parse_args()
+
+    upstream_group_prefixes = parse_prefixes(args.upstream_group_prefixes)
+    if not upstream_group_prefixes:
+        print("No upstream group prefixes configured; no findings will be downgraded.")
+
+    graph = AuditGraph(load_json(args.sbom), upstream_group_prefixes)
+    osv_results = load_json(args.osv)
+
+    actionable = []
+    upstream = []
+
+    for source, package_result in iter_packages(osv_results):
+        package = package_result.get("package", {})
+        ecosystem = package.get("ecosystem")
+        name = package.get("name")
+        version = package.get("version")
+        if ecosystem != "Maven" or not name or not version:
+            classification = {
+                "classification": "actionable",
+                "reason": f"unsupported or incomplete package metadata from {source.get('path', 'unknown source')}",
+                "via": [],
+            }
+        else:
+            classification = graph.classify_package(name, version)
+
+        finding = {
+            "name": name or "unknown",
+            "version": version or "unknown",
+            "ids": vulnerability_ids(package_result),
+            "fixed_versions": fixed_versions(package_result),
+            "reason": classification["reason"],
+            "via": classification["via"],
+        }
+        if classification["classification"] == "upstream":
+            upstream.append(finding)
+        else:
+            actionable.append(finding)
+
+    if upstream:
+        print("Upstream-owned vulnerability findings downgraded to informational:")
+        for finding in upstream:
+            print_finding("Reason", finding)
+
+    if actionable:
+        print("Actionable vulnerability findings:")
+        for finding in actionable:
+            print_finding("Reason", finding)
+        return 1
+
+    if not upstream:
+        print("No known vulnerabilities found.")
+    else:
+        print("No locally actionable vulnerabilities found after upstream ownership filtering.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/vulnerability-audit.sh
+++ b/.github/scripts/vulnerability-audit.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly CYCLONEDX_GRADLE_PLUGIN_VERSION="${CYCLONEDX_GRADLE_PLUGIN_VERSION:-3.2.4}"
+readonly OSV_SCANNER_IMAGE="${OSV_SCANNER_IMAGE:-ghcr.io/google/osv-scanner:v2.3.5@sha256:4d3d1a42ba435ac706286fec518c044f049c9753d21260b5bae60bab8740ed97}"
+readonly SBOM_PATH="${SBOM_PATH:-build/reports/cyclonedx/bom.json}"
+readonly UPSTREAM_GROUP_PREFIXES="${UPSTREAM_GROUP_PREFIXES:-io.micronaut}"
+readonly VULNERABILITY_AUDIT_ENFORCEMENT="${VULNERABILITY_AUDIT_ENFORCEMENT:-fail}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ "${VULNERABILITY_AUDIT_ENFORCEMENT}" != "fail" && "${VULNERABILITY_AUDIT_ENFORCEMENT}" != "advisory" ]]; then
+    echo "VULNERABILITY_AUDIT_ENFORCEMENT must be 'fail' or 'advisory'" >&2
+    exit 1
+fi
+
+if [[ ! -x ./gradlew ]]; then
+    echo "Gradle wrapper not found or not executable at ${ROOT_DIR}/gradlew" >&2
+    exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required to run OSV-Scanner" >&2
+    exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+init_script="${tmp_dir}/cyclonedx-init.gradle"
+cat > "${init_script}" <<GRADLE
+initscript {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.cyclonedx:cyclonedx-gradle-plugin:${CYCLONEDX_GRADLE_PLUGIN_VERSION}"
+    }
+}
+
+allprojects {
+    apply plugin: Class.forName('org.cyclonedx.gradle.CyclonedxPlugin')
+
+    tasks.withType(Class.forName('org.cyclonedx.gradle.CyclonedxDirectTask')).configureEach { task ->
+        task.enabled = false
+        task.includeConfigs.set(['runtimeClasspath'])
+        plugins.withId('maven-publish') {
+            task.enabled = true
+        }
+    }
+}
+GRADLE
+
+echo "Generating CycloneDX SBOM at ${SBOM_PATH}"
+./gradlew :cyclonedxBom --init-script "${init_script}" --no-parallel --info
+
+if [[ ! -s "${SBOM_PATH}" ]]; then
+    echo "CycloneDX SBOM was not generated at ${SBOM_PATH}" >&2
+    exit 1
+fi
+
+osv_args=(
+    run
+    --rm
+    -v "${ROOT_DIR}:/src:ro"
+    -w /src
+    "${OSV_SCANNER_IMAGE}"
+    scan
+    source
+    --experimental-no-default-plugins
+    --experimental-plugins
+    sbom
+    --lockfile
+    "/src/${SBOM_PATH}"
+    --format
+    json
+    --verbosity
+    warn
+)
+
+if [[ -f osv-scanner.toml ]]; then
+    echo "Using osv-scanner.toml for vulnerability audit exceptions"
+    osv_args+=(--config /src/osv-scanner.toml)
+fi
+
+osv_output="${tmp_dir}/osv-results.json"
+
+echo "Scanning CycloneDX SBOM with OSV-Scanner"
+set +e
+docker "${osv_args[@]}" > "${osv_output}"
+osv_status=$?
+set -e
+
+if [[ ${osv_status} -ne 0 && ${osv_status} -ne 1 ]]; then
+    echo "OSV-Scanner failed with exit code ${osv_status}" >&2
+    if [[ -s "${osv_output}" ]]; then
+        cat "${osv_output}" >&2
+    fi
+    exit "${osv_status}"
+fi
+
+set +e
+python3 .github/scripts/vulnerability-audit-filter.py \
+    --sbom "${SBOM_PATH}" \
+    --osv "${osv_output}" \
+    --upstream-group-prefixes "${UPSTREAM_GROUP_PREFIXES}"
+filter_status=$?
+set -e
+
+if [[ ${filter_status} -eq 0 ]]; then
+    exit 0
+fi
+
+if [[ ${filter_status} -eq 1 && "${VULNERABILITY_AUDIT_ENFORCEMENT}" == "advisory" ]]; then
+    message="Actionable vulnerabilities were found, but this milestone/RC release keeps the vulnerability audit advisory."
+    echo "::warning title=Vulnerability audit advisory::${message}"
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        {
+            echo "### Vulnerability audit advisory"
+            echo
+            echo "${message}"
+            echo
+            echo "GA releases and pull request audits remain blocking."
+        } >> "${GITHUB_STEP_SUMMARY}"
+    fi
+    exit 0
+fi
+
+exit "${filter_status}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,22 @@ jobs:
       - name: Set the current release version
         id: release_version
         run: echo "release_version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
+      - name: Vulnerability Audit
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
+          GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
+        run: |
+          release_version="${RELEASE_VERSION}"
+          if [[ "${release_version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-(M|RC)[0-9]+$ ]]; then
+            echo "Running vulnerability audit in advisory mode for ${release_version}"
+            VULNERABILITY_AUDIT_ENFORCEMENT=advisory .github/scripts/vulnerability-audit.sh
+          else
+            .github/scripts/vulnerability-audit.sh
+          fi
       - name: Run pre-release
         uses: micronaut-projects/github-actions/pre-release@master
         env:

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -168,6 +168,9 @@ If you are publishing a milestone or release candidate, check the pre-release ch
 
 Note that the release tags must be preceded with `v`, e.g.: `v1.2.3`.
 
+The release workflow runs a vulnerability audit before publishing. Vulnerability findings are advisory for milestone and
+release-candidate tags such as `v1.2.3-M1` and `v1.2.3-RC1`, but they remain blocking for GA releases.
+
 Once you publish the GitHub release, the
 [Release GitHub Action workflow](https://github.com/micronaut-projects/micronaut-project-template/blob/master/.github/workflows/release.yml)
 will kick off, performing the following steps:


### PR DESCRIPTION
## Summary
- Adds the template vulnerability audit scripts and runs the audit before pre-release and Gradle Plugin Portal publishing.
- Keeps milestone and RC vulnerability findings advisory while GA release findings remain blocking.
- Documents the release audit behavior in `MAINTAINING.md`.

## Template Sync Notes
- Applied the Micronaut Project Template prerelease vulnerability audit update for the Gradle Plugin release flow.
- Skipped the files-sync automerge template change because `.github/workflows/files-sync.yml` is not present in this downstream repository and the change is template-propagation infrastructure.

## Compatibility
- Gradle Plugin Portal publishing remains `publishPlugins docs`.
- No Gradle wrapper, plugin marker metadata, TestKit behavior, dependency resolution behavior, or Gradle/JDK support changed.
- QA selected the `5.0.0-M3` and `5.0.0 Release` organization projects. Ambiguity: the exact next Gradle Plugin 5.0 tag may be a milestone/RC before GA, so both prerelease and GA boards are intentionally linked.

## Verification
- `bash -n .github/scripts/vulnerability-audit.sh`
- Python compile check for `.github/scripts/vulnerability-audit-filter.py`
- Python YAML parse of `.github/workflows/release.yml`
- Focused vulnerability filter classification probe for direct, upstream-owned, external-before-owner, and missing-package cases
- `git diff --check origin/master...HEAD`
- QA also verified `./gradlew :cyclonedxBom --init-script <CycloneDX audit init script> --no-parallel`

Closes DEV-357

---
###### ✨ This message was AI-generated using gpt-5
