### PR TITLE
docs: fix stale guide links

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -455,7 +455,7 @@ plugins {
 
 The https://plugins.gradle.org/plugin/io.micronaut.library[Micronaut library plugin] applies the following modifications to the build:
 
-* Applies the https://search.maven.org/artifact/io.micronaut.platform/micronaut-platform[Micronaut Bill of Materials (BOM)]
+* Applies the https://central.sonatype.com/artifact/io.micronaut.platform/micronaut-platform[Micronaut Bill of Materials (BOM)]
 * Applies the `java-library` plugin
 * Configures annotation processing for the current language (Groovy, Java or Kotlin)
 * <<#sec:automatic-annotation-processors, Adds annotation processors automatically>> for Micronaut modules
@@ -1156,7 +1156,7 @@ tasks.named<io.micronaut.gradle.docker.NativeImageDockerfile>("dockerfileNative"
 }
 ----
 
-You can also add any of the other instructions/commands that the docker plugin supports, see {docker-plugin}/blob/master/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy[the Dockerfile task documentation].
+You can also add any of the other instructions/commands that the docker plugin supports, see https://bmuschko.github.io/gradle-docker-plugin/current/api/com/bmuschko/gradle/docker/tasks/image/Dockerfile.html[the Dockerfile task documentation].
 
 ==== Tweaking the generated docker files
 

--- a/src/docs/asciidoc/template/template.html
+++ b/src/docs/asciidoc/template/template.html
@@ -125,9 +125,9 @@
                                 </a>
                             </li>
                             <li id="menu-item-2888" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-2888">
-                                <a target="_blank" rel="noopener" href="https://gitter.im/micronautfw/">
-                                    <i class="fab fa-gitter">
-                                        <span class="sr-only">Gitter</span>
+                                <a target="_blank" rel="noopener" href="https://micronaut.io/community/">
+                                    <i class="fas fa-comments">
+                                        <span class="sr-only">Community</span>
                                     </i>
                                 </a>
                             </li>


### PR DESCRIPTION
## Summary
- Replace stale Search Maven and Gradle Docker source links in the generated user guide with live documentation/artifact links.
- Replace the stale Gitter footer link in the guide template with the Micronaut community page.

## Validation
- `./gradlew publishGuide --no-daemon` — blocked because this repository does not define a `publishGuide` task.
- `./gradlew docs --no-daemon` — passed.
- Checked generated `build/docs/index.html` for missing local anchors and local API links: 0 missing.
- Checked 52 unique external generated-guide links after the update: 0 failures.
- `./gradlew :functional-tests:test --tests '*ConfigurationValidation*' --no-daemon` — passed 12 tests while fact-checking the recently added configuration validation guide section.

Paperclip subtask: DEV-1362

---
###### ✨ This message was AI-generated using gpt-5.5
