### PR TITLE
Refresh root agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,10 @@ Use this file as durable project context for automation and review work in this 
 - Treat contributor-checklist items as handoff requirements. If a requirement is not applicable, state that explicitly in the PR description or handoff note.
 - For UI-visible changes, confirm whether screenshots or other visual evidence are required and include them in the PR description; if screenshots cannot be provided, explain why and describe the verification that was performed.
 
+## Branch Hygiene
+
+- If a long-lived work branch or managed checkout appears to be missing this root `AGENTS.md`, update the branch from the target branch before making guidance or implementation changes; do not recreate stale guidance from memory.
+
 ## Verification
 
 - Documentation-only guidance changes: run `git diff --check` and do a readability pass.


### PR DESCRIPTION
Refreshes durable root `AGENTS.md` guidance for the Micronaut Gradle Plugin repository after the daily managed-repository guidance audit found the active managed checkout branch did not expose root guidance.

Paperclip: DEV-1340

Verification:
- `git diff --check origin/master...origin/ceo/dev-1340-gradle-plugin-agents`
- PR diff is limited to `AGENTS.md`.

CI note:
- This is a documentation-only root agent guidance change that is not exercised by Gradle build verification, so the branch tip uses `[skip ci]`. The earlier full Java CI run failed in `functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy`, matching the current `master` Java CI failure state and unrelated to this `AGENTS.md`-only diff.

---
###### ✨ This message was AI-generated using gpt-5.5
