### PR TITLE
docs: correct OpenAPI generated source paths

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -2183,7 +2183,7 @@ micronaut {
 
 The `io.micronaut.openapi` plugin adds support for generating https://www.openapis.org/[OpenAPI] clients or servers, given an OpenAPI definition, in both Java and Kotlin.
 
-The plugin adds an link:api/io/micronaut/gradle/openapi/OpenApiExtension.html[openapi] extension to the `micronaut` configuration block.
+The plugin adds a link:api/io/micronaut/gradle/openapi/OpenApiExtension.html[openapi] extension to the `micronaut` configuration block.
 
 === Generating a client
 
@@ -2221,7 +2221,7 @@ micronaut {
 }
 ----
 
-The generated sources will be found by default in your `$buildDir/generated/openapi/client` directory, and automatically added to your main source set (so the classes are directly available for you to use).
+The generated API and model sources are written by default under task-specific directories in `$buildDir/generated/openapi`, such as `generateClientOpenApiApis` and `generateClientOpenApiModels`, and automatically added to your main source set (so the classes are directly available for you to use).
 
 You can generate multiple clients by adding multiple `client` blocks, in which case each client is identified by a name:
 
@@ -2319,7 +2319,7 @@ micronaut {
 }
 ----
 
-The generated sources will be found by default in your `$buildDir/generated/openapi/server` directory, and automatically added to your main source set (so the classes are directly available for you to use).
+The generated API and model sources are written by default under task-specific directories in `$buildDir/generated/openapi`, such as `generateServerOpenApiApis` and `generateServerOpenApiModels`, and automatically added to your main source set (so the classes are directly available for you to use).
 
 You can generate multiple servers by providing a name to the `server` block:
 


### PR DESCRIPTION
## Summary

- Correct the OpenAPI guide's generated source directory guidance to match the plugin's task-specific output directories.
- Fix the article before the OpenAPI extension API link.

## Validation

- `./gradlew publishGuide` was attempted for the weekly guide review requirement and failed because this repository has no `publishGuide` task.
- `./gradlew docs` passed and rendered the updated OpenAPI text in `build/docs/index.html`.
- `./gradlew :micronaut-openapi-plugin:test --tests 'io.micronaut.openapi.gradle.OpenApiClientGeneratorSpec.can generate an java OpenAPI client implementation' --tests 'io.micronaut.openapi.gradle.OpenApiServerGeneratorSpec.can generate an java OpenAPI server implementation'` passed, confirming the generated client/server task output paths referenced by the guide.

Paperclip: DEV-548 Weekly User Guide Review: Micronaut Gradle Plugin

---
###### ✨ This message was AI-generated using gpt-5.5
