### PR TITLE
Add Micronaut CycloneDX SBOM defaults

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     javadoc libs.micronaut.openapi.generator
     javadoc libs.bundles.optionalPlugins
     javadoc libs.shadowPlugin
+    javadoc libs.cyclonedxPlugin
     javadoc libs.micronaut.jsonschema.generator
 }
 
@@ -51,7 +52,8 @@ asciidoctorj {
             'kotlin-version': libs.versions.kotlin.get(),
             'micronaut-version': libs.versions.micronaut.platform.get(),
             'gradle-version': GradleVersion.current().version,
-            'shadow-version': libs.versions.shadow.get()
+            'shadow-version': libs.versions.shadow.get(),
+            'cyclonedx-version': libs.versions.cyclonedx.get()
 }
 
 if (System.getenv("SONAR_TOKEN")) {

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/sbom/CycloneDxSbomFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/sbom/CycloneDxSbomFunctionalTest.groovy
@@ -1,0 +1,317 @@
+package io.micronaut.gradle.sbom
+
+import groovy.json.JsonSlurper
+import io.micronaut.gradle.fixtures.AbstractFunctionalTest
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Unroll
+
+import java.util.jar.JarFile
+
+class CycloneDxSbomFunctionalTest extends AbstractFunctionalTest {
+
+    def "CycloneDX tasks are absent when the CycloneDX plugin is not applied"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id 'io.micronaut.application'
+            }
+
+            $repositoriesBlock
+
+            micronaut {
+                version "$micronautVersion"
+            }
+        """
+
+        when:
+        def result = build("tasks")
+
+        then:
+        result.task(":tasks").outcome == TaskOutcome.SUCCESS
+        !result.output.contains("cyclonedxDirectBom")
+        !file("build/reports/micronaut/sbom/application.cdx.json").exists()
+    }
+
+    def "no CycloneDX build is compatible with configuration cache"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id 'io.micronaut.application'
+            }
+
+            $repositoriesBlock
+
+            micronaut {
+                version "$micronautVersion"
+            }
+        """
+
+        when:
+        def result = build("tasks", "--configuration-cache")
+
+        then:
+        result.output.contains("Configuration cache entry stored")
+        !result.output.contains("cyclonedxDirectBom")
+    }
+
+    @Unroll
+    def "configures CycloneDX SBOM defaults when plugins are applied in #order order"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                ${plugins}
+            }
+
+            group = 'example'
+            version = '1.0.0'
+
+            $repositoriesBlock
+
+            micronaut {
+                version "$micronautVersion"
+            }
+
+            dependencies {
+                runtimeOnly 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+                testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.3'
+            }
+        """
+
+        when:
+        def result = build("cyclonedxDirectBom")
+        def sbom = file("build/reports/micronaut/sbom/application.cdx.json")
+        def json = new JsonSlurper().parse(sbom)
+        def text = sbom.text
+
+        then:
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+        sbom.exists()
+        !file("build/reports/micronaut/sbom/application.cdx.xml").exists()
+        json.bomFormat == "CycloneDX"
+        json.metadata.component.name == "hello-world"
+        text.contains("jackson-databind")
+        !text.contains("junit-jupiter-api")
+
+        where:
+        order                | plugins
+        "Micronaut first"    | "id 'io.micronaut.application'\n                id 'org.cyclonedx.bom' version '3.2.4'"
+        "CycloneDX first"    | "id 'org.cyclonedx.bom' version '3.2.4'\n                id 'io.micronaut.application'"
+    }
+
+    def "packages CycloneDX SBOM in the JVM jar when enabled"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id 'io.micronaut.application'
+                id 'org.cyclonedx.bom' version '3.2.4'
+            }
+
+            group = 'example'
+            version = '1.0.0'
+
+            $repositoriesBlock
+
+            micronaut {
+                version "$micronautVersion"
+                sbom {
+                    includeInJar.set(true)
+                }
+            }
+        """
+
+        when:
+        def result = build("jar")
+        def jarFile = file("build/libs/hello-world-1.0.0.jar")
+        def jar = new JarFile(jarFile)
+        def manifest = jar.manifest.mainAttributes
+
+        then:
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+        result.task(":jar").outcome == TaskOutcome.SUCCESS
+        jar.getEntry("META-INF/sbom/application.cdx.json") != null
+        manifest.getValue("Micronaut-SBOM-Format") == "CycloneDX JSON"
+        manifest.getValue("Micronaut-SBOM-Location") == "META-INF/sbom/application.cdx.json"
+
+        cleanup:
+        jar?.close()
+    }
+
+    def "packages CycloneDX SBOM in runner jar when enabled"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id 'io.micronaut.application'
+                id 'org.cyclonedx.bom' version '3.2.4'
+            }
+
+            group = 'example'
+            version = '1.0.0'
+
+            $repositoriesBlock
+
+            micronaut {
+                version "$micronautVersion"
+                sbom {
+                    includeInJar.set(true)
+                }
+            }
+
+            application {
+                mainClass.set("example.Application")
+            }
+        """
+        testProjectDir.newFolder("src", "main", "java", "example")
+        testProjectDir.newFile("src/main/java/example/Application.java") << """
+package example;
+
+public class Application {
+    public static void main(String... args) {
+    }
+}
+"""
+
+        when:
+        def result = build("runnerJar")
+        def jarFile = file("build/libs/hello-world-1.0.0-runner.jar")
+        def jar = new JarFile(jarFile)
+        def manifest = jar.manifest.mainAttributes
+
+        then:
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+        result.task(":runnerJar").outcome == TaskOutcome.SUCCESS
+        jar.getEntry("META-INF/sbom/application.cdx.json") != null
+        manifest.getValue("Micronaut-SBOM-Format") == "CycloneDX JSON"
+        manifest.getValue("Micronaut-SBOM-Location") == "META-INF/sbom/application.cdx.json"
+
+        cleanup:
+        jar?.close()
+    }
+
+    def "does not package or generate an SBOM from jar by default"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id 'io.micronaut.application'
+                id 'org.cyclonedx.bom' version '3.2.4'
+            }
+
+            group = 'example'
+            version = '1.0.0'
+
+            $repositoriesBlock
+
+            micronaut {
+                version "$micronautVersion"
+            }
+        """
+
+        when:
+        def result = build("jar")
+        def jarFile = file("build/libs/hello-world-1.0.0.jar")
+        def jar = new JarFile(jarFile)
+        def manifest = jar.manifest.mainAttributes
+
+        then:
+        result.task(":jar").outcome == TaskOutcome.SUCCESS
+        result.task(":cyclonedxDirectBom") == null
+        jar.getEntry("META-INF/sbom/application.cdx.json") == null
+        manifest.getValue("Micronaut-SBOM-Format") == null
+        manifest.getValue("Micronaut-SBOM-Location") == null
+
+        cleanup:
+        jar?.close()
+    }
+
+    def "CycloneDX generation is compatible with configuration cache"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id 'io.micronaut.application'
+                id 'org.cyclonedx.bom' version '3.2.4'
+            }
+
+            group = 'example'
+            version = '1.0.0'
+
+            $repositoriesBlock
+
+            micronaut {
+                version "$micronautVersion"
+            }
+        """
+
+        when:
+        def result = build("cyclonedxDirectBom", "--configuration-cache")
+
+        then:
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+        result.output.contains("Configuration cache entry stored")
+        file("build/reports/micronaut/sbom/application.cdx.json").exists()
+    }
+
+    def "can configure CycloneDX XML output directly"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id 'io.micronaut.application'
+                id 'org.cyclonedx.bom' version '3.2.4'
+            }
+
+            group = 'example'
+            version = '1.0.0'
+
+            $repositoriesBlock
+
+            micronaut {
+                version "$micronautVersion"
+            }
+
+            tasks.named("cyclonedxDirectBom") {
+                xmlOutput.set(layout.buildDirectory.file("reports/micronaut/sbom/application.cdx.xml"))
+            }
+        """
+
+        when:
+        def result = build("cyclonedxDirectBom")
+
+        then:
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+        file("build/reports/micronaut/sbom/application.cdx.json").exists()
+        file("build/reports/micronaut/sbom/application.cdx.xml").exists()
+    }
+
+    def "can disable Micronaut CycloneDX defaults"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id 'io.micronaut.application'
+                id 'org.cyclonedx.bom' version '3.2.4'
+            }
+
+            $repositoriesBlock
+
+            micronaut {
+                version "$micronautVersion"
+                sbom {
+                    enabled.set(false)
+                }
+            }
+        """
+
+        when:
+        def result = build("cyclonedxDirectBom")
+
+        then:
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+        !file("build/reports/micronaut/sbom/application.cdx.json").exists()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ mockserver = "5.15.0"
 log4j2 = "2.25.4"
 tomlj = "1.1.1"
 openrewrite = "7.32.2"
+cyclonedx = "3.2.4"
 
 micronaut-platform = "4.10.13" # This is the platform version, used in our tests
 micronaut-aot = "3.0.0-RC1"
@@ -32,6 +33,7 @@ diffplugPlugin = { module = "com.diffplug.gradle:goomph", version.ref = "diffplu
 shadowPlugin = { module = "com.gradleup.shadow:shadow-gradle-plugin", version.ref = "shadow" }
 graalvmPlugin = { module = "org.graalvm.buildtools:native-gradle-plugin", version.ref = "graalvmPlugin" }
 openrewritePlugin = { module = "org.openrewrite.rewrite:org.openrewrite.rewrite.gradle.plugin", version.ref = "openrewrite" }
+cyclonedxPlugin = { module = "org.cyclonedx:cyclonedx-gradle-plugin", version.ref = "cyclonedx" }
 
 kotlin-allopen = { module = "org.jetbrains.kotlin:kotlin-allopen", version.ref = "kotlin" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/minimal-plugin/build.gradle
+++ b/minimal-plugin/build.gradle
@@ -16,6 +16,7 @@ micronautPlugins {
 dependencies {
     compileOnly libs.bundles.optionalPlugins
     compileOnly libs.shadowPlugin
+    compileOnly libs.cyclonedxPlugin
 
     testFixturesImplementation gradleTestKit()
     testFixturesImplementation libs.groovy.core

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/CycloneDxSbomSupport.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/CycloneDxSbomSupport.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2003-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle;
+
+import org.cyclonedx.gradle.CyclonedxDirectTask;
+import org.cyclonedx.model.Component;
+import org.gradle.api.Project;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.jvm.tasks.Jar;
+
+import java.util.Map;
+
+final class CycloneDxSbomSupport {
+    private static final String CYCLONEDX_PLUGIN_ID = "org.cyclonedx.bom";
+    private static final String CYCLONEDX_DIRECT_BOM_TASK = "cyclonedxDirectBom";
+    private static final String SBOM_FORMAT = "CycloneDX JSON";
+    private static final String SBOM_FORMAT_ATTRIBUTE = "Micronaut-SBOM-Format";
+    private static final String SBOM_LOCATION_ATTRIBUTE = "Micronaut-SBOM-Location";
+
+    private CycloneDxSbomSupport() {
+    }
+
+    static void configure(Project project, String projectType) {
+        MicronautExtension micronaut = project.getExtensions().getByType(MicronautExtension.class);
+        MicronautSbomExtension sbom = micronaut.getSbom();
+        sbom.getOutputDirectory().convention(project.getLayout().getBuildDirectory().dir("reports/micronaut/sbom"));
+
+        project.getPluginManager().withPlugin(CYCLONEDX_PLUGIN_ID, unused -> {
+            project.afterEvaluate(evaluatedProject -> {
+                if (sbom.getEnabled().get()) {
+                    Provider<RegularFile> sbomFile = sbom.getOutputDirectory().file(sbom.getOutputFileName());
+                    TaskProvider<CyclonedxDirectTask> cyclonedxDirectBom = project.getTasks()
+                        .named(CYCLONEDX_DIRECT_BOM_TASK, CyclonedxDirectTask.class, task -> {
+                            task.getJsonOutput().convention(sbomFile);
+                            task.getXmlOutput().unsetConvention();
+                            task.getIncludeConfigs().convention(sbom.getIncludeConfigurations());
+                            task.getSkipConfigs().convention(sbom.getSkipConfigurations());
+                            task.getProjectType().convention(Component.Type.valueOf(projectType));
+                            task.getIncludeBuildEnvironment().convention(false);
+                            task.getIncludeBuildSystem().convention(false);
+                            task.getIncludeBomSerialNumber().convention(false);
+                            task.getIncludeLicenseText().convention(false);
+                        });
+                    configureJarPackaging(project, sbom, sbomFile, cyclonedxDirectBom);
+                }
+            });
+        });
+    }
+
+    private static void configureJarPackaging(Project project,
+                                              MicronautSbomExtension sbom,
+                                              Provider<RegularFile> sbomFile,
+                                              TaskProvider<CyclonedxDirectTask> cyclonedxDirectBom) {
+        if (!sbom.getIncludeInJar().get()) {
+            return;
+        }
+        String sbomPathInJar = sbom.getSbomPathInJar().get();
+        project.getTasks().named("jar", Jar.class, jar -> configureJar(jar, sbomFile, cyclonedxDirectBom, sbomPathInJar));
+        project.getTasks().withType(Jar.class).configureEach(jar -> {
+            if ("runnerJar".equals(jar.getName())) {
+                configureJar(jar, sbomFile, cyclonedxDirectBom, sbomPathInJar);
+            }
+        });
+    }
+
+    private static void configureJar(Jar jar,
+                                     Provider<RegularFile> sbomFile,
+                                     TaskProvider<CyclonedxDirectTask> cyclonedxDirectBom,
+                                     String sbomPathInJar) {
+        jar.dependsOn(cyclonedxDirectBom);
+        jar.from(sbomFile, copySpec -> {
+            copySpec.into(directoryOf(sbomPathInJar));
+            copySpec.rename(name -> fileNameOf(sbomPathInJar));
+        });
+        jar.getManifest().attributes(Map.of(
+            SBOM_FORMAT_ATTRIBUTE, SBOM_FORMAT,
+            SBOM_LOCATION_ATTRIBUTE, sbomPathInJar
+        ));
+    }
+
+    private static String directoryOf(String path) {
+        int index = path.lastIndexOf('/');
+        return index < 0 ? "" : path.substring(0, index);
+    }
+
+    private static String fileNameOf(String path) {
+        int index = path.lastIndexOf('/');
+        return index < 0 ? path : path.substring(index + 1);
+    }
+}

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
@@ -25,6 +25,7 @@ public abstract class MicronautExtension implements ExtensionAware {
     private final Property<Boolean> enableNativeImage;
     private final Property<MicronautRuntime> runtime;
     private final Property<MicronautTestRuntime> testRuntime;
+    private final MicronautSbomExtension sbom;
 
     /**
      * If set to false, then the Micronaut Gradle plugins will not automatically
@@ -55,6 +56,7 @@ public abstract class MicronautExtension implements ExtensionAware {
                                     .convention(MicronautRuntime.NONE);
         this.testRuntime = objectFactory.property(MicronautTestRuntime.class)
                                         .convention(MicronautTestRuntime.NONE);
+        this.sbom = objectFactory.newInstance(MicronautSbomExtension.class);
         getImportMicronautPlatform().convention(true);
     }
 
@@ -163,6 +165,23 @@ public abstract class MicronautExtension implements ExtensionAware {
 
     public AnnotationProcessing getProcessing() {
         return processing;
+    }
+
+    /**
+     * @return the Micronaut SBOM integration settings.
+     */
+    public MicronautSbomExtension getSbom() {
+        return sbom;
+    }
+
+    /**
+     * Allows configuring Micronaut SBOM integration.
+     * @param sbomAction The SBOM configuration action
+     * @return This extension
+     */
+    public MicronautExtension sbom(Action<MicronautSbomExtension> sbomAction) {
+        sbomAction.execute(this.getSbom());
+        return this;
     }
 
     /**

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
@@ -70,6 +70,7 @@ public class MicronautMinimalApplicationPlugin implements Plugin<Project> {
         configureLogging(project);
         configureMicronautRuntime(project);
         configureJavaExecTasks(project, developmentOnly);
+        CycloneDxSbomSupport.configure(project, "APPLICATION");
     }
 
 

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalLibraryPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalLibraryPlugin.java
@@ -30,5 +30,6 @@ public class MicronautMinimalLibraryPlugin implements Plugin<Project> {
         PluginManager plugins = project.getPluginManager();
         plugins.apply(JavaLibraryPlugin.class);
         plugins.apply(MicronautComponentPlugin.class);
+        CycloneDxSbomSupport.configure(project, "LIBRARY");
     }
 }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautSbomExtension.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautSbomExtension.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2003-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle;
+
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+
+import javax.inject.Inject;
+import java.util.List;
+
+/**
+ * Configures Micronaut SBOM generation defaults.
+ *
+ * @since 5.0.0
+ */
+public abstract class MicronautSbomExtension {
+    static final String DEFAULT_OUTPUT_FILE_NAME = "application.cdx.json";
+    static final String DEFAULT_PATH_IN_JAR = "META-INF/sbom/" + DEFAULT_OUTPUT_FILE_NAME;
+
+    /**
+     * @return Whether Micronaut should configure supported SBOM plugins.
+     */
+    public abstract Property<Boolean> getEnabled();
+
+    /**
+     * @return Whether generated SBOMs should be included in JVM JAR artifacts.
+     */
+    public abstract Property<Boolean> getIncludeInJar();
+
+    /**
+     * @return The Micronaut-owned SBOM reports directory.
+     */
+    public abstract DirectoryProperty getOutputDirectory();
+
+    /**
+     * @return The generated CycloneDX JSON file name.
+     */
+    public abstract Property<String> getOutputFileName();
+
+    /**
+     * @return The Gradle configurations included in the generated SBOM.
+     */
+    public abstract ListProperty<String> getIncludeConfigurations();
+
+    /**
+     * @return The Gradle configurations skipped by the generated SBOM.
+     */
+    public abstract ListProperty<String> getSkipConfigurations();
+
+    /**
+     * @return The SBOM path inside JVM JAR artifacts.
+     */
+    public abstract Property<String> getSbomPathInJar();
+
+    @Inject
+    public MicronautSbomExtension(ObjectFactory objects) {
+        getEnabled().convention(true);
+        getIncludeInJar().convention(false);
+        getOutputFileName().convention(DEFAULT_OUTPUT_FILE_NAME);
+        getIncludeConfigurations().convention(List.of("runtimeClasspath"));
+        getSkipConfigurations().convention(List.of());
+        getSbomPathInJar().convention(DEFAULT_PATH_IN_JAR);
+    }
+}

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1418,6 +1418,142 @@ plugins {
 }
 ----
 
+=== CycloneDX software bill of materials
+
+The Micronaut application and library plugins configure CycloneDX defaults when you apply the https://plugins.gradle.org/plugin/org.cyclonedx.bom[`org.cyclonedx.bom`] plugin.
+Micronaut does not apply the CycloneDX plugin automatically.
+
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+plugins {
+    id "io.micronaut.application" version "{gradle-project-version}"
+    id "org.cyclonedx.bom" version "{cyclonedx-version}"
+}
+
+micronaut {
+    version "{micronaut-version}"
+}
+----
+
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+plugins {
+    id("io.micronaut.application") version "{gradle-project-version}"
+    id("org.cyclonedx.bom") version "{cyclonedx-version}"
+}
+
+micronaut {
+    version.set("{micronaut-version}")
+}
+----
+
+Generate the per-project CycloneDX SBOM with:
+
+[source,bash]
+----
+./gradlew cyclonedxDirectBom
+----
+
+By default, Micronaut configures `cyclonedxDirectBom` to write a CycloneDX JSON SBOM to `build/reports/micronaut/sbom/application.cdx.json`.
+The default included configuration is `runtimeClasspath`, so production runtime dependencies are included and test-only configurations are not.
+
+You can configure the Micronaut defaults with `micronaut { sbom { ... } }`:
+
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+micronaut {
+    sbom {
+        enabled.set(true)
+        outputDirectory.set(layout.buildDirectory.dir("reports/micronaut/sbom"))
+        outputFileName.set("application.cdx.json")
+        includeConfigurations.set(["runtimeClasspath"])
+        skipConfigurations.set([])
+    }
+}
+----
+
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+micronaut {
+    sbom {
+        enabled.set(true)
+        outputDirectory.set(layout.buildDirectory.dir("reports/micronaut/sbom"))
+        outputFileName.set("application.cdx.json")
+        includeConfigurations.set(listOf("runtimeClasspath"))
+        skipConfigurations.set(emptyList())
+    }
+}
+----
+
+Set `enabled` to `false` if you want to apply and configure the CycloneDX plugin yourself without Micronaut changing its task defaults.
+Users who need XML output or other CycloneDX-specific settings can configure the CycloneDX task directly.
+
+==== Packaging the SBOM in a JAR
+
+JAR packaging is disabled by default.
+Enable it with `includeInJar`:
+
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+micronaut {
+    sbom {
+        includeInJar.set(true)
+    }
+}
+----
+
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+micronaut {
+    sbom {
+        includeInJar.set(true)
+    }
+}
+----
+
+When enabled, the `jar` task packages the generated SBOM at `META-INF/sbom/application.cdx.json` and records these manifest attributes:
+
+* `Micronaut-SBOM-Format: CycloneDX JSON`
+* `Micronaut-SBOM-Location: META-INF/sbom/application.cdx.json`
+
+You can verify the packaged SBOM with:
+
+[source,bash]
+----
+jar tf build/libs/<app>.jar | grep META-INF/sbom
+unzip -p build/libs/<app>.jar META-INF/MANIFEST.MF | grep Micronaut-SBOM
+----
+
+You can change the packaged path with `sbomPathInJar`:
+
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+micronaut {
+    sbom {
+        includeInJar.set(true)
+        sbomPathInJar.set("META-INF/sbom/application.cdx.json")
+    }
+}
+----
+
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+micronaut {
+    sbom {
+        includeInJar.set(true)
+        sbomPathInJar.set("META-INF/sbom/application.cdx.json")
+    }
+}
+----
+
+This first iteration produces an SBOM artifact and can package it into JVM JARs.
+It does not modify native executables, Docker image metadata, buildpacks image metadata, or OCI labels.
+For native-image, Docker, and buildpacks workflows, publish the generated SBOM next to the built artifact, or rely on the packaged JVM JAR path when that JAR is the image input.
+
+SBOMs expose dependency and component metadata.
+Treat them as release artifacts and publish them only to intended artifact repositories, registries, or compliance systems.
+An SBOM is not a signature, attestation, vulnerability scan, or provenance statement.
+
 == Micronaut GraalVM Plugin
 
 The https://plugins.gradle.org/plugin/io.micronaut.graalvm[Micronaut GraalVM plugin] is applied automatically by the


### PR DESCRIPTION
## Summary

- React to user-applied `org.cyclonedx.bom` from Micronaut application and library plugins with stable CycloneDX JSON SBOM defaults.
- Add `micronaut { sbom { ... } }` settings plus opt-in JAR packaging under `META-INF/sbom/application.cdx.json` with manifest metadata.
- Document the workflow and cover plugin order, CycloneDX-absent behavior, runtime dependency scope, standard JAR and runner JAR packaging, disable path, configuration cache, and direct CycloneDX XML override.

## Paperclip / Issue Linkage

- Paperclip issue: DEV-372.
- GitHub issue linkage: none. This is a manual-origin Paperclip issue, so no GitHub closing keyword or issue-creator reviewer is required.
- Type label: `type: enhancement`.
- Micronaut organization project: `5.2.0 Release`.
- Target branch: `master`, the active development branch for this repository. `master` has received the feature work merged since the `5.0.x` releases, while `5.1.x` has had no commits since it was created, so this enhancement stays on `master` and the earlier `5.1.x` targeting note in this description was incorrect.

## Verification

- `master` has been merged forward into this branch (merge commit `df90c7d9`) so the change applies cleanly on top of current `master`.
- `git diff --check origin/master..HEAD`
- `./gradlew :functional-tests:test --tests 'io.micronaut.gradle.sbom.CycloneDxSbomFunctionalTest' --rerun-tasks` re-run on the merged head: 10 tests passed, 0 failures.
- `./gradlew :micronaut-minimal-plugin:check` (41 tests passed) on the pre-merge head.
- `./gradlew docs`
- CI on the merged head is green: `Java CI / build (25)`, `GraalVM Latest CI / build`, `GraalVM Latest CI / build_matrix`, both test reports, and `license/cla`.
- All review threads are resolved; the diff against `master` remains limited to the 10 SBOM files.

## PR Assets

No rendered output or binary asset upload is required for this source, test, and AsciiDoc documentation change.

---
###### ✨ This pull request description was AI-generated using claude-opus-5