### PR TITLE
Fix test resources standalone shutdown lifecycle

### DIFF
--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -423,7 +423,7 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
                                 project.getLogger().debug("Stop file contains {}", stopFileLines);
                             }
                             Files.deleteIfExists(shouldStopFile);
-                            if (Boolean.parseBoolean(stopFileLines.get(0))) {
+                            if (!stopFileLines.isEmpty() && Boolean.parseBoolean(stopFileLines.get(0).trim())) {
                                 ServerUtils.stopServer(settingsDirectory.get().getAsFile().toPath());
                             }
                         }

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/MicronautTestResourcesPlugin.java
@@ -418,10 +418,12 @@ public class MicronautTestResourcesPlugin implements Plugin<Project> {
                 public void beforeComplete() {
                     try {
                         if (Files.exists(shouldStopFile)) {
+                            List<String> stopFileLines = Files.readAllLines(shouldStopFile);
                             if (project.getLogger().isDebugEnabled()) {
-                                project.getLogger().debug("Stop file contains {}", Files.readAllLines(shouldStopFile));
+                                project.getLogger().debug("Stop file contains {}", stopFileLines);
                             }
-                            if (Boolean.parseBoolean(Files.readAllLines(shouldStopFile).get(0))) {
+                            Files.deleteIfExists(shouldStopFile);
+                            if (Boolean.parseBoolean(stopFileLines.get(0))) {
                                 ServerUtils.stopServer(settingsDirectory.get().getAsFile().toPath());
                             }
                         }

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -281,7 +281,7 @@ public abstract class StartTestResourcesService extends DefaultTask {
     }
 
     private boolean canReuseExistingServer(Path settingsDirectory, Path portFile) {
-        java.util.Optional<ServerSettings> settings = ServerUtils.readServerSettings(settingsDirectory);
+        var settings = ServerUtils.readServerSettings(settingsDirectory);
         try {
             Integer port = null;
             if (settings.isPresent()) {

--- a/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
+++ b/test-resources-plugin/src/main/java/io/micronaut/gradle/testresources/StartTestResourcesService.java
@@ -16,6 +16,7 @@
 package io.micronaut.gradle.testresources;
 
 import io.micronaut.testresources.buildtools.ServerFactory;
+import io.micronaut.testresources.buildtools.ServerSettings;
 import io.micronaut.testresources.buildtools.ServerUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -261,16 +262,40 @@ public abstract class StartTestResourcesService extends DefaultTask {
                 Thread.sleep(duration.toMillis());
             }
         };
+        Path settingsDirectory = getSettingsDirectory().get().getAsFile().toPath();
+        Integer explicitPort = getExplicitPort().getOrNull();
+        Path portFile = getPortFile().map(f -> f.getAsFile().toPath()).getOrNull();
+        if (canReuseExistingServer(settingsDirectory, portFile)) {
+            return;
+        }
         ServerUtils.startOrConnectToExistingServer(
-            getExplicitPort().getOrNull(),
-            getPortFile().map(f -> f.getAsFile().toPath()).getOrNull(),
-            getSettingsDirectory().get().getAsFile().toPath(),
+            explicitPort,
+            portFile,
+            settingsDirectory,
             getAccessToken().getOrNull(),
             cdsDir,
             getClasspath().getFiles(),
             getClientTimeout().getOrNull(),
             getServerIdleTimeoutMinutes().getOrNull(),
             serverFactory);
+    }
+
+    private boolean canReuseExistingServer(Path settingsDirectory, Path portFile) {
+        java.util.Optional<ServerSettings> settings = ServerUtils.readServerSettings(settingsDirectory);
+        try {
+            Integer port = null;
+            if (settings.isPresent()) {
+                port = settings.get().getPort();
+            } else if (portFile != null && Files.exists(portFile)) {
+                List<String> lines = Files.readAllLines(portFile);
+                if (!lines.isEmpty()) {
+                    port = Integer.parseInt(lines.get(0).trim());
+                }
+            }
+            return port != null && ServerUtils.isServerStarted(port);
+        } catch (IOException | NumberFormatException ignored) {
+            return false;
+        }
     }
 
 }

--- a/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/ApplicationTestResourcesPluginSpec.groovy
+++ b/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/ApplicationTestResourcesPluginSpec.groovy
@@ -119,6 +119,11 @@ class ApplicationTestResourcesPluginSpec extends AbstractGradleBuildSpec {
 
         when:
         def firstRun = build '-DinterruptStartup=true', 'run'
+
+        then:
+        firstRun.task(':run').outcome == TaskOutcome.SUCCESS
+
+        when:
         def firstRunPort = testResourcesPort()
 
         and:
@@ -131,7 +136,6 @@ class ApplicationTestResourcesPluginSpec extends AbstractGradleBuildSpec {
         def stopResult = build 'stopTestResourcesService'
 
         then:
-        firstRun.task(':run').outcome == TaskOutcome.SUCCESS
         !canConnectTo(firstRunPort)
         startResult.task(':internalStartTestResourcesService').outcome == TaskOutcome.SUCCESS
         secondRun.task(':run').outcome == TaskOutcome.SUCCESS

--- a/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/ApplicationTestResourcesPluginSpec.groovy
+++ b/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/ApplicationTestResourcesPluginSpec.groovy
@@ -116,6 +116,9 @@ class ApplicationTestResourcesPluginSpec extends AbstractGradleBuildSpec {
 
     def "standalone test resources service survives after build-owned service shutdown"() {
         withSample("test-resources/data-mysql")
+        buildFile.text = buildFile.text
+                .replace('implementation("io.micronaut:micronaut-jackson-databind")', 'implementation("io.micronaut.serde:micronaut-serde-jackson")')
+                .replace('runtimeOnly("io.micronaut:micronaut-jackson-databind")', '')
 
         when:
         def firstRun = build '-DinterruptStartup=true', 'run'
@@ -126,19 +129,24 @@ class ApplicationTestResourcesPluginSpec extends AbstractGradleBuildSpec {
         when:
         def firstRunPort = testResourcesPort()
 
-        and:
+        then:
+        eventuallyCannotConnectTo(firstRunPort)
+
+        when:
         def startResult = build 'startTestResourcesService'
+        def standalonePort = testResourcesPort()
 
         and:
         def secondRun = build '-DinterruptStartup=true', 'run'
+        def reusedPort = testResourcesPort()
 
         and:
         def stopResult = build 'stopTestResourcesService'
 
         then:
-        !canConnectTo(firstRunPort)
         startResult.task(':internalStartTestResourcesService').outcome == TaskOutcome.SUCCESS
         secondRun.task(':run').outcome == TaskOutcome.SUCCESS
+        standalonePort == reusedPort
         stopResult.task(':stopTestResourcesService').outcome == TaskOutcome.SUCCESS
 
         cleanup:
@@ -156,12 +164,23 @@ class ApplicationTestResourcesPluginSpec extends AbstractGradleBuildSpec {
     private boolean canConnectTo(int port) {
         try {
             new Socket().withCloseable {
-                it.connect(new InetSocketAddress("localhost", port), 1000)
+                it.connect(new InetSocketAddress("127.0.0.1", port), 1000)
             }
             return true
         } catch (IOException ignored) {
             return false
         }
+    }
+
+    private boolean eventuallyCannotConnectTo(int port) {
+        long deadline = System.currentTimeMillis() + 5000
+        while (canConnectTo(port)) {
+            if (System.currentTimeMillis() >= deadline) {
+                return false
+            }
+            Thread.sleep(100)
+        }
+        true
     }
 
     private void withTestResourcesConfiguration(String configuration) {

--- a/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/ApplicationTestResourcesPluginSpec.groovy
+++ b/test-resources-plugin/src/test/groovy/io/micronaut/gradle/testresources/ApplicationTestResourcesPluginSpec.groovy
@@ -4,6 +4,9 @@ import io.micronaut.gradle.AbstractGradleBuildSpec
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.IgnoreIf
 
+import java.net.InetSocketAddress
+import java.net.Socket
+
 @IgnoreIf({ os.windows })
 class ApplicationTestResourcesPluginSpec extends AbstractGradleBuildSpec {
 
@@ -109,6 +112,52 @@ class ApplicationTestResourcesPluginSpec extends AbstractGradleBuildSpec {
         result.output.contains "Loaded 2 test resources resolvers"
         result.output.contains "io.micronaut.testresources.mysql.MySQLTestResourceProvider"
         result.output.contains "io.micronaut.testresources.testcontainers.GenericTestContainerProvider"
+    }
+
+    def "standalone test resources service survives after build-owned service shutdown"() {
+        withSample("test-resources/data-mysql")
+
+        when:
+        def firstRun = build '-DinterruptStartup=true', 'run'
+        def firstRunPort = testResourcesPort()
+
+        and:
+        def startResult = build 'startTestResourcesService'
+
+        and:
+        def secondRun = build '-DinterruptStartup=true', 'run'
+
+        and:
+        def stopResult = build 'stopTestResourcesService'
+
+        then:
+        firstRun.task(':run').outcome == TaskOutcome.SUCCESS
+        !canConnectTo(firstRunPort)
+        startResult.task(':internalStartTestResourcesService').outcome == TaskOutcome.SUCCESS
+        secondRun.task(':run').outcome == TaskOutcome.SUCCESS
+        stopResult.task(':stopTestResourcesService').outcome == TaskOutcome.SUCCESS
+
+        cleanup:
+        try {
+            build 'stopTestResourcesService'
+        } catch (ignored) {
+            // best effort cleanup when the assertion path already stopped the service
+        }
+    }
+
+    private int testResourcesPort() {
+        file(".micronaut/test-resources/test-resources-port.txt").text.trim() as int
+    }
+
+    private boolean canConnectTo(int port) {
+        try {
+            new Socket().withCloseable {
+                it.connect(new InetSocketAddress("localhost", port), 1000)
+            }
+            return true
+        } catch (IOException ignored) {
+            return false
+        }
     }
 
     private void withTestResourcesConfiguration(String configuration) {


### PR DESCRIPTION
## Summary

- Reuse an already-running Test Resources service from the recorded settings/port files before falling back to the build-tools JSON root probe that Micronaut Test Resources 4 no longer satisfies for Micronaut 5 Serde-based applications.
- Keep ordinary build-owned service cleanup intact while allowing an explicitly started standalone service to survive later application builds until `stopTestResourcesService` runs.
- Extend the TestKit regression to cover a Micronaut 5-style Serde application, assert the build-owned service stops before standalone mode, and assert the later `run` reuses the standalone service port instead of starting a second service.

## Verification

- `git diff --check`
- `./gradlew :micronaut-test-resources-plugin:compileJava --no-daemon`
- `./gradlew :micronaut-test-resources-plugin:test --tests "io.micronaut.gradle.testresources.ApplicationTestResourcesPluginSpec.standalone test resources service survives after build-owned service shutdown" --rerun-tasks --no-daemon`

## Release Target

- Target branch: `master`.
- Release target: `5.0.x` patch line; repository source currently indicates `5.0.1-SNAPSHOT`.
- Micronaut organization project: `5.0.3 Release`. Ambiguity preserved from QA intake: `5.0.1` and `5.0.2` Platform boards are closed, while `5.0.3 Release` is the earliest open matching Micronaut Platform BOM release board.

## PR Assets

- Not applicable; this changes code and regression tests only, with no rendered output or generated artifact requiring upload.

Fixes #1342

---
###### ✨ This message was AI-generated using openai/gpt-5.5
