### PR TITLE
Add Gradle Plugin docs agent skill

### DIFF
--- a/.agents/skills/docs/SKILL.md
+++ b/.agents/skills/docs/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: docs
+description: Maintain Micronaut Gradle Plugin user guide documentation and docs examples. Use when changing src/docs/asciidoc/index.adoc, docs assets, samples referenced by the guide, or docs build/publishing behavior.
+license: Apache-2.0
+compatibility: micronaut-projects/micronaut-gradle-plugin
+metadata:
+  author: Micronaut Agent Company
+  version: "1.0.0"
+  source: micronaut-projects/micronaut-project-template .agents/skills/docs adapted for the Gradle Plugin repository
+---
+
+# Docs (Micronaut Gradle Plugin Maintainer)
+
+Use this skill for maintainer-facing documentation work in the Micronaut Gradle Plugin repository. The repository does **not** use the standard Micronaut module `src/main/docs/guide/toc.yml` layout; keep the local single-page AsciiDoc guide and Gradle Plugin-specific docs pipeline authoritative.
+
+## Goal
+
+Implement source-backed documentation changes in `src/docs/asciidoc/index.adoc`, keep sample snippets and assets aligned with executable repository sources, and validate with this repository's `docs` task.
+
+## Procedure
+
+1. Confirm the local docs layout and changed surface.
+2. Edit the single AsciiDoc guide and any source-backed samples together.
+3. Preserve repository-specific snippet/include conventions.
+4. Keep Gradle Plugin behavior, task names, and release/publishing guidance accurate.
+5. Build and inspect documentation output.
+
+### 1) Confirm docs layout and changed surface
+
+- Start with `src/docs/asciidoc/index.adoc`; it is the guide source of truth for this repository.
+- There is no `src/main/docs/guide/toc.yml` in this repository. Do not add one for normal guide work.
+- Static guide assets live under:
+  - `src/docs/asciidoc/css/`
+  - `src/docs/asciidoc/js/`
+  - `src/docs/asciidoc/highlight/`
+  - `src/docs/asciidoc/template/`
+- Runnable documentation examples live under `samples/` and are copied into TestKit builds by `minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy`.
+- Docs build wiring is repository-local in `buildSrc/src/main/groovy/io.micronaut.internal.build.documented.gradle`.
+
+### 2) Edit guide and samples together
+
+- When prose describes a plugin, extension, task, default, or generated file, confirm the implementation or tests in the owning module before editing.
+- When a code block comes from a sample or test fixture, prefer updating the source sample and preserving an include over pasting a divergent copy into the guide.
+- If a sample changes, run the focused TestKit/spec coverage when practical, or document why only docs rendering was run.
+- Keep public task, extension, and plugin-id names exact; this repository publishes Gradle plugins and plugin marker metadata.
+
+### 3) Preserve snippet/include conventions
+
+This repository uses plain Asciidoctor includes and tagged source snippets rather than the standard Micronaut module `snippet::` and `dependency:` macros.
+
+Guardrails:
+
+- Preserve existing `include::...[]` snippets, tags such as `tag=test`, and callout explanations unless the underlying source behavior changes.
+- Do not convert source-backed includes into pasted `[source]` blocks as a cleanup shortcut.
+- Do not introduce Micronaut module-only docs macros (`dependency:`, `snippet::`, generated configuration property includes, or `toc.yml`) unless the local docs build is first updated and verified to support them.
+- Keep multi-language or multi-build-tool examples consistent with the current guide style and samples.
+- Keep environment-sensitive instructions explicit, especially for Docker, GraalVM/native-image, CRaC, AOT, and test resources.
+
+See `references/gradle-plugin-docs.md` for repository-specific source evidence.
+
+### 4) Keep Gradle Plugin-specific behavior accurate
+
+- Preserve Gradle Plugin repository layout, wrapper policy, release automation, and Gradle Plugin Portal publishing model.
+- Do not copy Maven Central-only release or standard Micronaut module publishing advice from template docs.
+- When documenting Gradle/JDK compatibility, use the support matrix encoded in this repository and preserve user-facing unsupported-version guidance.
+- When documenting plugin application, dependency resolution, buildscript behavior, Docker/native-image behavior, or publishing metadata, add or update focused tests whenever possible.
+- Keep examples compatible with the targeted release line unless an approved issue plan says otherwise.
+
+### 5) Build and validate documentation
+
+For docs-only guide changes, run:
+
+```bash
+./gradlew docs
+```
+
+Validation checklist:
+
+1. `./gradlew docs` exits with code `0`.
+2. Rendered output exists under `build/docs/`.
+3. Updated sections render without missing includes or broken local assets.
+4. `git diff --check` passes.
+
+For broad sample or behavior changes, also run the focused module tests or functional TestKit specs that exercise the changed example.
+
+## Maintainer Delivery Contract
+
+When finishing docs work, report:
+
+1. Exact changed files (`index.adoc`, samples, docs resources, or docs build logic).
+2. Which source-backed includes or examples were preserved or updated.
+3. Build/test commands run and outcomes.
+4. Any repo-specific divergence from Micronaut Project Template docs guidance.
+5. Any skipped template docs changes and why they are not applicable to the Gradle Plugin repository.
+
+## Validation Checklist
+
+- [ ] `src/docs/asciidoc/index.adoc` remains the guide source of truth.
+- [ ] Existing includes, tags, and callouts are preserved unless source behavior changed.
+- [ ] No unsupported Micronaut module docs macros or `toc.yml` were introduced.
+- [ ] `./gradlew docs` and `git diff --check` ran successfully, or skipped validation has a concrete blocker.
+- [ ] Guidance remains Gradle Plugin-maintainer focused, not generic application documentation.
+
+## References
+
+- `references/gradle-plugin-docs.md`
+- `AGENTS.md`
+- `src/docs/asciidoc/index.adoc`
+- `buildSrc/src/main/groovy/io.micronaut.internal.build.documented.gradle`

--- a/.agents/skills/docs/references/gradle-plugin-docs.md
+++ b/.agents/skills/docs/references/gradle-plugin-docs.md
@@ -1,0 +1,75 @@
+# Micronaut Gradle Plugin Docs Layout
+
+This reference captures repository-specific facts that replace the standard Micronaut module docs guidance from `micronaut-project-template`.
+
+## Guide source
+
+- Primary guide source: `src/docs/asciidoc/index.adoc`
+- There is no `src/main/docs/guide/toc.yml` in this repository.
+- Shared assets are stored under `src/docs/asciidoc/css/`, `src/docs/asciidoc/js/`, `src/docs/asciidoc/highlight/`, and `src/docs/asciidoc/template/`.
+
+Maintainer implication:
+
+- Do not add or update `src/main/docs/guide/toc.yml` for normal Micronaut Gradle Plugin guide changes.
+- Keep section ordering and anchors in the single `index.adoc` file unless the requested docs change explicitly reorganizes the guide.
+
+## Docs build wiring
+
+Repository-local build logic:
+
+- `buildSrc/src/main/groovy/io.micronaut.internal.build.documented.gradle`
+
+Relevant behavior:
+
+- Applies `org.asciidoctor.jvm.convert`.
+- Configures the `asciidoctor` task output under `build/asciidoc`.
+- Copies local CSS, JavaScript, highlight assets, and the template from `src/docs/asciidoc`.
+- Registers `asciidocThemer` to apply `src/docs/asciidoc/template/template.html`.
+- Registers `docs`, a `Copy` task that writes assembled documentation under `build/docs` and includes generated API docs under `build/docs/api`.
+
+Maintainer implication:
+
+- Use `./gradlew docs` for guide rendering verification.
+- Inspect `build/docs/` when the visual/rendered output matters.
+
+## Source-backed examples
+
+The guide currently uses plain Asciidoctor includes for source-backed examples. Examples include:
+
+- `include::samples/test-resources/custom-test-resource/src/testResources/java/demo/GreetingTestResource.java[]`
+- `include::samples/test-resources/custom-test-resource/src/testResources/resources/META-INF/services/io.micronaut.testresources.core.TestResourcesResolver[]`
+- `include::samples/test-resources/custom-test-resource/src/test/java/demo/DemoTest.java[tag=test]`
+
+Sample projects live under `samples/` and are copied into TestKit builds by:
+
+- `minimal-plugin/src/testFixtures/groovy/io/micronaut/gradle/AbstractGradleBuildSpec.groovy`
+
+Maintainer implication:
+
+- Preserve includes and snippet tags when editing nearby prose.
+- If a sample-backed snippet needs to change, update the sample source and any TestKit coverage that depends on it.
+- Do not paste generated snippet output into the guide as a replacement for a source include.
+
+## Template docs macros not imported by default
+
+The standard Micronaut module docs skill references `dependency:`, `snippet::`, `[configuration]`, generated configuration property includes, and `publishGuide`. Those are provided by the normal Micronaut module docs pipeline.
+
+This repository's documented pipeline is different:
+
+- It has a single Gradle Plugin guide in `src/docs/asciidoc/index.adoc`.
+- Its documented verification task is `./gradlew docs`.
+- Existing source-backed examples use plain Asciidoctor `include::` directives and tags.
+
+Maintainer implication:
+
+- Do not introduce template-only docs macros unless the local build is explicitly updated and verified to support them.
+- Prefer the local include/tag style for narrow docs changes.
+
+## Release and publishing caveat
+
+The Micronaut Gradle Plugin repository publishes Gradle plugins and plugin marker metadata through the Gradle Plugin Portal. It is not a standard Micronaut module release.
+
+Maintainer implication:
+
+- Do not copy Maven Central-only or standard module-release docs guidance from `micronaut-project-template` into this repository.
+- When documenting release or publishing behavior, check `.github/workflows/release.yml`, `MAINTAINING.md`, module `build.gradle` plugin marker registrations, and current Gradle Plugin Portal conventions.

--- a/.agents/skills/docs/references/gradle-plugin-docs.md
+++ b/.agents/skills/docs/references/gradle-plugin-docs.md
@@ -23,8 +23,8 @@ Relevant behavior:
 
 - Applies `org.asciidoctor.jvm.convert`.
 - Configures the `asciidoctor` task output under `build/asciidoc`.
-- Copies local CSS, JavaScript, highlight assets, and the template from `src/docs/asciidoc`.
-- Registers `asciidocThemer` to apply `src/docs/asciidoc/template/template.html`.
+- Copies local CSS, JavaScript, and highlight assets from `src/docs/asciidoc` as `asciidoctor` resources.
+- Registers `asciidocThemer` to read and apply `src/docs/asciidoc/template/template.html`.
 - Registers `docs`, a `Copy` task that writes assembled documentation under `build/docs` and includes generated API docs under `build/docs/api`.
 
 Maintainer implication:


### PR DESCRIPTION
## Summary
- Add a repository-local `docs` agent skill for Micronaut Gradle Plugin documentation work.
- Capture Gradle Plugin-specific docs layout evidence in `references/gradle-plugin-docs.md`.
- Preserve the latest Micronaut Project Template docs-skill intent while avoiding standard-module-only docs macros and publishing assumptions.

## Template changes applied
- Adapted the template `.agents/skills/docs/SKILL.md` guidance to this repository's single-page `src/docs/asciidoc/index.adoc` guide.
- Documented that docs rendering uses `./gradlew docs` and outputs under `build/docs/`.
- Kept source-backed Asciidoctor `include::...[]` and tagged include conventions as the default guidance.

## Template changes intentionally skipped
- Did not add `src/main/docs/guide/toc.yml`; this repository does not use the standard Micronaut module guide layout.
- Did not add `publishGuide`, `dependency:`, `snippet::`, `[configuration]`, or generated configuration property include guidance as defaults because the local docs pipeline does not expose those module macros by default.
- Did not import Maven Central/module-release guidance; Micronaut Gradle Plugin publishing goes through the Gradle Plugin Portal and plugin marker metadata.

## Verification
- `git fetch origin master --prune`
- Confirmed this work branch is up to date with `origin/master` before PR creation.
- `git diff --check origin/master...HEAD`
- QA verified branch/diff/remote state, duplicate PR preflight, template source comparison, frontmatter/referenced-path guards, and absence of `src/main/docs/guide/toc.yml`.
- Security reviewed the `.agents/skills/docs/**` diff and approved it as non-executable maintainer guidance with no concrete exploit path.

`./gradlew docs` was not run because this change is repository-local agent guidance only; it does not modify public guide AsciiDoc, samples, docs assets, generated API links, or docs build logic.

## Metadata
- Paperclip issue: DEV-1230
- Target branch: `master`
- Release line: `5.0.1-SNAPSHOT`
- Type label: `type: docs`
- Closing keyword: not applicable; this run is linked to the Paperclip issue and no linked GitHub issue was present in the issue context.
- Micronaut organization projects: no QA intake project set was recorded for this run. I found the matching `5.0.1 Release` organization project, but it is closed, so no live project link is being applied.

---
###### ✨ This message was AI-generated using gpt-5.5
