### PR TITLE
docs: document Kotlin test resources idle timeout

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1821,6 +1821,7 @@ micronaut {
         inferClasspath.set(true) // true by default
         additionalModules.add(JDBC_MYSQL) // empty by default
         clientTimeout.set(60) // in seconds, maximum time to wait for resources to be available, 60s by default
+        serverIdleTimeoutMinutes.set(60) // if the server doesn't receive any request for this amount of time, it will be shut down
         sharedServer.set(true) // false by default
         sharedServerNamespace.set("custom") // unset by default
         javaLauncher.set(javaToolchainSpec) // uses the project's toolchain if available, otherwise uses the same Java executable as Gradle


### PR DESCRIPTION
## Summary

- Add the missing Kotlin DSL example for `serverIdleTimeoutMinutes` in the Micronaut Test Resources configuration block.
- Keep the Kotlin sample aligned with the Groovy sample and the `TestResourcesConfiguration#getServerIdleTimeoutMinutes()` extension property.

## Validation

- `./gradlew publishGuide` attempted; this repository does not define a `publishGuide` task.
- `./gradlew docs` passed before and after the change using the repository-local docs task.
- `git diff --check` passed.
- Rendered output check confirmed `build/docs/index.html` contains `serverIdleTimeoutMinutes.set(60)` exactly once and local generated-guide anchors/files resolve.

---
###### ✨ This message was AI-generated using gpt-5.5
