### PR TITLE
Add generic OpenAPI generator support

### DIFF
--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/DefaultOpenApiExtension.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/DefaultOpenApiExtension.java
@@ -18,6 +18,7 @@ package io.micronaut.gradle.openapi;
 import io.micronaut.gradle.PluginsHelper;
 import io.micronaut.gradle.openapi.tasks.AbstractOpenApiGenerator;
 import io.micronaut.gradle.openapi.tasks.OpenApiClientGenerator;
+import io.micronaut.gradle.openapi.tasks.OpenApiGenericGenerator;
 import io.micronaut.gradle.openapi.tasks.OpenApiServerGenerator;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
@@ -35,6 +36,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -66,6 +68,12 @@ public abstract class DefaultOpenApiExtension implements OpenApiExtension {
     public void client(File file, Action<? super OpenApiClientSpec> spec) {
         var regularFileProperty = project.getObjects().fileProperty();
         client("client", regularFileProperty.fileValue(file), spec);
+    }
+
+    @Override
+    public void generic(File file, Action<? super OpenApiGenericSpec> spec) {
+        var regularFileProperty = project.getObjects().fileProperty();
+        generic("generic", regularFileProperty.fileValue(file), spec);
     }
 
     @Override
@@ -278,6 +286,37 @@ public abstract class DefaultOpenApiExtension implements OpenApiExtension {
         task.getUserParameterMode().convention(openApiSpec.getUserParameterMode());
     }
 
+    @Override
+    public void generic(String name, Provider<RegularFile> definition, Action<? super OpenApiGenericSpec> spec) {
+        if (names.add(name)) {
+            var genericSpec = project.getObjects().newInstance(OpenApiGenericSpec.class);
+            configureCommonExtensionDefaults(genericSpec);
+            genericSpec.getGeneratorProperties().convention(Map.of());
+            genericSpec.getOutputKinds().convention(List.of(CodegenConstants.APIS, CodegenConstants.MODELS, CodegenConstants.SUPPORTING_FILES));
+
+            spec.execute(genericSpec);
+            var generic = project.getTasks().register(generateGenericTaskName(name), OpenApiGenericGenerator.class, task -> {
+                configureCommonProperties(name, task, genericSpec, definition);
+                task.setDescription("Generates sources with a custom Micronaut OpenAPI generator");
+                task.getGeneratorClassName().convention(genericSpec.getGeneratorClassName());
+                task.getGeneratorProperties().convention(genericSpec.getGeneratorProperties());
+                task.getOutputKinds().convention(genericSpec.getOutputKinds());
+            });
+            withJavaSourceSets(sourceSets -> {
+                var javaMain = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).getJava();
+                javaMain.srcDir(generic.flatMap(DefaultOpenApiExtension::mainSrcDir));
+                project.getPluginManager().withPlugin("org.jetbrains.kotlin.jvm", unused -> {
+                    var ext = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).getExtensions().getByName("kotlin");
+                    if (ext instanceof SourceDirectorySet kotlinMain) {
+                        kotlinMain.srcDir(generic.flatMap(d -> DefaultOpenApiExtension.mainSrcDir(d, "kotlin")));
+                    }
+                });
+            });
+        } else {
+            throwDuplicateEntryFor(name);
+        }
+    }
+
     private void withJavaSourceSets(Consumer<? super SourceSetContainer> consumer) {
         project.getPlugins().withId("java", unused -> consumer.accept(PluginsHelper.findSourceSets(project)));
     }
@@ -353,6 +392,11 @@ public abstract class DefaultOpenApiExtension implements OpenApiExtension {
         client(name, project.getObjects().fileProperty().fileValue(definition), spec);
     }
 
+    @Override
+    public void generic(String name, File definition, Action<? super OpenApiGenericSpec> spec) {
+        generic(name, project.getObjects().fileProperty().fileValue(definition), spec);
+    }
+
     private static Provider<Directory> mainSrcDir(AbstractOpenApiGenerator<?, ?> t, String language) {
         return t.getOutputDirectory().dir("src/main/" + language);
     }
@@ -390,6 +434,10 @@ public abstract class DefaultOpenApiExtension implements OpenApiExtension {
 
     private static String generateApisTaskName(String name) {
         return "generate" + capitalize(name) + "OpenApiApis";
+    }
+
+    private static String generateGenericTaskName(String name) {
+        return "generate" + capitalize(name) + "OpenApi";
     }
 
     private static void configureServerTask(OpenApiServerSpec serverSpec, OpenApiServerGenerator task) {

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiExtension.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiExtension.java
@@ -48,6 +48,13 @@ public interface OpenApiExtension {
     void client(File file, Action<? super OpenApiClientSpec> spec);
 
     /**
+     * Configures generation with a custom Micronaut OpenAPI generator, given a definition file.
+     * @param file the OpenAPI definition file
+     * @param spec configuration for the generator
+     */
+    void generic(File file, Action<? super OpenApiGenericSpec> spec);
+
+    /**
      * Configures generation of a server, given a definition file.
      * @param name an identifier used to uniquely refer to the generator, used to derive task names
      * @param definition the OpenAPI definition file provider
@@ -64,6 +71,14 @@ public interface OpenApiExtension {
     void client(String name, Provider<RegularFile> definition, Action<? super OpenApiClientSpec> spec);
 
     /**
+     * Configures generation with a custom Micronaut OpenAPI generator, given a definition file.
+     * @param name an identifier used to uniquely refer to the generator, used to derive task names
+     * @param definition the OpenAPI definition file provider
+     * @param spec configuration for the generator
+     */
+    void generic(String name, Provider<RegularFile> definition, Action<? super OpenApiGenericSpec> spec);
+
+    /**
      * Configures generation of a server, given a definition file.
      * @param name an identifier used to uniquely refer to the generator, used to derive task names
      * @param definition the OpenAPI definition file provider
@@ -78,4 +93,12 @@ public interface OpenApiExtension {
      * @param spec configuration for the server generation
      */
     void client(String name, File definition, Action<? super OpenApiClientSpec> spec);
+
+    /**
+     * Configures generation with a custom Micronaut OpenAPI generator, given a definition file.
+     * @param name an identifier used to uniquely refer to the generator, used to derive task names
+     * @param definition the OpenAPI definition file provider
+     * @param spec configuration for the generator
+     */
+    void generic(String name, File definition, Action<? super OpenApiGenericSpec> spec);
 }

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiGenericSpec.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiGenericSpec.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle.openapi;
+
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+
+public interface OpenApiGenericSpec extends OpenApiSpec {
+
+    Property<String> getGeneratorClassName();
+
+    MapProperty<String, Object> getGeneratorProperties();
+
+    ListProperty<String> getOutputKinds();
+}

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiGenericSpec.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/OpenApiGenericSpec.java
@@ -21,9 +21,33 @@ import org.gradle.api.provider.Property;
 
 public interface OpenApiGenericSpec extends OpenApiSpec {
 
+    /**
+     * The fully qualified class name of the custom Micronaut OpenAPI generator.
+     *
+     * <p>The class must implement {@code io.micronaut.openapi.generator.MicronautCodeGenerator}
+     * and be available on the {@code openApiGenerator} classpath.</p>
+     *
+     * @return the custom generator class name
+     */
     Property<String> getGeneratorClassName();
 
+    /**
+     * Additional properties to apply to the custom generator options builder.
+     *
+     * <p>Each entry is matched against a builder method with the property name,
+     * {@code with<PropertyName>}, or {@code set<PropertyName>}.</p>
+     *
+     * @return the custom generator properties
+     */
     MapProperty<String, Object> getGeneratorProperties();
 
+    /**
+     * The OpenAPI generator output kinds to produce.
+     *
+     * <p>Common values are {@code apis}, {@code models}, and
+     * {@code supporting_files}.</p>
+     *
+     * @return the requested output kinds
+     */
     ListProperty<String> getOutputKinds();
 }

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/OpenApiGenericGenerator.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/OpenApiGenericGenerator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle.openapi.tasks;
+
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+
+public abstract class OpenApiGenericGenerator extends AbstractOpenApiGenerator<OpenApiGenericWorkAction, OpenApiGenericWorkAction.GenericParameters> {
+
+    @Input
+    public abstract Property<String> getGeneratorClassName();
+
+    @Input
+    public abstract MapProperty<String, Object> getGeneratorProperties();
+
+    @Override
+    protected Class<OpenApiGenericWorkAction> getWorkerAction() {
+        return OpenApiGenericWorkAction.class;
+    }
+
+    @Override
+    protected void configureWorkerParameters(OpenApiGenericWorkAction.GenericParameters params) {
+        params.getGeneratorClassName().set(getGeneratorClassName());
+        params.getGeneratorProperties().set(getGeneratorProperties());
+    }
+}

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/OpenApiGenericGenerator.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/OpenApiGenericGenerator.java
@@ -17,8 +17,10 @@ package io.micronaut.gradle.openapi.tasks;
 
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 
+@CacheableTask
 public abstract class OpenApiGenericGenerator extends AbstractOpenApiGenerator<OpenApiGenericWorkAction, OpenApiGenericWorkAction.GenericParameters> {
 
     @Input

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/OpenApiGenericWorkAction.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/OpenApiGenericWorkAction.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gradle.openapi.tasks;
+
+import io.micronaut.openapi.generator.GeneratorOptionsBuilder;
+import io.micronaut.openapi.generator.MicronautCodeGenerator;
+import io.micronaut.openapi.generator.MicronautCodeGeneratorBuilder;
+import org.gradle.api.GradleException;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Locale;
+import java.util.Map;
+
+public abstract class OpenApiGenericWorkAction extends AbstractOpenApiWorkAction<OpenApiGenericWorkAction.GenericParameters> {
+
+    protected interface GenericParameters extends OpenApiParameters {
+
+        Property<String> getGeneratorClassName();
+
+        MapProperty<String, Object> getGeneratorProperties();
+    }
+
+    @Override
+    protected void configureBuilder(MicronautCodeGeneratorBuilder builder) {
+        var params = getParameters();
+        builder.forCodeGenerator(instantiateGenerator(params.getGeneratorClassName().get()), config -> {
+            for (Map.Entry<String, Object> entry : params.getGeneratorProperties().getOrElse(Map.of()).entrySet()) {
+                invokeMethod(entry.getKey(), config, entry.getValue());
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private MicronautCodeGenerator<? extends GeneratorOptionsBuilder> instantiateGenerator(String generatorClassName) {
+        try {
+            var constructor = getClass()
+                .getClassLoader()
+                .loadClass(generatorClassName)
+                .getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return (MicronautCodeGenerator<? extends GeneratorOptionsBuilder>) constructor.newInstance();
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new GradleException("Unable to instantiate OpenAPI generator '" + generatorClassName + "'", e);
+        }
+    }
+
+    private static void invokeMethod(String name, GeneratorOptionsBuilder builder, Object value) {
+        String capitalizedName = Character.toUpperCase(name.charAt(0)) + name.substring(1);
+        String witherName = "with" + capitalizedName;
+        String setterName = "set" + capitalizedName;
+        Class<? extends GeneratorOptionsBuilder> builderClass = builder.getClass();
+        try {
+            for (Method method : builderClass.getMethods()) {
+                if (invokeIfMatches(name, builder, value, witherName, setterName, method)) {
+                    return;
+                }
+            }
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new GradleException("Unable to configure OpenAPI generator property '" + name + "'", e);
+        }
+        throw new GradleException("Unable to find a method on builder " + builderClass + " with name '" + name + "' which accepts argument '" + value + "'");
+    }
+
+    private static boolean invokeIfMatches(
+        String name,
+        GeneratorOptionsBuilder builder,
+        Object value,
+        String witherName,
+        String setterName,
+        Method method
+    ) throws IllegalAccessException, InvocationTargetException {
+        var methodName = method.getName();
+        if ((methodName.equals(name) || methodName.equals(witherName) || methodName.equals(setterName)) && method.getParameterCount() == 1) {
+            Object argument = coerceArgument(method.getParameterTypes()[0], value);
+            if (argument != null) {
+                method.setAccessible(true);
+                method.invoke(builder, argument);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Object coerceArgument(Class<?> parameterType, Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (parameterType.isInstance(value)) {
+            return value;
+        }
+        if (parameterType.equals(Boolean.TYPE) && value instanceof Boolean) {
+            return value;
+        }
+        if (parameterType.equals(Integer.TYPE) && value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String stringValue) {
+            if (parameterType.equals(String.class)) {
+                return stringValue;
+            }
+            if (parameterType.equals(Boolean.TYPE)) {
+                var coerced = stringValue.toLowerCase(Locale.US);
+                if ("true".equals(coerced) || "false".equals(coerced)) {
+                    return Boolean.parseBoolean(coerced);
+                }
+            }
+            if (parameterType.equals(Integer.TYPE) && stringValue.matches("[0-9]+")) {
+                return Integer.parseInt(stringValue);
+            }
+        }
+        return null;
+    }
+}

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/OpenApiGenericWorkAction.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/OpenApiGenericWorkAction.java
@@ -61,40 +61,47 @@ public abstract class OpenApiGenericWorkAction extends AbstractOpenApiWorkAction
     }
 
     private static void invokeMethod(String name, GeneratorOptionsBuilder builder, Object value) {
+        if (name == null || name.isBlank()) {
+            throw new GradleException("OpenAPI generator property name must not be blank");
+        }
         String capitalizedName = Character.toUpperCase(name.charAt(0)) + name.substring(1);
         String witherName = "with" + capitalizedName;
         String setterName = "set" + capitalizedName;
         Class<? extends GeneratorOptionsBuilder> builderClass = builder.getClass();
+        boolean methodNameFound = false;
         try {
             for (Method method : builderClass.getMethods()) {
-                if (invokeIfMatches(name, builder, value, witherName, setterName, method)) {
-                    return;
+                if (methodNameMatches(name, witherName, setterName, method)) {
+                    methodNameFound = true;
+                    Object argument = coerceArgument(method.getParameterTypes()[0], value);
+                    if (argument != null) {
+                        method.setAccessible(true);
+                        method.invoke(builder, argument);
+                        return;
+                    }
                 }
             }
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new GradleException("Unable to configure OpenAPI generator property '" + name + "'", e);
         }
-        throw new GradleException("Unable to find a method on builder " + builderClass + " with name '" + name + "' accepting a value of type '" + valueType(value) + "'. Supported value types are String, Boolean, and Integer.");
+        if (!methodNameFound) {
+            throw new GradleException("Unable to find a method on builder " + builderClass + " with name '" + name + "'");
+        }
+        throw new GradleException(
+            "Unable to find an overload on builder " + builderClass + " with name '" + name
+                + "' accepting a value of type '" + valueType(value)
+                + "'. Supported value types are String, Boolean, and Integer."
+        );
     }
 
-    private static boolean invokeIfMatches(
+    private static boolean methodNameMatches(
         String name,
-        GeneratorOptionsBuilder builder,
-        Object value,
         String witherName,
         String setterName,
         Method method
-    ) throws IllegalAccessException, InvocationTargetException {
+    ) {
         var methodName = method.getName();
-        if ((methodName.equals(name) || methodName.equals(witherName) || methodName.equals(setterName)) && method.getParameterCount() == 1) {
-            Object argument = coerceArgument(method.getParameterTypes()[0], value);
-            if (argument != null) {
-                method.setAccessible(true);
-                method.invoke(builder, argument);
-                return true;
-            }
-        }
-        return false;
+        return (methodName.equals(name) || methodName.equals(witherName) || methodName.equals(setterName)) && method.getParameterCount() == 1;
     }
 
     private static Object coerceArgument(Class<?> parameterType, Object value) {
@@ -104,27 +111,35 @@ public abstract class OpenApiGenericWorkAction extends AbstractOpenApiWorkAction
         if (parameterType.isInstance(value)) {
             return value;
         }
-        if (parameterType.equals(Boolean.TYPE) && value instanceof Boolean) {
+        if (isBoolean(parameterType) && value instanceof Boolean) {
             return value;
         }
-        if (parameterType.equals(Integer.TYPE) && value instanceof Number number) {
+        if (isInteger(parameterType) && value instanceof Number number) {
             return number.intValue();
         }
         if (value instanceof String stringValue) {
             if (parameterType.equals(String.class)) {
                 return stringValue;
             }
-            if (parameterType.equals(Boolean.TYPE)) {
+            if (isBoolean(parameterType)) {
                 var coerced = stringValue.toLowerCase(Locale.US);
                 if ("true".equals(coerced) || "false".equals(coerced)) {
                     return Boolean.parseBoolean(coerced);
                 }
             }
-            if (parameterType.equals(Integer.TYPE) && stringValue.matches("[0-9]+")) {
+            if (isInteger(parameterType) && stringValue.matches("[0-9]+")) {
                 return Integer.parseInt(stringValue);
             }
         }
         return null;
+    }
+
+    private static boolean isBoolean(Class<?> parameterType) {
+        return parameterType.equals(Boolean.TYPE) || parameterType.equals(Boolean.class);
+    }
+
+    private static boolean isInteger(Class<?> parameterType) {
+        return parameterType.equals(Integer.TYPE) || parameterType.equals(Integer.class);
     }
 
     private static String valueType(Object value) {

--- a/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/OpenApiGenericWorkAction.java
+++ b/openapi-plugin/src/main/java/io/micronaut/gradle/openapi/tasks/OpenApiGenericWorkAction.java
@@ -74,7 +74,7 @@ public abstract class OpenApiGenericWorkAction extends AbstractOpenApiWorkAction
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new GradleException("Unable to configure OpenAPI generator property '" + name + "'", e);
         }
-        throw new GradleException("Unable to find a method on builder " + builderClass + " with name '" + name + "' which accepts argument '" + value + "'");
+        throw new GradleException("Unable to find a method on builder " + builderClass + " with name '" + name + "' accepting a value of type '" + valueType(value) + "'. Supported value types are String, Boolean, and Integer.");
     }
 
     private static boolean invokeIfMatches(
@@ -125,5 +125,9 @@ public abstract class OpenApiGenericWorkAction extends AbstractOpenApiWorkAction
             }
         }
         return null;
+    }
+
+    private static String valueType(Object value) {
+        return value == null ? "null" : value.getClass().getName();
     }
 }

--- a/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiGenericGeneratorSpec.groovy
+++ b/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiGenericGeneratorSpec.groovy
@@ -117,8 +117,43 @@ class OpenApiGenericGeneratorSpec extends AbstractOpenApiGeneratorSpec {
 
         then:
         result.output.contains("missingSecretProperty")
-        result.output.contains("java.lang.String")
-        result.output.contains("Supported value types are String, Boolean, and Integer")
+        result.output.contains("Unable to find a method")
         !result.output.contains("super-secret-token-value")
+    }
+
+    def "generic OpenAPI generator property type mismatch reports supported value types"() {
+        given:
+        settingsFile << "rootProject.name = 'openapi-generic-type-mismatch'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.openapi"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+                testRuntime "junit5"
+                openapi {
+                    generic("pet", file("petstore.json")) {
+                        generatorClassName = "io.micronaut.openapi.generator.JavaMicronautClientCodegen"
+                        generatorProperties.put("retryableAttempts", true)
+                    }
+                }
+            }
+
+            $repositoriesBlock
+            application { mainClass = "example.Application" }
+        """
+
+        withPetstore()
+
+        when:
+        def result = fails('generatePetOpenApi')
+
+        then:
+        result.output.contains("retryableAttempts")
+        result.output.contains("java.lang.Boolean")
+        result.output.contains("Supported value types are String, Boolean, and Integer")
     }
 }

--- a/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiGenericGeneratorSpec.groovy
+++ b/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiGenericGeneratorSpec.groovy
@@ -1,0 +1,87 @@
+package io.micronaut.openapi.gradle
+
+import org.gradle.testkit.runner.TaskOutcome
+
+class OpenApiGenericGeneratorSpec extends AbstractOpenApiGeneratorSpec {
+
+    def "can generate sources with a generic OpenAPI generator"() {
+        given:
+        settingsFile << "rootProject.name = 'openapi-generic'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.openapi"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+                testRuntime "junit5"
+                openapi {
+                    generic("pet", file("petstore.json")) {
+                        generatorClassName = "io.micronaut.openapi.generator.JavaMicronautClientCodegen"
+                        outputKinds = ["models"]
+                        generatorProperties.put("retryable", "true")
+                        generatorProperties.put("retryableAttempts", "5")
+                        generatorProperties.put("clientId", "pet-client")
+                    }
+                }
+            }
+
+            $repositoriesBlock
+            application { mainClass = "example.Application" }
+        """
+
+        withPetstore()
+
+        when:
+        def result = build('generatePetOpenApi')
+
+        then:
+        result.task(":generatePetOpenApi").outcome == TaskOutcome.SUCCESS
+
+        and:
+        file("build/generated/openapi/generatePetOpenApi/src/main/java/io/micronaut/openapi/model/Pet.java").exists()
+    }
+
+    def "generic OpenAPI generated source directory is wired into the main source set"() {
+        given:
+        settingsFile << "rootProject.name = 'openapi-generic-source-set'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.openapi"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+                testRuntime "junit5"
+                openapi {
+                    generic("pet", file("petstore.json")) {
+                        generatorClassName = "io.micronaut.openapi.generator.JavaMicronautClientCodegen"
+                    }
+                }
+            }
+
+            $repositoriesBlock
+            application { mainClass = "example.Application" }
+
+            tasks.register("printMainJavaSourceDirs") {
+                doLast {
+                    sourceSets.main.java.srcDirs.each {
+                        println("sourceDir=" + it.path)
+                    }
+                }
+            }
+        """
+
+        withPetstore()
+
+        when:
+        def result = build('printMainJavaSourceDirs')
+
+        then:
+        result.output.contains("build/generated/openapi/generatePetOpenApi/src/main/java")
+    }
+}

--- a/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiGenericGeneratorSpec.groovy
+++ b/openapi-plugin/src/test/groovy/io/micronaut/openapi/gradle/OpenApiGenericGeneratorSpec.groovy
@@ -84,4 +84,41 @@ class OpenApiGenericGeneratorSpec extends AbstractOpenApiGeneratorSpec {
         then:
         result.output.contains("build/generated/openapi/generatePetOpenApi/src/main/java")
     }
+
+    def "generic OpenAPI generator property mismatch does not log raw property value"() {
+        given:
+        settingsFile << "rootProject.name = 'openapi-generic-mismatch'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.openapi"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+                testRuntime "junit5"
+                openapi {
+                    generic("pet", file("petstore.json")) {
+                        generatorClassName = "io.micronaut.openapi.generator.JavaMicronautClientCodegen"
+                        generatorProperties.put("missingSecretProperty", "super-secret-token-value")
+                    }
+                }
+            }
+
+            $repositoriesBlock
+            application { mainClass = "example.Application" }
+        """
+
+        withPetstore()
+
+        when:
+        def result = fails('generatePetOpenApi')
+
+        then:
+        result.output.contains("missingSecretProperty")
+        result.output.contains("java.lang.String")
+        result.output.contains("Supported value types are String, Boolean, and Integer")
+        !result.output.contains("super-secret-token-value")
+    }
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -2395,7 +2395,53 @@ micronaut {
 ----
 
 In addition, it exposes a `openApiGenerator` configuration which can be used to declare additional dependencies to put on the generator classpath.
-This can be useful in case you want to implement your own generators, in which case you will also have to implement custom tasks which extend the link:api/io/micronaut/gradle/openapi/tasks/AbstractOpenApiGenerator.html[AbstractOpenApiGenerator task type].
+This can be useful in case you want to implement your own generators.
+Custom Micronaut OpenAPI generators can be configured with the `generic { ... }` block:
+
+[source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
+----
+dependencies {
+    openApiGenerator("com.mycompany:my-openapi-generator:1.0.0")
+}
+
+micronaut {
+    ...
+    openapi {
+        generic("myGenerator", file("src/openapi/my-definition.yml")) {
+            generatorClassName = "com.mycompany.openapi.MyCodeGenerator"
+            outputKinds = ["apis", "models", "supporting_files"]
+            generatorProperties.put("apiPrefix", "Internal")
+            generatorProperties.put("retryable", true)
+            generatorProperties.put("retryableAttempts", 3)
+        }
+    }
+}
+----
+
+[source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
+----
+dependencies {
+    openApiGenerator("com.mycompany:my-openapi-generator:1.0.0")
+}
+
+micronaut {
+    ...
+    openapi {
+        generic("myGenerator", file("src/openapi/my-definition.yml")) {
+            generatorClassName.set("com.mycompany.openapi.MyCodeGenerator")
+            outputKinds.set(listOf("apis", "models", "supporting_files"))
+            generatorProperties.put("apiPrefix", "Internal")
+            generatorProperties.put("retryable", true)
+            generatorProperties.put("retryableAttempts", 3)
+        }
+    }
+}
+----
+
+The custom generator class must implement `io.micronaut.openapi.generator.MicronautCodeGenerator` and be available on the `openApiGenerator` classpath.
+`generatorProperties` entries are applied to the generator options builder by matching the property name, `with<PropertyName>`, or `set<PropertyName>`.
+String, boolean, and integer values are supported; string values are coerced to boolean or integer values when the matching builder method requires that type.
+By default, the generic task writes to `$buildDir/generated/openapi/<taskName>` and adds `src/main/java` or `src/main/kotlin` from that directory to the main source set.
 
 == Source Generator from Micronaut JSON Schema
 


### PR DESCRIPTION
## Summary
- Add an additive `openapi.generic(...)` Gradle DSL for custom Micronaut OpenAPI generators.
- Register a generic OpenAPI generation task that uses the `openApiGenerator` classpath, applies string/boolean/integer generator properties, and wires generated Java/Kotlin sources into the main source set.
- Document the custom generator DSL and add focused functional coverage, including the secret-safe property mismatch regression.

## Verification
- `git rebase origin/master`
- `git diff --check origin/master...HEAD`
- `git diff --check`
- `./gradlew :micronaut-openapi-plugin:test --tests 'io.micronaut.openapi.gradle.OpenApiGenericGeneratorSpec' --rerun-tasks`

## Release Targeting
- Paperclip issue: DEV-611
- Target branch: `5.1.x`
- Release line: `5.1.0-SNAPSHOT`
- Selected Micronaut organization project: `5.1.0 Release`
- No linked GitHub issue exists for this recovered Paperclip-originated feature, so no GitHub closing keyword or issue-author reviewer applies.

## PR Assets
No PR-visible rendered or generated artifact upload is required; the change is source, tests, and AsciiDoc guide text only.


---
###### ✨ This message was AI-generated using gpt-5.5