### PR TITLE
Add CRaC restore verification task

### DIFF
--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCConfiguration.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/CRaCConfiguration.java
@@ -2,11 +2,14 @@ package io.micronaut.gradle.crac;
 
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
+
+import java.time.Duration;
 
 public interface CRaCConfiguration {
 
@@ -84,4 +87,61 @@ public interface CRaCConfiguration {
      * @return the bash command to run to check the app is running, it should exit with 0 if the app is up.
      */
     Property<String> getPreCheckpointReadinessCommand();
+
+    /**
+     * The command to run in the restored CRaC container to verify the application became ready.
+     * Defaults to {@link #getPreCheckpointReadinessCommand()}.
+     * @return the bash command to run in the restored container, it should exit with 0 if the app is up.
+     */
+    Property<String> getPostRestoreReadinessCommand();
+
+    /**
+     * The maximum time to wait for the post-restore readiness command to succeed.
+     * @return the readiness timeout
+     */
+    Property<Duration> getPostRestoreReadinessTimeout();
+
+    /**
+     * The delay between post-restore readiness command attempts.
+     * @return the readiness retry delay
+     */
+    Property<Duration> getPostRestoreReadinessRetryDelay();
+
+    /**
+     * The optional docker network name to use for the post-restore verification container.
+     * Defaults to {@link #getNetwork()}.
+     * @return the network name
+     */
+    @Optional
+    Property<String> getPostRestoreNetwork();
+
+    /**
+     * Docker host port bindings to apply when verifying the restored CRaC image.
+     * @return the port bindings
+     */
+    ListProperty<String> getPostRestorePortBindings();
+
+    /**
+     * Environment variables to apply when verifying the restored CRaC image.
+     * @return the environment variables
+     */
+    MapProperty<String, String> getPostRestoreEnvironment();
+
+    /**
+     * Arguments passed to the restored-image verification container.
+     * @return list of arguments
+     */
+    ListProperty<String> getPostRestoreArgs();
+
+    /**
+     * Linux capabilities added to the restored-image verification container.
+     * @return list of capabilities
+     */
+    ListProperty<String> getPostRestoreCapAdd();
+
+    /**
+     * If set to true, the restored-image verification container is retained for debugging.
+     * @return whether the container should be retained
+     */
+    Property<Boolean> getRetainPostRestoreContainer();
 }

--- a/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
+++ b/crac-plugin/src/main/java/io/micronaut/gradle/crac/MicronautCRaCPlugin.java
@@ -2,6 +2,7 @@ package io.micronaut.gradle.crac;
 
 import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer;
 import com.bmuschko.gradle.docker.tasks.container.DockerExistingContainer;
+import com.bmuschko.gradle.docker.tasks.container.DockerExecContainer;
 import com.bmuschko.gradle.docker.tasks.container.DockerLogsContainer;
 import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer;
 import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer;
@@ -34,6 +35,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -50,6 +52,9 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
     public static final String X86_64_ARCH = "amd64";
     public static final String DEFAULT_OS = "linux-glibc";
     public static final String CRAC_DEFAULT_READINESS_COMMAND = "curl --output /dev/null --silent --head http://localhost:8080";
+    public static final Duration CRAC_DEFAULT_RESTORE_READINESS_TIMEOUT = Duration.ofMinutes(2);
+    public static final Duration CRAC_DEFAULT_RESTORE_READINESS_RETRY_DELAY = Duration.ofSeconds(2);
+    public static final String CRAC_DEFAULT_RESTORE_CAPABILITY = "SYS_PTRACE";
     private static final String CRAC_TASK_GROUP = "CRaC";
     public static final String BUILD_DOCKER_DIRECTORY = "docker/";
 
@@ -74,6 +79,15 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
         crac.getEnabled().convention(true);
         crac.getBaseImage().convention(CRAC_DEFAULT_BASE_IMAGE);
         crac.getPreCheckpointReadinessCommand().convention(CRAC_DEFAULT_READINESS_COMMAND);
+        crac.getPostRestoreReadinessCommand().convention(crac.getPreCheckpointReadinessCommand());
+        crac.getPostRestoreReadinessTimeout().convention(CRAC_DEFAULT_RESTORE_READINESS_TIMEOUT);
+        crac.getPostRestoreReadinessRetryDelay().convention(CRAC_DEFAULT_RESTORE_READINESS_RETRY_DELAY);
+        crac.getPostRestoreNetwork().convention(crac.getNetwork());
+        crac.getPostRestorePortBindings().convention(Collections.emptyList());
+        crac.getPostRestoreEnvironment().convention(Collections.emptyMap());
+        crac.getPostRestoreArgs().convention(Collections.emptyList());
+        crac.getPostRestoreCapAdd().convention(Collections.singletonList(CRAC_DEFAULT_RESTORE_CAPABILITY));
+        crac.getRetainPostRestoreContainer().convention(false);
 
         // Default to current architecture
         String osArch = System.getProperty("os.arch");
@@ -109,13 +123,14 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
         });
         TaskProvider<BuildLayersTask> buildLayersTask = tasks.named("buildLayers", BuildLayersTask.class);
         CheckpointTasksOfNote checkpointDockerBuild = configureCheckpointDockerBuild(project, tasks, scriptTask, buildLayersTask, configuration, imageName);
-        Optional<TaskProvider<CRaCFinalDockerfile>> finalDockerBuild = configureFinalDockerBuild(project, tasks, scriptTask, buildLayersTask, checkpointDockerBuild.start, configuration, imageName);
+        FinalDockerTasksOfNote finalDockerBuild = configureFinalDockerBuild(project, tasks, scriptTask, buildLayersTask, checkpointDockerBuild.start, configuration, imageName);
+        configurePostRestoreVerification(project, tasks, finalDockerBuild.dockerBuildTask(), configuration, imageName);
         withBuildStrategy(project, buildStrategy -> {
             checkpointDockerBuild.getCheckpointDockerBuild().ifPresent(t -> t.configure(it -> {
                 buildStrategy.ifPresent(bs -> it.getBuildStrategy().set(buildStrategy.get()));
                 it.setupTaskPostEvaluate();
             }));
-            finalDockerBuild.ifPresent(t -> t.configure(it -> {
+            finalDockerBuild.getFinalDockerBuild().ifPresent(t -> t.configure(it -> {
                 buildStrategy.ifPresent(bs -> it.getBuildStrategy().set(buildStrategy.get()));
                 it.setupTaskPostEvaluate();
             }));
@@ -244,13 +259,13 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
             }
     }
 
-    private Optional<TaskProvider<CRaCFinalDockerfile>> configureFinalDockerBuild(Project project,
-                                                                                  TaskContainer tasks,
-                                                                                  TaskProvider<CheckpointScriptTask> scriptTask,
-                                                                                  TaskProvider<BuildLayersTask> buildLayersTask,
-                                                                                  TaskProvider<DockerStartContainer> start,
-                                                                                  CRaCConfiguration configuration,
-                                                                                  String imageName) {
+    private FinalDockerTasksOfNote configureFinalDockerBuild(Project project,
+                                                             TaskContainer tasks,
+                                                             TaskProvider<CheckpointScriptTask> scriptTask,
+                                                             TaskProvider<BuildLayersTask> buildLayersTask,
+                                                             TaskProvider<DockerStartContainer> start,
+                                                             CRaCConfiguration configuration,
+                                                             String imageName) {
         File f = project.file(adaptTaskName("Dockerfile", imageName));
         String dockerFileTaskName = adaptTaskName("dockerfileCrac", imageName);
         Provider<RegularFile> targetCheckpointDockerFile = project.getLayout().getBuildDirectory().file(BUILD_DOCKER_DIRECTORY + imageName + "/Dockerfile");
@@ -298,9 +313,78 @@ public class MicronautCRaCPlugin implements Plugin<Project> {
             task.setDescription("Pushes the " + imageName + " Docker Image");
             task.getImages().set(dockerBuildTask.flatMap(DockerBuildImage::getImages));
         });
-        if (!f.exists()) {
-            return Optional.of(dockerFileTask);
+        return new FinalDockerTasksOfNote(f.exists() ? null : dockerFileTask, dockerBuildTask);
+    }
+
+    private record FinalDockerTasksOfNote(
+        @Nullable
+        TaskProvider<CRaCFinalDockerfile> finalDockerBuild,
+        TaskProvider<DockerBuildImage> dockerBuildTask
+    ) {
+
+        Optional<TaskProvider<CRaCFinalDockerfile>> getFinalDockerBuild() {
+            return Optional.ofNullable(finalDockerBuild);
         }
-        return Optional.empty();
+    }
+
+    private void configurePostRestoreVerification(Project project,
+                                                  TaskContainer tasks,
+                                                  TaskProvider<DockerBuildImage> dockerBuildTask,
+                                                  CRaCConfiguration configuration,
+                                                  String imageName) {
+        TaskProvider<DockerCreateContainer> createContainer = tasks.register(adaptTaskName("postRestoreCreateContainer", imageName), DockerCreateContainer.class, task -> {
+            task.dependsOn(dockerBuildTask);
+            task.setGroup(CRAC_TASK_GROUP);
+            task.setDescription("Creates the CRaC restored-image verification container");
+            task.getImage().set(dockerBuildTask.flatMap(DockerBuildImage::getImages).map(images -> images.iterator().next()));
+            task.getHostConfig().getNetwork().convention(configuration.getPostRestoreNetwork());
+            task.getHostConfig().getPortBindings().set(configuration.getPostRestorePortBindings());
+            task.getHostConfig().getCapAdd().set(configuration.getPostRestoreCapAdd());
+            task.getEnvVars().set(configuration.getPostRestoreEnvironment());
+            task.getCmd().set(configuration.getPostRestoreArgs());
+        });
+
+        TaskProvider<DockerStartContainer> start = tasks.register(adaptTaskName("postRestoreDockerRun", imageName), DockerStartContainer.class, task -> {
+            task.dependsOn(createContainer);
+            task.setGroup(CRAC_TASK_GROUP);
+            task.setDescription("Runs the CRaC restored-image verification container");
+            task.targetContainerId(createContainer.flatMap(DockerCreateContainer::getContainerId));
+        });
+
+        TaskProvider<DockerLogsContainer> logs = tasks.register(adaptTaskName("postRestoreLogs", imageName), DockerLogsContainer.class, task -> {
+            task.setGroup(CRAC_TASK_GROUP);
+            task.setDescription("Shows logs from the CRaC restored-image verification container");
+            task.getTailAll().set(true);
+            task.getContainerId().set(createContainer.flatMap(DockerCreateContainer::getContainerId));
+        });
+
+        TaskProvider<DockerRemoveContainer> removeContainer = tasks.register(adaptTaskName("postRestoreRemoveContainer", imageName), DockerRemoveContainer.class, task -> {
+            task.setGroup(CRAC_TASK_GROUP);
+            task.setDescription("Removes the CRaC restored-image verification container");
+            task.getForce().set(true);
+            task.getContainerId().set(createContainer.flatMap(DockerCreateContainer::getContainerId));
+            task.onlyIf(t -> !configuration.getRetainPostRestoreContainer().get());
+        });
+
+        TaskProvider<DockerExecContainer> verify = tasks.register(adaptTaskName("dockerVerifyCrac", imageName), DockerExecContainer.class, task -> {
+            task.dependsOn(start);
+            task.setGroup(CRAC_TASK_GROUP);
+            task.setDescription("Verifies the restored CRaC Docker Image");
+            task.getContainerId().set(createContainer.flatMap(DockerCreateContainer::getContainerId));
+            task.getCommands().set(configuration.getPostRestoreReadinessCommand().map(command -> Collections.singletonList(new String[] {"/bin/sh", "-c", command})));
+            task.getSuccessOnExitCodes().set(Collections.singletonList(0));
+            task.doFirst(new Action<>() {
+                @Override
+                public void execute(Task t) {
+                    t.getLogger().lifecycle("Verifying restored CRaC image readiness using configured postRestoreReadinessCommand");
+                }
+            });
+            task.finalizedBy(logs, removeContainer);
+        });
+        project.afterEvaluate(p -> verify.configure(task -> task.setExecProbe(configuration.getPostRestoreReadinessTimeout().zip(configuration.getPostRestoreReadinessRetryDelay(),
+            (timeout, retryDelay) -> task.execProbe(timeout.toMillis(), retryDelay.toMillis())).get())));
+        start.configure(t -> t.finalizedBy(logs, removeContainer));
+        logs.configure(t -> t.mustRunAfter(verify));
+        removeContainer.configure(t -> t.mustRunAfter(logs));
     }
 }

--- a/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
+++ b/crac-plugin/src/test/groovy/io/micronaut/gradle/crac/CracCustomizationSpec.groovy
@@ -203,4 +203,98 @@ class CracCustomizationSpec extends BaseCracGradleBuildSpec {
         fileTextContents("build/docker/main/Dockerfile.CRaCCheckpoint").readLines().head() == "I am checkpoint dockerfile"
         fileTextContents("build/docker/main/Dockerfile").readLines().head() == "I am the main dockerfile"
     }
+
+    void "restore verification tasks are registered and wired with default CRaC restore settings"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << buildFileBlock
+
+        when:
+        def result = build('tasks', '--all')
+
+        then:
+        result.output.contains('dockerVerifyCrac - Verifies the restored CRaC Docker Image')
+        result.output.contains('postRestoreCreateContainer - Creates the CRaC restored-image verification container')
+        result.output.contains('postRestoreDockerRun - Runs the CRaC restored-image verification container')
+        result.output.contains('postRestoreLogs - Shows logs from the CRaC restored-image verification container')
+        result.output.contains('postRestoreRemoveContainer - Removes the CRaC restored-image verification container')
+    }
+
+    void "restore verification task uses configurable readiness and docker runtime settings"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << getBuildFileBlockWithMicronautConfig(getMicronautConfigBlock("""crac {
+    preCheckpointReadinessCommand.set("curl --fail http://localhost:8080/health")
+    postRestoreReadinessCommand.set("curl --fail http://localhost:8080/ready")
+    postRestoreReadinessTimeout.set(java.time.Duration.ofSeconds(12))
+    postRestoreReadinessRetryDelay.set(java.time.Duration.ofSeconds(2))
+    postRestoreNetwork.set("ci-network")
+    postRestorePortBindings.add("18080:8080")
+    postRestoreEnvironment.put("MICRONAUT_ENVIRONMENTS", "test")
+    postRestoreArgs.add("--micronaut.server.port=8080")
+    retainPostRestoreContainer.set(true)
+}"""))
+        buildFile << """
+
+tasks.register("printCracRestoreVerification") {
+    doLast {
+        def create = tasks.named("postRestoreCreateContainer").get()
+        def verify = tasks.named("dockerVerifyCrac").get()
+        def remove = tasks.named("postRestoreRemoveContainer").get()
+        println("verify.commands=" + verify.commands.get().collect { it.join(' ') })
+        println("verify.probe=" + verify.execProbe.pollTime + ":" + verify.execProbe.pollInterval)
+        println("create.network=" + create.hostConfig.network.get())
+        println("create.ports=" + create.hostConfig.portBindings.get())
+        println("create.envKeys=" + create.envVars.get().keySet())
+        println("create.cmd=" + create.cmd.get())
+        println("create.capAdd=" + create.hostConfig.capAdd.get())
+        println("remove.onlyIf=" + remove.onlyIf.isSatisfiedBy(remove))
+    }
+}
+"""
+
+        when:
+        def result = build('printCracRestoreVerification')
+
+        then:
+        result.output.contains('verify.commands=[/bin/sh -c curl --fail http://localhost:8080/ready]')
+        result.output.contains('verify.probe=12000:2000')
+        result.output.contains('create.network=ci-network')
+        result.output.contains('create.ports=[18080:8080]')
+        result.output.contains('create.envKeys=[MICRONAUT_ENVIRONMENTS]')
+        result.output.contains('create.cmd=[--micronaut.server.port=8080]')
+        result.output.contains('create.capAdd=[SYS_PTRACE]')
+        result.output.contains('remove.onlyIf=false')
+    }
+
+    void "restore verification failure and cleanup behavior is wired"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << buildFileBlock
+        buildFile << """
+
+tasks.register("printCracRestoreFailureWiring") {
+    doLast {
+        def start = tasks.named("postRestoreDockerRun").get()
+        def verify = tasks.named("dockerVerifyCrac").get()
+        def remove = tasks.named("postRestoreRemoveContainer").get()
+        println("verify.successCodes=" + verify.successOnExitCodes.get())
+        println("verify.probe=" + verify.execProbe.pollTime + ":" + verify.execProbe.pollInterval)
+        println("verify.finalizedBy=" + verify.finalizedBy.getDependencies(verify).collect { it.name }.sort())
+        println("start.finalizedBy=" + start.finalizedBy.getDependencies(start).collect { it.name }.sort())
+        println("remove.onlyIf=" + remove.onlyIf.isSatisfiedBy(remove))
+    }
+}
+"""
+
+        when:
+        def result = build('printCracRestoreFailureWiring')
+
+        then:
+        result.output.contains('verify.successCodes=[0]')
+        result.output.contains('verify.probe=120000:2000')
+        result.output.contains('verify.finalizedBy=[postRestoreLogs, postRestoreRemoveContainer]')
+        result.output.contains('start.finalizedBy=[postRestoreLogs, postRestoreRemoveContainer]')
+        result.output.contains('remove.onlyIf=true')
+    }
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -636,6 +636,7 @@ The following additional tasks are provided by this plugin:
 * `dockerfileNative` - Builds a Docker File for GraalVM Native Image
 * `dockerBuildNative` - Builds a Native Docker Image using GraalVM Native Image
 * `dockerBuildCrac` - Builds a docker Image containing a CRaC enabled JDK and a pre-warmed, checkpointed application.
+* `dockerVerifyCrac` - Starts the final restored CRaC Docker image and fails if it does not become ready.
 * `dockerFileCrac` - Builds a Docker File for a CRaC checkpointed image.
 * `nativeCompile` - Builds a GraalVM Native Executable
 * `dockerPush` - Pushes a Docker Image to configured container registry
@@ -2075,6 +2076,30 @@ You will then be able to run your image via:
 docker run --cap-add=cap_sys_ptrace -p 8080:8080 <image-name>
 ----
 
+You can also verify the restored image from Gradle after `dockerBuildCrac`:
+
+[source, bash]
+----
+$ ./gradlew dockerVerifyCrac
+----
+
+The `dockerVerifyCrac` task is opt-in. It depends on the final CRaC image, creates a temporary container with the `SYS_PTRACE` capability needed for restore, starts the restored image, and runs a post-restore readiness command in the container until it succeeds or the configured timeout expires. The task is useful in CI because `dockerBuildCrac` proves that checkpointing completed, while `dockerVerifyCrac` proves that the final restored image starts and becomes ready.
+
+By default, the post-restore readiness command uses the same command as `preCheckpointReadinessCommand`, the timeout is two minutes, the retry delay is two seconds, and the verification container is removed after success or failure. The verification task streams container logs for diagnosis, so avoid passing secrets unless the restored application is configured not to print them. Use `retainPostRestoreContainer` only when debugging, because the retained container, logs, and CRaC checkpoint files may contain secrets or other JVM-visible runtime state.
+
+=== Restore verification scenarios
+
+Use these checks when adding `dockerVerifyCrac` to local development or CI:
+
+Successful restored-image verification::
+Run `./gradlew dockerVerifyCrac` after configuring any required `postRestorePortBindings`, `postRestoreEnvironment`, `postRestoreArgs`, or `postRestoreNetwork` values. The task builds the final CRaC image if needed, starts the restored image, retries `postRestoreReadinessCommand`, and succeeds only when that command exits with status `0` before `postRestoreReadinessTimeout`.
+
+Readiness timeout or failure::
+To verify that CI fails closed, temporarily point `postRestoreReadinessCommand` at an endpoint that will not become ready, or set a short `postRestoreReadinessTimeout` with a non-zero command such as `sh -c 'exit 1'`. `dockerVerifyCrac` should fail the Gradle build after retrying for the configured timeout. If the restored container exits before the readiness probe can run, the Docker exec/readiness step fails the build instead of reporting success.
+
+Cleanup after verification failure::
+Leave `retainPostRestoreContainer` at its default `false` in CI. The verification flow finalizes both the container start task and `dockerVerifyCrac` with log collection and `postRestoreRemoveContainer`, so logs are emitted and the temporary verification container is removed after a readiness failure, timeout, or early container failure. Set `retainPostRestoreContainer.set(true)` only for local debugging when you intentionally want to inspect the failed container and checkpoint files, then remove that container manually when finished.
+
 === Configuration
 
 The `io.micronaut.crac` plugin is a standalone plugin which requires the following minimal configuration.
@@ -2128,10 +2153,27 @@ micronaut {
         javaVersion = JavaLanguageVersion.of(25)
 
         // A command to run that will be successful when the application is ready to be checkpointed.
-        preCheckpointReadinessCheck = "curl --output /dev/null --silent --head http://localhost:8080"
+        preCheckpointReadinessCommand = "curl --output /dev/null --silent --head http://localhost:8080"
+
+        // A command to run in the restored container for dockerVerifyCrac.
+        // Defaults to preCheckpointReadinessCommand.
+        postRestoreReadinessCommand = "curl --fail --silent http://localhost:8080/health"
+
+        // Timeout and retry delay for the post-restore readiness command.
+        postRestoreReadinessTimeout = java.time.Duration.ofSeconds(60)
+        postRestoreReadinessRetryDelay = java.time.Duration.ofSeconds(2)
 
         // The existing Docker network to use when running the application prior to checkpointing
         network = "my-docker-network"
+
+        // Optional Docker runtime settings for dockerVerifyCrac.
+        postRestoreNetwork = "my-docker-network"
+        postRestorePortBindings.add("18080:8080")
+        postRestoreEnvironment.put("MICRONAUT_ENVIRONMENTS", "ci")
+        postRestoreArgs.add("--micronaut.server.port=8080")
+
+        // Keep the verification container for debugging instead of removing it.
+        retainPostRestoreContainer = false
 
         // You can use these to replace the script that generates a checkpoint, and the script that warms up the
         // application prior to checkpointing
@@ -2166,10 +2208,27 @@ micronaut {
         javaVersion.set(JavaLanguageVersion.of(25))
 
         // A command to run that will be successful when the application is ready to be checkpointed.
-        preCheckpointReadinessCheck.set("curl --output /dev/null --silent --head http://localhost:8080")
+        preCheckpointReadinessCommand.set("curl --output /dev/null --silent --head http://localhost:8080")
+
+        // A command to run in the restored container for dockerVerifyCrac.
+        // Defaults to preCheckpointReadinessCommand.
+        postRestoreReadinessCommand.set("curl --fail --silent http://localhost:8080/health")
+
+        // Timeout and retry delay for the post-restore readiness command.
+        postRestoreReadinessTimeout.set(java.time.Duration.ofSeconds(60))
+        postRestoreReadinessRetryDelay.set(java.time.Duration.ofSeconds(2))
 
         // The existing Docker network to use when running the application prior to checkpointing
         network.set("my-docker-network")
+
+        // Optional Docker runtime settings for dockerVerifyCrac.
+        postRestoreNetwork.set("my-docker-network")
+        postRestorePortBindings.add("18080:8080")
+        postRestoreEnvironment.put("MICRONAUT_ENVIRONMENTS", "ci")
+        postRestoreArgs.add("--micronaut.server.port=8080")
+
+        // Keep the verification container for debugging instead of removing it.
+        retainPostRestoreContainer.set(false)
 
         // You can use these to replace the script that generates a checkpoint, and the script that warms up the
         // application prior to checkpointing

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -2085,7 +2085,7 @@ $ ./gradlew dockerVerifyCrac
 
 The `dockerVerifyCrac` task is opt-in. It depends on the final CRaC image, creates a temporary container with the `SYS_PTRACE` capability needed for restore, starts the restored image, and runs a post-restore readiness command in the container until it succeeds or the configured timeout expires. The task is useful in CI because `dockerBuildCrac` proves that checkpointing completed, while `dockerVerifyCrac` proves that the final restored image starts and becomes ready.
 
-By default, the post-restore readiness command uses the same command as `preCheckpointReadinessCommand`, the timeout is two minutes, the retry delay is two seconds, and the verification container is removed after success or failure. The verification task streams container logs for diagnosis, so avoid passing secrets unless the restored application is configured not to print them. Use `retainPostRestoreContainer` only when debugging, because the retained container, logs, and CRaC checkpoint files may contain secrets or other JVM-visible runtime state.
+By default, the post-restore readiness command uses the same command as `preCheckpointReadinessCommand`, the timeout is two minutes, the retry delay is two seconds, and the verification container is removed after success or failure. The verification flow prints container logs after the readiness check for diagnosis, so avoid passing secrets unless the restored application is configured not to print them. Use `retainPostRestoreContainer` only when debugging, because the retained container, logs, and CRaC checkpoint files may contain secrets or other JVM-visible runtime state.
 
 === Restore verification scenarios
 
@@ -2171,6 +2171,7 @@ micronaut {
         postRestorePortBindings.add("18080:8080")
         postRestoreEnvironment.put("MICRONAUT_ENVIRONMENTS", "ci")
         postRestoreArgs.add("--micronaut.server.port=8080")
+        postRestoreCapAdd.add("SYS_PTRACE")
 
         // Keep the verification container for debugging instead of removing it.
         retainPostRestoreContainer = false
@@ -2226,6 +2227,7 @@ micronaut {
         postRestorePortBindings.add("18080:8080")
         postRestoreEnvironment.put("MICRONAUT_ENVIRONMENTS", "ci")
         postRestoreArgs.add("--micronaut.server.port=8080")
+        postRestoreCapAdd.add("SYS_PTRACE")
 
         // Keep the verification container for debugging instead of removing it.
         retainPostRestoreContainer.set(false)


### PR DESCRIPTION
## Summary

- adds an opt-in `dockerVerifyCrac` task that builds/starts the final restored CRaC Docker image and probes readiness from inside the verification container
- adds CRaC DSL options for restore readiness command, timeout/retry delay, network, port bindings, environment, container args, Linux capabilities, and debug container retention
- documents local/CI usage, success/failure/cleanup scenarios, and CRaC restore/logging security considerations

## Release and routing notes

- Paperclip: DEV-1073
- Type: enhancement
- Target branch: `master`
- Approved release guidance: `5.1.0 Release`; `6.0.0 Release` remains the recorded ambiguity if maintainers want this CRaC task/DSL API held for a major release.
- Linked GitHub issue: none recorded for the Paperclip issue, so there is no GitHub issue creator/reporter to request as reviewer and no GitHub closing keyword target beyond the Paperclip reference above.

## Verification

- `./gradlew :micronaut-crac-plugin:test --tests 'io.micronaut.gradle.crac.CracCustomizationSpec.restore verification*' docs --continue`
- `git diff --check`

## PR-visible assets

No screenshots or binary artifacts are required for this Gradle plugin/docs change. The user-visible output is covered by the updated AsciiDoc guide and focused TestKit coverage.

---
###### ✨ This message was AI-generated using gpt-5.5
