### PR TITLE
Pin token-bearing workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ secrets.GH_TOKEN }}
-      - uses: gradle/actions/wrapper-validation@v6
+      - uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -41,7 +41,7 @@ jobs:
             .github/scripts/vulnerability-audit.sh
           fi
       - name: Run pre-release
-        uses: micronaut-projects/github-actions/pre-release@master
+        uses: micronaut-projects/github-actions/pre-release@300bf6db7c062dcba77c90bb90e475df31b2acab # master
         env:
           MICRONAUT_BUILD_EMAIL: ${{ secrets.MICRONAUT_BUILD_EMAIL }}
         with:
@@ -56,14 +56,14 @@ jobs:
         run: ./gradlew -Pgradle.publish.key="$PUBLISH_KEY" -Pgradle.publish.secret="$PUBLISH_SECRET" publishPlugins docs
       - name: Run post-release
         if: success()
-        uses: micronaut-projects/github-actions/post-release@master
+        uses: micronaut-projects/github-actions/post-release@300bf6db7c062dcba77c90bb90e475df31b2acab # master
         env:
           MICRONAUT_BUILD_EMAIL: ${{ secrets.MICRONAUT_BUILD_EMAIL }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to Github Pages
         if: success()
-        uses: micronaut-projects/github-pages-deploy-action@master
+        uses: micronaut-projects/github-pages-deploy-action@76d63aafbab7108d74e83be4e5b3b0501382e829 # master
         env:
           BETA: ${{ contains(steps.release_version.outputs.release_version, 'M') || contains(steps.release_version.outputs.release_version, 'RC') }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -76,7 +76,7 @@ jobs:
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
       - name: Run post-release
         if: success()
-        uses: micronaut-projects/github-actions/post-release@master
+        uses: micronaut-projects/github-actions/post-release@300bf6db7c062dcba77c90bb90e475df31b2acab # master
         env:
           MICRONAUT_BUILD_EMAIL: ${{ secrets.MICRONAUT_BUILD_EMAIL }}
         with:

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ secrets.GH_TOKEN }}
       - name: "Update Gradle Wrapper"
@@ -23,10 +23,10 @@ jobs:
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
         run: |
           latest=`curl -s https://services.gradle.org/versions/current | jq -cr ".version"`
-          echo ::set-output name=latest_version::${latest}
+          echo "latest_version=${latest}" >> $GITHUB_OUTPUT
           ./gradlew wrapper --gradle-version $latest
-      - uses: gradle/actions/wrapper-validation@v6
-      - uses: stefanzweifel/git-auto-commit-action@v7.1.0
+      - uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: Upgrade Gradle Wrapper to ${{ steps.update.outputs.latest_version }}
           commit_user_name: micronaut-build


### PR DESCRIPTION
## Summary
- Pin token-bearing actions in the release and update-wrapper workflows to immutable SHAs.
- Replace the deprecated update-wrapper `::set-output` call with `$GITHUB_OUTPUT`.
- Preserve Gradle Plugin Portal publishing and avoid importing standard-module Maven Central release behavior from the template.

## Template Applicability
Applied:
- Release workflow action pinning for checkout, wrapper validation, Java setup, Micronaut release helpers, and GitHub Pages deploy.
- Update-wrapper workflow action pinning and output syntax modernization.

Skipped:
- Template `files-sync.yml` and `skills-validation.yml`, because this repository does not have those workflows.
- Maven Central/Sonatype/module release changes, because this repository publishes through the Gradle Plugin Portal.
- Wrapper, plugin marker metadata, TestKit, source, docs, sample, and compatibility-matrix changes, because this pass is workflow-only.

## Compatibility and Risk
- No plugin source, build logic, dependency resolution, publishing task implementation, docs, samples, wrapper files, or plugin marker metadata changed.
- The publish command remains `./gradlew -Pgradle.publish.key="$PUBLISH_KEY" -Pgradle.publish.secret="$PUBLISH_SECRET" publishPlugins docs`.
- No linked GitHub issue exists for this routine run. Paperclip issue: `DEV-514`; GitHub closing keyword and linked-issue reporter reviewer are not applicable.
- QA did not record a selected Micronaut organization project. Live Micronaut organization projects were checked, but no unambiguous Gradle Plugin release project was selected or applied.

## Verification
- `git fetch origin master DEV-514-manually-apply-template-changes-to-the-micronaut-gradle-plugin --prune`
- `git rebase origin/master`
- `git diff --check origin/master...HEAD`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "parsed #{f}" }' .github/workflows/release.yml .github/workflows/update-gradle-wrapper.yml`
- `awk` check that every changed `uses:` ref in the touched workflows is a 40-character SHA
- `git ls-remote` checks for the pinned source refs listed in the workflow comments

No Gradle task was run because this is restricted to GitHub Actions workflow metadata/output syntax and does not change plugin behavior.

---
###### ✨ This message was AI-generated using gpt-5
