### PR TITLE
Allow watching outside fields during continuous run

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautExtension.java
@@ -1,8 +1,11 @@
 package io.micronaut.gradle;
 
 import org.gradle.api.Action;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.Directory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 
@@ -25,6 +28,7 @@ public abstract class MicronautExtension implements ExtensionAware {
     private final Property<Boolean> enableNativeImage;
     private final Property<MicronautRuntime> runtime;
     private final Property<MicronautTestRuntime> testRuntime;
+    private final ConfigurableFileCollection additionalFilesToWatch;
 
     /**
      * If set to false, then the Micronaut Gradle plugins will not automatically
@@ -49,6 +53,7 @@ public abstract class MicronautExtension implements ExtensionAware {
     public MicronautExtension(ObjectFactory objectFactory, SourceSetConfigurer sourceSetConfigurer) {
         this.processing = objectFactory.newInstance(AnnotationProcessing.class, sourceSetConfigurer);
         this.version = objectFactory.property(String.class);
+        this.additionalFilesToWatch = objectFactory.fileCollection();
         this.enableNativeImage = objectFactory.property(Boolean.class)
                                     .convention(true);
         this.runtime = objectFactory.property(MicronautRuntime.class)
@@ -159,6 +164,13 @@ public abstract class MicronautExtension implements ExtensionAware {
      */
     public Property<String> getVersion() {
         return version;
+    }
+
+    /*
+     * @return list of files to watch when running the application with continuous build
+     */
+    public ConfigurableFileCollection getAdditionalFilesToWatch() {
+        return this.additionalFilesToWatch;
     }
 
     public AnnotationProcessing getProcessing() {

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
@@ -37,11 +37,9 @@ import org.gradle.api.tasks.SourceSetOutput;
 import org.gradle.api.tasks.TaskContainer;
 
 import java.io.File;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.micronaut.gradle.PluginsHelper.resolveRuntime;
 
@@ -106,17 +104,23 @@ public class MicronautMinimalApplicationPlugin implements Plugin<Project> {
             if (project.getGradle().getStartParameter().isContinuous() || Boolean.getBoolean(INTERNAL_CONTINUOUS_FLAG)) {
                 SourceSet sourceSet = sourceSets.findByName("main");
                 if (sourceSet != null) {
+                    MicronautExtension micronautExtension = project.getExtensions().findByType(MicronautExtension.class);
                     var sysProps = new LinkedHashMap<String, Object>();
                     sysProps.put("micronaut.io.watch.restart", true);
                     sysProps.put("micronaut.io.watch.enabled", true);
                     FileCollection sourceDirectories = sourceSet.getAllSource().getSourceDirectories();
+                    FileCollection additionalFilePathsToWatch = micronautExtension.getAdditionalFilesToWatch();
                     //noinspection Convert2Lambda
                     javaExec.doFirst(new Action<>() {
                         @Override
                         public void execute(Task workaroundEagerSystemProps) {
-                            String watchPaths = sourceDirectories
-                                    .getFiles()
-                                    .stream()
+                            Stream<File> fileSources = Stream.concat(
+                                    sourceDirectories
+                                            .getFiles().stream(),
+                                    additionalFilePathsToWatch.getFiles().stream()
+
+                            );
+                            String watchPaths = fileSources
                                     .map(File::getPath)
                                     .collect(Collectors.joining(","));
                             javaExec.systemProperty("micronaut.io.watch.paths", watchPaths);

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautMinimalApplicationPlugin.java
@@ -37,7 +37,10 @@ import org.gradle.api.tasks.SourceSetOutput;
 import org.gradle.api.tasks.TaskContainer;
 
 import java.io.File;
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMinimalApplicationPluginSpec.groovy
+++ b/minimal-plugin/src/test/groovy/io/micronaut/gradle/MicronautMinimalApplicationPluginSpec.groovy
@@ -84,6 +84,54 @@ class MicronautMinimalApplicationPluginSpec extends AbstractGradleBuildSpec {
         task.outcome == TaskOutcome.SUCCESS
         watchLine.contains 'src/main/groovy'
     }
+    def "additional files are passed when configuring watch paths"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id 'groovy'
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+                additionalFilesToWatch.setFrom(
+                    fileTree("watch")
+                )
+            }
+
+            $repositoriesBlock
+
+            dependencies {
+                implementation "org.apache.groovy:groovy"
+            }
+            $withSerde
+
+            application { mainClass = "example.Application" }
+        """
+
+        testProjectDir.newFolder("src", "main", "groovy", "example")
+        testProjectDir.newFolder("watch")
+        testProjectDir.newFile("watch/example.txt")
+        def groovyApp = testProjectDir.newFile("src/main/groovy/example/Application.groovy")
+
+        groovyApp << """package example
+
+            println "Watch paths: \${System.getProperty('micronaut.io.watch.paths')}"
+        """
+
+        when:
+        def result = build('run', "-D${MicronautMinimalApplicationPlugin.INTERNAL_CONTINUOUS_FLAG}=true")
+        def task = result.task(":run")
+        def output = result.output.readLines()
+        def watchLine = output.find { it.startsWith("Watch paths: ") }
+                .replace(File.separatorChar, (char) '/')
+
+        then:
+        task.outcome == TaskOutcome.SUCCESS
+        watchLine.contains 'watch/example.txt'
+    }
 
     @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/765")
     def "run task honors application default JVM args"() {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -651,6 +651,37 @@ $ ./gradlew run -t
 
 The `run` task honors Gradle `application.applicationDefaultJvmArgs`. Micronaut-specific JVM arguments are added in addition to those defaults.
 
+=== Continuous Build and Watching Additional Files
+By default, when running the application in continuous mode (e.g. `./gradlew run -t`), the Micronaut plugin watches for changes to any file in the main source set and will restart if modified.
+
+If your project relies on files outside of the main source set (like separate source sets or externalized configuration files), you can configure the plugin to watch these additional files so that modifying any of these files will also trigger a rebuild and restart.
+
+You can specify these directories using the `additionalFilesToWatch` property within the `micronaut` extension:
+
+[source,groovy]
+.build.gradle
+----
+micronaut {
+    // Watch a specific directory
+    additionalFilesToWatch.from(file("src/custom-assets"))
+
+    // Or watch an entire custom source set
+    additionalFilesToWatch.from(sourceSets.custom.allSource.srcDirs)
+}
+----
+
+[source,kotlin]
+.build.gradle.kts
+----
+micronaut {
+    // Watch a specific directory
+    additionalFilesToWatch.from(file("src/custom-assets"))
+
+    // Or watch an entire custom source set
+    additionalFilesToWatch.from(sourceSets.getByName("custom").allSource.srcDirs)
+}
+----
+
 === Development-only Dependencies
 
 The application plugin creates a `developmentOnly` configuration for dependencies that are needed only while running the application locally.


### PR DESCRIPTION
Micronaut automatically watches any files in the main source set when running `./gradlew run -t` but there is no support for watching files outside of the main source set. This pr adds a new field `additionalFilesToWatch` to the root `micronaut {...}` plugin extension (because I couldnt find a better place to put it but am open to suggestions/feedback). Any files passed to the new  field will be resolved just like files in the main source set. If those files modified, Micronaut will trigger a rebuild of the app.

I created an [example repo](https://github.com/RooHoo33/watch-extra-files-poc/tree/main) that has a separate source set with its [files being watched using this new feature](https://github.com/RooHoo33/watch-extra-files-poc/blob/main/build.gradle.kts#L94) and ran it with a locally published version of this plugin with my change.

I am also assuming if this is approved and merged, I will need to update [the plugin docs](https://github.com/micronaut-projects/micronaut-gradle-plugin/blob/master/src/docs/asciidoc/index.adoc) but I wasnt sure if that should be done in this pr or a separate one

Implements https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/1347
