### PR TITLE
fix: bound native Dockerfile metadata instructions

### DIFF
--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/NativeImageDockerfile.java
@@ -514,28 +514,17 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
         executable.set("application");
         String workDir = getTargetWorkingDirectory().get();
         runCommand("mkdir " + workDir + "/config-dirs");
-        getInstructions().addAll(getNativeImageOptions().map(options -> {
-                    var namer = new DockerResourceConfigDirectoryNamer();
-                    return options.getConfigurationFileDirectories()
-                            .getFiles()
-                            .stream()
-                            .filter(java.io.File::exists)
-                            .map(dir -> {
-                                String dirName = namer.determineNameFor(dir);
-                                return new RunCommandInstruction("mkdir -p " + workDir + "/config-dirs/" + dirName);
-                            })
-                            .toList();
-                }
-        ));
-        getInstructions().addAll(getNativeImageOptions().map(options -> {
-                    var namer = new DockerResourceConfigDirectoryNamer();
-                    return options.getConfigurationFileDirectories()
-                            .getFiles()
-                            .stream()
-                            .filter(java.io.File::exists)
-                            .map(dir -> toCopyResourceDirectoryInstruction(dir, namer))
-                            .toList();
-                }
+        getInstructions().addAll(getNativeImageOptions().map(options ->
+                options.getConfigurationFileDirectories()
+                        .getFiles()
+                        .stream()
+                        .filter(java.io.File::exists)
+                        .findAny()
+                        .map(ignored -> List.<Instruction>of(new CopyFileInstruction(new CopyFile(
+                                "config-dirs",
+                                workDir + "/config-dirs"
+                        ))))
+                        .orElseGet(List::of)
         ));
         runCommand(getProviders().provider(() -> renderShellCommand(buildActualCommandLine(executable, buildStrategy, imageResolver))));
         switch (buildStrategy) {
@@ -590,14 +579,6 @@ public abstract class NativeImageDockerfile extends Dockerfile implements Docker
                 }));
                 break;
         }
-    }
-
-    private CopyFileInstruction toCopyResourceDirectoryInstruction(java.io.File resourceDirectory, DockerResourceConfigDirectoryNamer namer) {
-        String relativePath = namer.determineNameFor(resourceDirectory).replace(java.io.File.separatorChar, '/');
-        return new CopyFileInstruction(new CopyFile(
-                "config-dirs/" + relativePath,
-                getTargetWorkingDirectory().get() + "/config-dirs/" + relativePath
-        ));
     }
 
     protected List<String> buildActualCommandLine(Provider<String> executable, DockerBuildStrategy buildStrategy, BaseImageForBuildStrategyResolver imageResolver) {

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/PrepareDockerContext.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/PrepareDockerContext.java
@@ -47,10 +47,12 @@ public abstract class PrepareDockerContext extends DefaultTask {
 
     @TaskAction
     void copy() {
+        File outputDirectory = getOutputDirectory().get().getAsFile();
+        getFileOperations().delete(spec -> spec.delete(outputDirectory));
         var namer = new DockerResourceConfigDirectoryNamer();
         for (File directory : getInputDirectories().getFiles()) {
             if (directory.exists()) {
-                getFileOperations().copy(spec -> spec.into(getOutputDirectory().dir(namer.determineNameFor(directory))).from(directory));
+                getFileOperations().copy(spec -> spec.into(new File(outputDirectory, namer.determineNameFor(directory))).from(directory));
             }
         }
     }

--- a/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/PrepareDockerContext.java
+++ b/docker-plugin/src/main/java/io/micronaut/gradle/docker/tasks/PrepareDockerContext.java
@@ -18,7 +18,7 @@ package io.micronaut.gradle.docker.tasks;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.internal.file.FileOperations;
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
@@ -37,7 +37,7 @@ import java.io.File;
  */
 public abstract class PrepareDockerContext extends DefaultTask {
     @Inject
-    protected abstract FileOperations getFileOperations();
+    protected abstract FileSystemOperations getFileSystemOperations();
 
     @InputFiles
     public abstract ConfigurableFileCollection getInputDirectories();
@@ -47,14 +47,15 @@ public abstract class PrepareDockerContext extends DefaultTask {
 
     @TaskAction
     void copy() {
-        File outputDirectory = getOutputDirectory().get().getAsFile();
-        getFileOperations().delete(spec -> spec.delete(outputDirectory));
         var namer = new DockerResourceConfigDirectoryNamer();
-        for (File directory : getInputDirectories().getFiles()) {
-            if (directory.exists()) {
-                getFileOperations().copy(spec -> spec.into(new File(outputDirectory, namer.determineNameFor(directory))).from(directory));
+        getFileSystemOperations().sync(spec -> {
+            spec.into(getOutputDirectory());
+            for (File directory : getInputDirectories().getFiles()) {
+                if (directory.exists()) {
+                    spec.from(directory, child -> child.into(namer.determineNameFor(directory)));
+                }
             }
-        }
+        });
     }
 
 }

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/BuildLayersSpec.groovy
@@ -199,8 +199,8 @@ class BuildLayersSpec extends AbstractGradleBuildSpec {
 
     private static File cachedDependency(String group, String module, String fileName) {
         def cacheRoots = [
-            System.getenv("GRADLE_USER_HOME"),
             new File(System.getProperty("java.io.tmpdir"), ".gradle-test-kit").absolutePath,
+            System.getenv("GRADLE_USER_HOME"),
             new File(System.getProperty("user.home"), ".gradle").absolutePath
         ].findAll { it?.trim() }
         for (def cacheRoot : cacheRoots) {

--- a/docker-plugin/src/test/groovy/io/micronaut/gradle/docker/tasks/PrepareDockerContextSpec.groovy
+++ b/docker-plugin/src/test/groovy/io/micronaut/gradle/docker/tasks/PrepareDockerContextSpec.groovy
@@ -1,0 +1,51 @@
+package io.micronaut.gradle.docker.tasks
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class PrepareDockerContextSpec extends Specification {
+
+    @TempDir
+    File projectDir
+
+    def "output is an exact snapshot of existing input directories"() {
+        given:
+        def retainedInput = new File(projectDir, 'inputs/retained')
+        def removedInput = new File(projectDir, 'inputs/removed')
+        new File(retainedInput, 'reachability-metadata.json').tap {
+            parentFile.mkdirs()
+            text = 'retained'
+        }
+        new File(removedInput, 'reachability-metadata.json').tap {
+            parentFile.mkdirs()
+            text = 'removed'
+        }
+        def output = new File(projectDir, 'build/docker/native-main/config-dirs')
+        def task = ProjectBuilder.builder()
+                .withProjectDir(projectDir)
+                .build()
+                .tasks
+                .create('prepareDockerContext', PrepareDockerContext)
+        task.inputDirectories.from(retainedInput, removedInput)
+        task.outputDirectory.set(output)
+
+        when:
+        task.copy()
+
+        then:
+        new File(output, 'retained/reachability-metadata.json').text == 'retained'
+        new File(output, 'removed/reachability-metadata.json').text == 'removed'
+
+        when:
+        assert removedInput.deleteDir()
+        def outsideOutput = new File(output.parentFile, 'keep.txt')
+        outsideOutput.text = 'keep'
+        task.copy()
+
+        then:
+        new File(output, 'retained/reachability-metadata.json').text == 'retained'
+        !new File(output, 'removed').exists()
+        outsideOutput.text == 'keep'
+    }
+}

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/aot/MicronautAOTDockerSpec.groovy
@@ -75,30 +75,7 @@ ENTRYPOINT ["java", "-jar", "/home/app/application.jar"]
             COPY --link layers/libs /home/app/libs
             COPY --link layers/app /home/app/
             RUN mkdir /home/app/config-dirs
-            RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
-            RUN mkdir -p /home/app/config-dirs/org.reactivestreams/reactive-streams/4.0.0
-            RUN mkdir -p /home/app/config-dirs/org.slf4j/slf4j-api/4.0.0
-            RUN mkdir -p /home/app/config-dirs/jakarta.inject/jakarta.inject-api/4.0.0
-            RUN mkdir -p /home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0
-            RUN mkdir -p /home/app/config-dirs/io.netty/netty-common/4.0.0.Final
-            RUN mkdir -p /home/app/config-dirs/io.netty/netty-transport/4.0.0.Final
-            RUN mkdir -p /home/app/config-dirs/com.fasterxml.jackson.core/jackson-annotations/4.0.0
-            RUN mkdir -p /home/app/config-dirs/org.yaml/snakeyaml/1.32
-            RUN mkdir -p /home/app/config-dirs/jakarta.validation/jakarta.validation-api/4.0.0
-            RUN mkdir -p /home/app/config-dirs/ch.qos.logback/logback-classic/4.0.0
-            RUN mkdir -p /home/app/config-dirs/ch.qos.logback/logback-core/4.0.0
-            COPY --link config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
-            COPY --link config-dirs/org.reactivestreams/reactive-streams/4.0.0 /home/app/config-dirs/org.reactivestreams/reactive-streams/4.0.0
-            COPY --link config-dirs/org.slf4j/slf4j-api/4.0.0 /home/app/config-dirs/org.slf4j/slf4j-api/4.0.0
-            COPY --link config-dirs/jakarta.inject/jakarta.inject-api/4.0.0 /home/app/config-dirs/jakarta.inject/jakarta.inject-api/4.0.0
-            COPY --link config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0 /home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0
-            COPY --link config-dirs/io.netty/netty-common/4.0.0.Final /home/app/config-dirs/io.netty/netty-common/4.0.0.Final
-            COPY --link config-dirs/io.netty/netty-transport/4.0.0.Final /home/app/config-dirs/io.netty/netty-transport/4.0.0.Final
-            COPY --link config-dirs/com.fasterxml.jackson.core/jackson-annotations/4.0.0 /home/app/config-dirs/com.fasterxml.jackson.core/jackson-annotations/4.0.0
-            COPY --link config-dirs/org.yaml/snakeyaml/1.32 /home/app/config-dirs/org.yaml/snakeyaml/1.32
-            COPY --link config-dirs/jakarta.validation/jakarta.validation-api/4.0.0 /home/app/config-dirs/jakarta.validation/jakarta.validation-api/4.0.0
-            COPY --link config-dirs/ch.qos.logback/logback-classic/4.0.0 /home/app/config-dirs/ch.qos.logback/logback-classic/4.0.0
-            COPY --link config-dirs/ch.qos.logback/logback-core/4.0.0 /home/app/config-dirs/ch.qos.logback/logback-core/4.0.0
+            COPY --link config-dirs /home/app/config-dirs
             RUN native-image
             FROM cgr.dev/chainguard/wolfi-base:latest
             EXPOSE 8080

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -580,7 +580,10 @@ class Application {
         "jetty"           | "FROM ghcr.io/graalvm/native-image-community:25-ol${DefaultVersions.ORACLELINUX}"
     }
 
-    @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/402")
+    @Issue([
+            "https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/402",
+            "https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/1367"
+    ])
     def "can configure an alternate working directory"() {
         given:
         settingsFile << "rootProject.name = 'hello-world'"
@@ -649,8 +652,13 @@ micronaut:
 
         when:
         build "dockerfileNative"
-        def dockerFile = normalizeLineEndings(file("build/docker/native-main/DockerfileNative").text)
-        dockerFile = dockerFile.replaceAll("[0-9]\\.[0-9]+\\.[0-9]+", "4.0.0")
+        def generatedDockerFile = normalizeLineEndings(file("build/docker/native-main/DockerfileNative").text)
+        def configurationDirectories = generatedDockerFile.readLines()
+                .find { it.startsWith('RUN native-image ') }
+                .split('-H:ConfigurationFileDirectories=')[1]
+                .split(' ')[0]
+                .split(',')
+        def dockerFile = generatedDockerFile.replaceAll("[0-9]\\.[0-9]+\\.[0-9]+", "4.0.0")
                 .replaceAll("RUN native-image .*", "RUN native-image")
                 .trim()
 
@@ -662,26 +670,19 @@ micronaut:
             COPY --link layers/app /home/alternate/
             COPY --link layers/resources /home/alternate/resources
             RUN mkdir /home/alternate/config-dirs
-            RUN mkdir -p /home/alternate/config-dirs/generateResourcesConfigFile
-            RUN mkdir -p /home/alternate/config-dirs/org.slf4j/slf4j-api/4.0.0
-            RUN mkdir -p /home/alternate/config-dirs/jakarta.inject/jakarta.inject-api/4.0.0
-            RUN mkdir -p /home/alternate/config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0
-            RUN mkdir -p /home/alternate/config-dirs/org.reactivestreams/reactive-streams/4.0.0
-            RUN mkdir -p /home/alternate/config-dirs/io.netty/netty-common/4.0.0.Final
-            RUN mkdir -p /home/alternate/config-dirs/io.netty/netty-transport/4.0.0.Final
-            COPY --link config-dirs/generateResourcesConfigFile /home/alternate/config-dirs/generateResourcesConfigFile
-            COPY --link config-dirs/org.slf4j/slf4j-api/4.0.0 /home/alternate/config-dirs/org.slf4j/slf4j-api/4.0.0
-            COPY --link config-dirs/jakarta.inject/jakarta.inject-api/4.0.0 /home/alternate/config-dirs/jakarta.inject/jakarta.inject-api/4.0.0
-            COPY --link config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0 /home/alternate/config-dirs/jakarta.annotation/jakarta.annotation-api/4.0.0
-            COPY --link config-dirs/org.reactivestreams/reactive-streams/4.0.0 /home/alternate/config-dirs/org.reactivestreams/reactive-streams/4.0.0
-            COPY --link config-dirs/io.netty/netty-common/4.0.0.Final /home/alternate/config-dirs/io.netty/netty-common/4.0.0.Final
-            COPY --link config-dirs/io.netty/netty-transport/4.0.0.Final /home/alternate/config-dirs/io.netty/netty-transport/4.0.0.Final
+            COPY --link config-dirs /home/alternate/config-dirs
             RUN native-image
             FROM cgr.dev/chainguard/wolfi-base:latest
             EXPOSE 8080
             HEALTHCHECK CMD curl -s localhost:8090/health | grep '"status":"UP"'
             COPY --link --from=graalvm /home/alternate/application /app/application
             ENTRYPOINT ["/app/application", "-Xmx64m"]""".stripIndent().trim()
+
+        and:
+        generatedDockerFile.readLines().findAll { it.startsWith('COPY') && it.contains('config-dirs') } ==
+                ['COPY --link config-dirs /home/alternate/config-dirs']
+        configurationDirectories.size() > 1
+        configurationDirectories.every { it.startsWith('/home/alternate/config-dirs/') }
 
         when:
         def result = build ":dockerBuildNative"
@@ -690,6 +691,50 @@ micronaut:
         then:
         task.outcome == TaskOutcome.SUCCESS
 
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/1367")
+    def "can disable COPY --link for native configuration directories"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            plugins {
+                id "io.micronaut.minimal.application"
+                id "io.micronaut.docker"
+                id "io.micronaut.graalvm"
+            }
+
+            micronaut {
+                version "$micronautVersion"
+                runtime "netty"
+                docker.useCopyLink = false
+            }
+
+            $repositoriesBlock
+
+            application { mainClass = "example.Application" }
+
+            java {
+                sourceCompatibility = JavaVersion.toVersion('25')
+                targetCompatibility = JavaVersion.toVersion('25')
+            }
+        """
+
+        when:
+        def result = build('dockerfileNative')
+        def dockerFile = normalizeLineEndings(file("build/docker/native-main/DockerfileNative").text)
+        def configurationDirectories = dockerFile.readLines()
+                .find { it.startsWith('RUN native-image ') }
+                .split('-H:ConfigurationFileDirectories=')[1]
+                .split(' ')[0]
+                .split(',')
+
+        then:
+        result.task(':dockerfileNative').outcome == TaskOutcome.SUCCESS
+        dockerFile.readLines().findAll { it.startsWith('COPY') && it.contains('config-dirs') } ==
+                ['COPY config-dirs /home/app/config-dirs']
+        configurationDirectories.size() > 1
+        configurationDirectories.every { it.startsWith('/home/app/config-dirs/') }
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/373")

--- a/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
+++ b/functional-tests/src/test/groovy/io/micronaut/gradle/docker/DockerNativeFunctionalTest.groovy
@@ -839,15 +839,8 @@ COPY --link server.iprof /home/app/server.iprof
 COPY --link layers/app /home/app/
 COPY --link layers/resources /home/app/resources
 RUN mkdir /home/app/config-dirs
-RUN mkdir -p /home/app/config-dirs/generateResourcesConfigFile
-RUN mkdir -p /home/app/config-dirs/org.slf4j/slf4j-api/1.7.36
-RUN mkdir -p /home/app/config-dirs/jakarta.inject/jakarta.inject-api/2.0.0
-RUN mkdir -p /home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/1.3.3
-COPY --link config-dirs/generateResourcesConfigFile /home/app/config-dirs/generateResourcesConfigFile
-COPY --link config-dirs/org.slf4j/slf4j-api/1.7.36 /home/app/config-dirs/org.slf4j/slf4j-api/1.7.36
-COPY --link config-dirs/jakarta.inject/jakarta.inject-api/2.0.0 /home/app/config-dirs/jakarta.inject/jakarta.inject-api/2.0.0
-COPY --link config-dirs/jakarta.annotation/jakarta.annotation-api/1.3.3 /home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/1.3.3
-RUN native-image -cp '/home/app/libs/*.jar:/home/app/resources:/home/app/application.jar' --no-fallback -o application -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile,/home/app/config-dirs/org.slf4j/slf4j-api/1.7.36,/home/app/config-dirs/jakarta.inject/jakarta.inject-api/2.0.0,/home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/1.3.3 ${SHARED_ARENA_SUPPORT} example.Application
+COPY --link config-dirs /home/app/config-dirs
+RUN native-image -cp '/home/app/libs/*.jar:/home/app/resources:/home/app/application.jar' --no-fallback -o application -H:ConfigurationFileDirectories=/home/app/config-dirs/generateResourcesConfigFile,/home/app/config-dirs/org.slf4j/slf4j-api/1.7.36,/home/app/config-dirs/jakarta.inject/jakarta.inject-api/2.0.0,/home/app/config-dirs/jakarta.annotation/jakarta.annotation-api/2.1.0,/home/app/config-dirs/org.jspecify/jspecify/1.0.0 ${SHARED_ARENA_SUPPORT} example.Application
 ${defaultDockerFrom}
 EXPOSE 8080
 COPY --link --from=graalvm /home/app/application /app/application


### PR DESCRIPTION
Fixes #1367

## Summary
- Replace per-metadata-directory native Dockerfile setup with one bounded tree-level `config-dirs` copy.
- Rebuild the prepared native `config-dirs` output as an exact snapshot, removing stale metadata before the broad copy.
- Use Gradle's public `FileSystemOperations.sync` API for the exact-snapshot preparation instead of internal `FileOperations`.
- Preserve alternate target working directories and linked/plain `COPY` behavior.
- Make the dependency-mtime test select the default TestKit cache used by `GradleRunner`, avoiding comparisons against a different cached copy of the same jar.

## Verification
- `PrepareDockerContextSpec.output is an exact snapshot of existing input directories` — passed before and after the public-API refactor.
- `:micronaut-docker-plugin:validatePlugins` with Gradle 9.3, `--configuration-cache`, and `--configuration-cache-problems=fail` — stored and reused successfully.
- `:micronaut-docker-plugin:test --rerun-tasks` — passed, 28 tests.
- `BuildLayersSpec.test build layers preserves dependency mtimes across reruns` — reproduced the prior CI failure before the TestKit cache correction and passed afterward.
- `DockerNativeFunctionalTest` alternate-working-directory and `useCopyLink=false` selectors — passed, 2 tests.
- `DockerNativeFunctionalTest.can tweak the generated docker file` and `MicronautAOTDockerSpec.generates a native optimized docker image` — reproduced the stale golden-output failures before correction and passed afterward, 2 tests.
- GitHub CI status and review-thread state are tracked separately by the repository checks.

## PR Assets
- [DEV-1448 focused verification log](https://raw.githubusercontent.com/micronaut-projects/micronaut-gradle-plugin/d8b46638b7fd586d6b2885adca3f58344cdb632b/assets/pr-1368/c13293efd19e/dev-1448-focused-verification.txt)

## Release / project
Target is `master` for the `5.0.2` patch release from `v5.0.1`. The PR is associated with Micronaut Platform project `5.1.0 Release` (#147). The plugin-to-Platform-BOM mapping is not exposed directly in project metadata, so this association retains the QA intake ambiguity rather than asserting a direct version mapping.

## Documentation
No user-guide change is required: this remains an internal generated-Dockerfile batching, build-context correctness, and Gradle implementation-detail change with no public DSL, configuration, API, context layout, or runtime path change.

---
###### ✨ This pull request description was AI-generated using gpt-5.6-sol