### PR TITLE
Add Java CI build job name

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,6 +15,7 @@ on:
       - '[1-9]+.[0-9]+.x'
 jobs:
   build:
+    name: "build"
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary

- Applies the current Micronaut Project Template `gradle.yml` build job display metadata to the Gradle Plugin repository.
- Adds only `jobs.build.name: "build"` under the existing Java CI `build` job.
- Leaves workflow triggers, permissions, runner, matrix, secrets, actions, Gradle commands, source, docs, publishing, and release automation unchanged.

## Verification

- `git fetch origin master:refs/remotes/origin/master`
- Confirmed the branch contains the fetched `origin/master` before PR creation.
- `git diff --check origin/master...HEAD`
- `ruby -e 'require "yaml"; data=YAML.load_file(".github/workflows/gradle.yml"); build=data.fetch("jobs").fetch("build"); abort("wrong build job name") unless build.fetch("name") == "build"; abort("missing steps") unless build.fetch("steps").any?; puts "build job name=#{build.fetch("name")}"'`

No Gradle test task was run because this is non-executable workflow display metadata only.

## Template Scope

Applied:

- `.github/workflows/gradle.yml`: explicit build job display name from the Micronaut Project Template.

Intentionally skipped:

- Template publishing or release assumptions for standard Micronaut modules.
- Wrapper, dependency, plugin-coordinate, action-pinning, broader CI hardening, source, sample, and documentation changes outside this single template delta.

## Issue Linkage And Metadata

- Paperclip issue: DEV-1106
- Linked GitHub issue: none found for this routine run; no GitHub closing keyword applies.
- Target branch: `master`
- Release target: patch-level CI maintenance for the current default branch line.
- Selected Micronaut organization project: `5.0.3 Release`, the current open patch Micronaut Platform BOM release board. QA did not record a separate `qa-intake` project-selection artifact.
- Type label: `type: task`

---
###### ✨ This message was AI-generated using gpt-5
