### PR TITLE
Use exploded layers for JIT Docker images

### DIFF
--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
@@ -24,6 +24,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.plugins.JavaApplication;
 import org.gradle.api.plugins.PluginManager;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskContainer;
@@ -156,6 +157,7 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
             task.getArch().set(configuration.getArch());
             task.getOs().set(configuration.getOs());
             task.getJavaVersion().set(configuration.getJavaVersion());
+            task.getArgs().set(project.getExtensions().getByType(JavaApplication.class).getMainClass().map(Collections::singletonList));
             task.setupDockerfileInstructions();
             task.getLayers().convention(buildLayersTask.flatMap(BuildLayersTask::getLayers));
         });

--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
@@ -145,6 +145,7 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
         File f = project.file(adaptTaskName("DockerfileCracCheckpoint", imageName));
         String dockerFileTaskName = adaptTaskName("checkpointDockerfile", imageName);
         Provider<RegularFile> targetCheckpointDockerFile = project.getLayout().getBuildDirectory().file(BUILD_DOCKER_DIRECTORY + imageName + "/Dockerfile.CRaCCheckpoint");
+        Provider<List<String>> checkpointMainClassArgs = checkpointMainClassArgs(project);
         TaskProvider<CRaCCheckpointDockerfile> dockerFileTask = tasks.register(dockerFileTaskName, CRaCCheckpointDockerfile.class, task -> {
             task.setGroup(CRAC_TASK_GROUP);
             task.setDescription("Builds a Checkpoint Docker File for image " + imageName);
@@ -157,7 +158,7 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
             task.getArch().set(configuration.getArch());
             task.getOs().set(configuration.getOs());
             task.getJavaVersion().set(configuration.getJavaVersion());
-            task.getArgs().set(project.getExtensions().getByType(JavaApplication.class).getMainClass().map(Collections::singletonList));
+            task.getArgs().set(checkpointMainClassArgs);
             task.setupDockerfileInstructions();
             task.getLayers().convention(buildLayersTask.flatMap(BuildLayersTask::getLayers));
         });
@@ -229,6 +230,14 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
         });
         start.configure(t -> t.finalizedBy(await));
         return new CheckpointTasksOfNote(f.exists() ? null : dockerFileTask, start);
+    }
+
+    private Provider<List<String>> checkpointMainClassArgs(Project project) {
+        JavaApplication application = project.getExtensions().findByType(JavaApplication.class);
+        if (application == null) {
+            throw new GradleException("The CRaC checkpoint Dockerfile requires the Gradle application extension. Apply the application plugin or a Micronaut application plugin and configure application.mainClass.");
+        }
+        return application.getMainClass().map(Collections::singletonList);
     }
 
     static String createCheckpointImageName(Project project) {

--- a/crac-plugin/src/main/resources/checkpoint.sh
+++ b/crac-plugin/src/main/resources/checkpoint.sh
@@ -13,12 +13,27 @@ echo "Starting application"
 GLIBC_TUNABLES=glibc.pthread.rseq=0
 
 # Run the app in the background
-/azul-crac-jdk/bin/java \
-  -XX:CRaCCheckpointTo=cr \
-  -XX:+UnlockDiagnosticVMOptions \
-  -XX:+CRTraceStartupTime \
-  -Djdk.crac.trace-startup-time=true \
-  -jar application.jar &
+JAVA_CMD=(
+  /azul-crac-jdk/bin/java
+  -XX:CRaCCheckpointTo=cr
+  -XX:+UnlockDiagnosticVMOptions
+  -XX:+CRTraceStartupTime
+  -Djdk.crac.trace-startup-time=true
+)
+
+if [ -f application.jar ]; then
+  JAVA_CMD+=(-jar application.jar)
+else
+  MAIN_CLASS=$1
+  shift
+  if [ -z "$MAIN_CLASS" ]; then
+    echo "Main class argument is required when application.jar is not present"
+    exit 1
+  fi
+  JAVA_CMD+=(-cp "/home/app/resources:/home/app/classes:/home/app/libs/*" "$MAIN_CLASS" "$@")
+fi
+
+"${JAVA_CMD[@]}" &
 PROCESS=$!
 echo "Started application as process $PROCESS"
 

--- a/crac-plugin/src/main/resources/checkpoint.sh
+++ b/crac-plugin/src/main/resources/checkpoint.sh
@@ -24,12 +24,12 @@ JAVA_CMD=(
 if [ -f application.jar ]; then
   JAVA_CMD+=(-jar application.jar)
 else
-  MAIN_CLASS=$1
-  shift
-  if [ -z "$MAIN_CLASS" ]; then
+  if [ -z "$1" ]; then
     echo "Main class argument is required when application.jar is not present"
     exit 1
   fi
+  MAIN_CLASS=$1
+  shift
   JAVA_CMD+=(-cp "/home/app/resources:/home/app/classes:/home/app/libs/*" "$MAIN_CLASS" "$@")
 fi
 

--- a/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
+++ b/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
@@ -94,6 +94,7 @@ class CracCustomizationSpec extends BaseCracGradleBuildSpec {
         result.output.contains("BUILD SUCCESSFUL")
         fileTextContents("build/docker/main/Dockerfile").readLines().head() == "FROM $MicronautCRaCPlugin.CRAC_DEFAULT_BASE_IMAGE"
         fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").readLines().head() == "FROM $MicronautCRaCPlugin.CRAC_DEFAULT_BASE_IMAGE"
+        fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains('ENTRYPOINT ["/home/app/checkpoint.sh", "example.Application"]')
     }
 
     void "base image is customizable"() {

--- a/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
+++ b/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
@@ -97,6 +97,31 @@ class CracCustomizationSpec extends BaseCracGradleBuildSpec {
         fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").contains('ENTRYPOINT ["/home/app/checkpoint.sh", "example.Application"]')
     }
 
+    void "checkpoint dockerfile reports missing application extension clearly"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "java"
+                id "io.micronaut.docker"
+                id "io.micronaut.crac"
+            }
+
+            $repositoriesBlock
+
+            micronaut {
+                version "$micronautVersion"
+                runtime("netty")
+            }
+        """.stripIndent()
+
+        when:
+        def result = fails('checkpointDockerfile', '-s')
+
+        then:
+        result.output.contains("The CRaC checkpoint Dockerfile requires the Gradle application extension. Apply the application plugin or a Micronaut application plugin and configure application.mainClass.")
+    }
+
     void "base image is customizable"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
@@ -68,16 +68,23 @@ public class MicronautDockerPlugin implements Plugin<Project> {
             micronautExtension.getExtensions().add("dockerImages", dockerImages);
             dockerImages.all(image -> createDockerImage(project, image));
             TaskProvider<Jar> runnerJar = createMainRunnerJar(project, tasks);
+            SourceSet mainSourceSet = project.getExtensions().getByType(SourceSetContainer.class)
+                .getByName(SourceSet.MAIN_SOURCE_SET_NAME);
             dockerImages.create("main", image -> {
                 createDependencyLayers(image, project.getConfigurations().getByName(RUNTIME_CLASSPATH_CONFIGURATION_NAME));
                 image.addLayer(layer -> {
                     layer.getLayerKind().set(LayerKind.APP);
+                    layer.getRuntimeKind().set(RuntimeKind.JIT);
+                    layer.getFiles().from(mainSourceSet.getOutput().getClassesDirs());
+                });
+                image.addLayer(layer -> {
+                    layer.getLayerKind().set(LayerKind.APP);
+                    layer.getRuntimeKind().set(RuntimeKind.NATIVE);
                     layer.getFiles().from(runnerJar);
                 });
                 image.addLayer(layer -> {
                     layer.getLayerKind().set(LayerKind.EXPANDED_RESOURCES);
-                    layer.getFiles().from(project.getExtensions().getByType(SourceSetContainer.class)
-                        .getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput().getResourcesDir());
+                    layer.getFiles().from(mainSourceSet.getOutput().getResourcesDir());
                 });
             });
         });

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerPlugin.java
@@ -156,6 +156,8 @@ public class MicronautDockerPlugin implements Plugin<Project> {
 
     private void createDockerImage(Project project, MicronautDockerImage imageSpec) {
         TaskContainer tasks = project.getTasks();
+        SourceSet mainSourceSet = project.getExtensions().getByType(SourceSetContainer.class)
+            .getByName(SourceSet.MAIN_SOURCE_SET_NAME);
         String imageName = imageSpec.getName();
         project.getLogger().info("Creating docker tasks for image {}", imageName);
         TaskProvider<BuildLayersTask> buildLayersTask = tasks.register(adaptTaskName("buildLayers", imageName), BuildLayersTask.class, task -> {
@@ -163,6 +165,7 @@ public class MicronautDockerPlugin implements Plugin<Project> {
             task.setDescription("Builds application layers for use in a Docker container (" + imageName + " image)");
             task.getLayers().set(imageSpec.findLayers(RuntimeKind.JIT));
             task.getOutputDir().convention(project.getLayout().getBuildDirectory().dir("docker/" + imageName + "/layers"));
+            task.dependsOn(tasks.named(mainSourceSet.getClassesTaskName()));
         });
 
 
@@ -179,6 +182,7 @@ public class MicronautDockerPlugin implements Plugin<Project> {
                 task.setDescription("Builds application layers for use in a Docker container (" + imageName + " image)");
                 task.getLayers().set(imageSpec.findLayers(RuntimeKind.NATIVE));
                 task.getOutputDir().convention(project.getLayout().getBuildDirectory().dir("docker/native-" + imageName + "/layers"));
+                task.dependsOn(tasks.named(mainSourceSet.getClassesTaskName()));
             });
             TaskProvider<NativeImageDockerfile> nativeImageDockerFileTask = configureNativeDockerBuild(project, tasks, buildNativeLayersTask, imageName);
             withBuildStrategy(project, buildStrategy -> nativeImageDockerFileTask.configure(it -> {

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
@@ -166,7 +166,9 @@ public abstract class MicronautDockerfile extends Dockerfile implements DockerBu
                         newList.addAll(strings);
                         newList.add("-cp");
                         newList.add(workDir + "/resources:" + workDir + "/classes:" + workDir + "/libs/*");
-                        newList.add(javaApplication.getMainClass().get());
+                        newList.add(buildStrategy == DockerBuildStrategy.LAMBDA
+                            ? "io.micronaut.function.aws.runtime.MicronautLambdaRuntime"
+                            : javaApplication.getMainClass().get());
                         return newList;
                     }));
                 }

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/MicronautDockerfile.java
@@ -161,17 +161,12 @@ public abstract class MicronautDockerfile extends Dockerfile implements DockerBu
                 getInstructions().addAll(additionalInstructions);
                 if (getInstructions().get().stream().noneMatch(instruction -> instruction.getKeyword().equals(EntryPointInstruction.KEYWORD))) {
                     entryPoint(getArgs().map(strings -> {
-                        var newList = new ArrayList<String>(strings.size() + 4);
+                        var newList = new ArrayList<String>(strings.size() + 5);
                         newList.add("java");
                         newList.addAll(strings);
-                        if (buildStrategy == DockerBuildStrategy.LAMBDA) {
-                            newList.add("-cp");
-                            newList.add(workDir + "/libs/*:" + workDir + "/resources:" + workDir + "/application.jar");
-                            newList.add("io.micronaut.function.aws.runtime.MicronautLambdaRuntime");
-                        } else {
-                            newList.add("-jar");
-                            newList.add(workDir + "/application.jar");
-                        }
+                        newList.add("-cp");
+                        newList.add(workDir + "/resources:" + workDir + "/classes:" + workDir + "/libs/*");
+                        newList.add(javaApplication.getMainClass().get());
                         return newList;
                     }));
                 }

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/BuildLayersTask.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/BuildLayersTask.java
@@ -2,8 +2,8 @@ package io.micronaut.gradle.docker.tasks;
 
 import io.micronaut.gradle.docker.model.Layer;
 import io.micronaut.gradle.docker.model.LayerKind;
+import io.micronaut.gradle.docker.model.RuntimeKind;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
@@ -20,9 +20,13 @@ import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
 import javax.inject.Inject;
+import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -48,11 +52,21 @@ public abstract class BuildLayersTask extends DefaultTask {
         fileOperations.delete(getOutputDir());
         // Create folders if case there are no resources/libs in project
         for (Layer layer : getLayers().get()) {
-            final Provider<Directory> layerDir = layerDirectoryOf(layer, getOutputDir());
             if (layer.getLayerKind().get() == LayerKind.APP) {
-                // special case for now
-                copyLayer(fileOperations, layer, getOutputDir().dir("app"), copy -> copy.rename(s -> "application.jar"));
+                if (layer.getRuntimeKind().get() == RuntimeKind.NATIVE) {
+                    copyLayer(fileOperations, layer, getOutputDir().dir("app"), copy -> copy.rename(s -> "application.jar"));
+                } else {
+                    var appClassesDir = getOutputDir().dir("app/classes");
+                    createDir(appClassesDir);
+                    copyToLayer(fileOperations, appClassesDir, copy -> {
+                        copy.from(layer.getFiles().getFiles().stream()
+                            .sorted(Comparator.comparing(File::getAbsolutePath))
+                            .map(file -> file.getName().endsWith(".jar") ? fileOperations.zipTree(file) : file)
+                            .toList()).into(appClassesDir);
+                    });
+                }
             } else {
+                final Provider<Directory> layerDir = layerDirectoryOf(layer, getOutputDir());
                 copyLayer(fileOperations, layer, layerDir, copy -> {
                 });
             }
@@ -63,12 +77,20 @@ public abstract class BuildLayersTask extends DefaultTask {
                            Layer layer,
                            Provider<Directory> destination,
                            org.gradle.api.Action<CopySpec> customizer) {
+        copyToLayer(fileOperations, destination, copy -> {
+            copy.from(layer.getFiles()).into(destination);
+            customizer.execute(copy);
+        });
+    }
+
+    private void copyToLayer(FileOperations fileOperations,
+                             Provider<Directory> destination,
+                             org.gradle.api.Action<CopySpec> configurer) {
         Path destinationPath = destination.get().getAsFile().toPath();
         Map<Path, Path> copiedFiles = new LinkedHashMap<>();
         fileOperations.copy(copy -> {
             configureDuplicatesStrategy(copy);
-            copy.from(layer.getFiles()).into(destination);
-            customizer.execute(copy);
+            configurer.execute(copy);
             copy.eachFile(details -> recordCopiedFile(copiedFiles, destinationPath.resolve(relativePathOf(details)), details.getFile().toPath()));
         });
         restoreLastModifiedTimes(copiedFiles);
@@ -87,7 +109,7 @@ public abstract class BuildLayersTask extends DefaultTask {
         if (segments.length == 0) {
             return Path.of("");
         }
-        return Path.of(segments[0], java.util.Arrays.copyOfRange(segments, 1, segments.length));
+        return Path.of(segments[0], Arrays.copyOfRange(segments, 1, segments.length));
     }
 
     private void restoreLastModifiedTimes(Map<Path, Path> copiedFiles) {
@@ -102,6 +124,15 @@ public abstract class BuildLayersTask extends DefaultTask {
         }
     }
 
+    private static void createDir(Provider<Directory> dir) {
+        Path path = dir.get().getAsFile().toPath();
+        try {
+            Files.createDirectories(path);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create directory " + path, e);
+        }
+    }
+
     private void configureDuplicatesStrategy(CopySpec copy) {
         if (getDuplicatesStrategy().isPresent()) {
             copy.setDuplicatesStrategy(getDuplicatesStrategy().get());
@@ -112,11 +143,7 @@ public abstract class BuildLayersTask extends DefaultTask {
                                                         DirectoryProperty outputDir) {
         var kind = layer.getLayerKind().get();
         var dir = outputDir.dir(kind.sourceDirName());
-        try {
-            Files.createDirectories(dir.get().getAsFile().toPath());
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to create layer directory " + dir.get().getAsFile(), e);
-        }
+        createDir(dir);
         return dir;
     }
 }

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
@@ -43,6 +43,8 @@ class BuildLayersSpec extends AbstractGradleBuildSpec {
         task.outcome == TaskOutcome.SUCCESS
         new File(testProjectDir.root, "build-custom/docker/main/layers").exists()
         !new File(testProjectDir.root, "build/docker/main/layers").exists()
+        new File(testProjectDir.root, "build-custom/docker/main/layers/app/classes").exists()
+        !new File(testProjectDir.root, "build-custom/docker/main/layers/app/application.jar").exists()
     }
 
     void 'test build layers with duplicates strategy'() {
@@ -219,5 +221,48 @@ class BuildLayersSpec extends AbstractGradleBuildSpec {
             }
         }
         throw new IllegalStateException("Unable to locate ${fileName} for ${group}:${module} under ${cacheRoots}")
+    }
+
+    void 'test native app layers keep application jar layout'() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            import io.micronaut.gradle.docker.model.LayerKind
+            import io.micronaut.gradle.docker.model.RuntimeKind
+            import io.micronaut.gradle.docker.tasks.BuildLayersTask
+            import org.gradle.api.tasks.bundling.Zip
+
+            plugins {
+                id "base"
+                id "io.micronaut.docker"
+            }
+
+            def nativeLayer = objects.newInstance(io.micronaut.gradle.docker.model.Layer)
+            def appArchive = tasks.register("appArchive", Zip) {
+                archiveFileName = "runner.jar"
+                destinationDirectory = layout.buildDirectory.dir("native-input")
+                from(layout.projectDirectory.file("seed.txt"))
+            }
+
+            tasks.register("buildNativeLayersTask", BuildLayersTask) {
+                dependsOn(appArchive)
+                layers.set([nativeLayer])
+                outputDir = layout.buildDirectory.dir("docker/native-main/layers")
+            }
+
+            nativeLayer.layerKind.set(LayerKind.APP)
+            nativeLayer.runtimeKind.set(RuntimeKind.NATIVE)
+            nativeLayer.files.from(appArchive.flatMap { it.archiveFile })
+        """
+        file("seed.txt").text = "native"
+
+        when:
+        def result = build('buildNativeLayersTask')
+
+        then:
+        def task = result.task(":buildNativeLayersTask")
+        task.outcome == TaskOutcome.SUCCESS
+        new File(testProjectDir.root, "build/docker/native-main/layers/app/application.jar").exists()
+        !new File(testProjectDir.root, "build/docker/native-main/layers/app/classes").exists()
     }
 }

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
@@ -290,7 +290,7 @@ class Application {
 
         and:
         def dockerfile = new File(testProjectDir.root, 'build/docker/main/Dockerfile').text
-        dockerfile.contains('ENTRYPOINT ["java", "-Dtest.flag=from-application", "-Xmx256m", "-jar", "/home/app/application.jar"]')
+        dockerfile.contains('ENTRYPOINT ["java", "-Dtest.flag=from-application", "-Xmx256m", "-cp", "/home/app/resources:/home/app/classes:/home/app/libs/*", "example.Application"]')
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/765")
@@ -339,7 +339,7 @@ class Application {
 
         and:
         def dockerfile = new File(testProjectDir.root, 'build/docker/main/Dockerfile').text
-        dockerfile.contains('ENTRYPOINT ["java", "-Xmx128m", "-jar", "/home/app/application.jar"]')
+        dockerfile.contains('ENTRYPOINT ["java", "-Xmx128m", "-cp", "/home/app/resources:/home/app/classes:/home/app/libs/*", "example.Application"]')
         !dockerfile.contains('-Dtest.flag=from-application')
         !dockerfile.contains('-Xmx256m')
     }

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/DockerBuildTaskSpec.groovy
@@ -133,9 +133,9 @@ class Application {
         testProjectDir.newFile("Dockerfile") << """FROM eclipse-temurin:25-jre
 WORKDIR /home/alternate
 COPY --link layers/libs /home/alternate/libs
-COPY --link layers/app/application.jar /home/alternate/application.jar
+COPY --link layers/app /home/alternate/
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/home/alternate/application.jar"]
+ENTRYPOINT ["java", "-cp", "/home/alternate/resources:/home/alternate/classes:/home/alternate/libs/*", "example.Application"]
 """
         when:
         def result = build('dockerBuild', '-s')
@@ -244,7 +244,7 @@ COPY --link layers/libs /home/alternate/libs
 COPY --link layers/app /home/alternate/
 COPY --link layers/resources /home/alternate/resources
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/home/alternate/application.jar"]
+ENTRYPOINT ["java", "-cp", "/home/alternate/resources:/home/alternate/classes:/home/alternate/libs/*", "example.Application"]
 """
     }
 
@@ -440,7 +440,7 @@ COPY layers/libs /home/app/libs
 COPY layers/app /home/app/
 COPY layers/resources /home/app/resources
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
+ENTRYPOINT ["java", "-cp", "/home/app/resources:/home/app/classes:/home/app/libs/*", "example.Application"]
 """
     }
 

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -24,7 +24,7 @@ WORKDIR /home/app
 COPY --link layers/libs /home/app/libs
 COPY --link layers/app /home/app/
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
+ENTRYPOINT ["java", "-cp", "/home/app/resources:/home/app/classes:/home/app/libs/*", "demo.app.Application"]
 """
 
     }
@@ -51,7 +51,7 @@ WORKDIR /home/app
 COPY --link layers/libs /home/app/libs
 COPY --link layers/app /home/app/
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
+ENTRYPOINT ["java", "-cp", "/home/app/resources:/home/app/classes:/home/app/libs/*", "demo.app.Application"]
 """
 
     }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerJvmFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerJvmFunctionalTest.groovy
@@ -4,8 +4,6 @@ import io.micronaut.gradle.fixtures.AbstractEagerConfiguringFunctionalTest
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Issue
 
-import java.util.jar.JarFile
-
 @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/820")
 class DockerJvmFunctionalTest extends AbstractEagerConfiguringFunctionalTest {
 
@@ -46,18 +44,15 @@ public class Application {
 
         when:
         def result = build("assemble")
-        def runnerJar = new File(testProjectDir.root, "build/libs/hello-world-runner.jar")
-        def manifestMainClass
-        new JarFile(runnerJar).withCloseable { jar ->
-            manifestMainClass = jar.manifest.mainAttributes.getValue("Main-Class")
-        }
+        def startScript = new File(testProjectDir.root, "build/scripts/hello-world")
 
         then:
         result.task(":assemble").outcome == TaskOutcome.SUCCESS
-        manifestMainClass == "example.Application"
+        startScript.text.contains('example.Application')
+        !startScript.text.contains('io.micronaut.function.aws.runtime.MicronautLambdaRuntime')
     }
 
-    void "dockerfile uses lambda runtime entrypoint without changing runner jar main class"() {
+    void "dockerfile uses lambda runtime entrypoint without changing application main class"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"
         buildFile << """
@@ -96,17 +91,14 @@ public class Application {
         def result = build("dockerfile", "assemble")
         def dockerFile = new File(testProjectDir.root, "build/docker/main/Dockerfile").readLines("UTF-8")
         def imageLibraries = new File(testProjectDir.root, "build/docker/main/layers/libs").list()
-        def runnerJar = new File(testProjectDir.root, "build/libs/hello-world-runner.jar")
-        def manifestMainClass
-        new JarFile(runnerJar).withCloseable { jar ->
-            manifestMainClass = jar.manifest.mainAttributes.getValue("Main-Class")
-        }
+        def startScript = new File(testProjectDir.root, "build/scripts/hello-world")
 
         then:
         result.task(":dockerfile").outcome == TaskOutcome.SUCCESS
         result.task(":assemble").outcome == TaskOutcome.SUCCESS
-        manifestMainClass == "example.Application"
-        dockerFile.find { s -> s == 'ENTRYPOINT ["java", "-cp", "/home/app/libs/*:/home/app/resources:/home/app/application.jar", "io.micronaut.function.aws.runtime.MicronautLambdaRuntime"]' }
+        startScript.text.contains('example.Application')
+        !startScript.text.contains('io.micronaut.function.aws.runtime.MicronautLambdaRuntime')
+        dockerFile.find { s -> s == 'ENTRYPOINT ["java", "-cp", "/home/app/resources:/home/app/classes:/home/app/libs/*", "io.micronaut.function.aws.runtime.MicronautLambdaRuntime"]' }
         imageLibraries.any { it.startsWith("micronaut-function-aws-custom-runtime-") }
     }
 }

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -780,7 +780,7 @@ COPY --link server.iprof /home/app/server.iprof
 COPY --link layers/app /home/app/
 COPY --link layers/resources /home/app/resources
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
+ENTRYPOINT ["java", "-cp", "/home/app/resources:/home/app/classes:/home/app/libs/*", "example.Application"]
 """
 
         when:
@@ -918,7 +918,7 @@ COPY --link server.iprof /home/app/server.iprof
 COPY --link layers/app /home/app/
 COPY --link layers/resources /home/app/resources
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
+ENTRYPOINT ["java", "-cp", "/home/app/resources:/home/app/classes:/home/app/libs/*", "example.Application"]
 """
 
         when:

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1265,7 +1265,7 @@ tasks.withType(io.micronaut.gradle.docker.tasks.BuildLayersTask) {
 The `buildLayers` task creates files under `build/docker/main/layers` for the generated Docker image.
 This directory is an internal Docker build artifact, not a supported application distribution.
 
-For JIT images, the application layer now contains exploded classes under `layers/app/classes`, resources under `layers/resources`, and dependency buckets under the existing `layers/libs*` directories.
+For JIT images, the exploded layout now includes application classes under `layers/app/classes`, resources under `layers/resources`, and dependency buckets under the existing `layers/libs*` directories.
 The generated Dockerfile launches those layers with an explicit classpath and the configured application main class instead of `java -jar`.
 
 If you copied internal `layers/app/application.jar` paths into a custom Dockerfile, update those references to the exploded layout and use a classpath entrypoint such as `java -cp /home/app/resources:/home/app/classes:/home/app/libs/* your.main.Class`.

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1265,8 +1265,10 @@ tasks.withType(io.micronaut.gradle.docker.tasks.BuildLayersTask) {
 The `buildLayers` task creates files under `build/docker/main/layers` for the generated Docker image.
 This directory is an internal Docker build artifact, not a supported application distribution.
 
-The plugin also produces an additional runner JAR in `build/libs` with the `runner` classifier.
-That archive is used to populate the Docker layers and is not meant to be copied or run on its own.
+For JIT images, the application layer now contains exploded classes under `layers/app/classes`, resources under `layers/resources`, and dependency buckets under the existing `layers/libs*` directories.
+The generated Dockerfile launches those layers with an explicit classpath and the configured application main class instead of `java -jar`.
+
+If you copied internal `layers/app/application.jar` paths into a custom Dockerfile, update those references to the exploded layout and use a classpath entrypoint such as `java -cp /home/app/resources:/home/app/classes:/home/app/libs/* your.main.Class`.
 
 
 === Micronaut Runtimes


### PR DESCRIPTION
Fixes #81

## Summary
- use exploded `layers/app/classes` plus an explicit classpath entrypoint for JIT Docker images
- preserve the native Docker `application.jar` layout and add non-skipped native layer coverage
- update functional expectations and docs for custom Dockerfiles that referenced the old JIT jar path

## Verification
- `./gradlew :micronaut-docker-plugin:test --tests 'io.micronaut.gradle.BuildLayersSpec' --tests 'io.micronaut.gradle.DockerBuildTaskSpec'`
- `./gradlew :functional-tests:test --tests 'io.micronaut.gradle.aot.MicronautAOTDockerSpec' --tests 'io.micronaut.gradle.docker.DockerNativeFunctionalTest'`

## Project
- Linked Micronaut organization project: `5.0.3 Release` (https://github.com/orgs/micronaut-projects/projects/153).
- QA ambiguity note: this is the best-fit Micronaut Platform BOM release board for the default-branch patch line; it is not an exact Gradle plugin module-version board.

---
###### ✨ This message was AI-generated using openai/gpt-5.5
