### PR TITLE
Fix stale Gradle plugin guide examples

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1248,14 +1248,14 @@ You can work around this issue by configuring the duplicates strategy on the tas
 
 [source, groovy, subs="verbatim,attributes", role="multi-language-sample"]
 ----
-tasks.withType<io.micronaut.gradle.docker.tasks.BuildLayersTask> {
+tasks.withType(io.micronaut.gradle.docker.tasks.BuildLayersTask).configureEach {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 ----
 
 [source, kotlin, subs="verbatim,attributes", role="multi-language-sample"]
 ----
-tasks.withType(io.micronaut.gradle.docker.tasks.BuildLayersTask) {
+tasks.withType<io.micronaut.gradle.docker.tasks.BuildLayersTask>().configureEach {
     duplicatesStrategy.set(DuplicatesStrategy.INCLUDE)
 }
 ----
@@ -2125,7 +2125,7 @@ micronaut {
         // The OS of the Azul CRaC JDK to use. Defaults to linux-glibc for the default base image.
         os = "linux-glibc"
 
-        // The version of the Azul CRaC JDK to use in the image (currently only 17 is supported)
+        // The version of the Azul CRaC JDK to use in the image (25 by default; other versions can be configured)
         javaVersion = JavaLanguageVersion.of(25)
 
         // A command to run that will be successful when the application is ready to be checkpointed.
@@ -2163,7 +2163,7 @@ micronaut {
         // The OS of the Azul CRaC JDK to use. Defaults to linux-glibc for the default base image.
         os.set("linux-glibc")
 
-        // The version of the Azul CRaC JDK to use in the image (currently only 17 is supported)
+        // The version of the Azul CRaC JDK to use in the image (25 by default; other versions can be configured)
         javaVersion.set(JavaLanguageVersion.of(25))
 
         // A command to run that will be successful when the application is ready to be checkpointed.


### PR DESCRIPTION
## Summary
- Correct the Groovy and Kotlin `BuildLayersTask` duplicate-strategy examples.
- Update CRaC guide comments to match the Java 25 default and configurable versions.

## Verification
- `./gradlew docs --no-daemon`
- `./gradlew :micronaut-crac-plugin:test --tests 'io.micronaut.gradle.crac.CracCustomizationSpec' --no-daemon` (13 tests passed)
- Inspected generated `build/docs/index.html` end to end: 75 headings, 227 links, 135 code blocks, and no unresolved version attributes.

The initial requested `./gradlew publishGuide` command is not present in this repository; the repository-defined equivalent is `./gradlew docs`.

---
###### ✨ This pull request description was AI-generated using gpt-5.6-luna