### PR TITLE
ci: avoid running dependencies for disabled sonar task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ if (System.getenv("SONAR_TOKEN")) {
     allprojects {
         tasks.configureEach {
             if (name == "sonar" || name == "sonarqube") {
+                setDependsOn([])
                 enabled = false
             }
         }


### PR DESCRIPTION
## Summary

Prevent the disabled `sonar`/`sonarqube` tasks from scheduling their dependencies when `SONAR_TOKEN` is present. This keeps the dedicated static-analysis CI invocation from re-entering test and coverage work after the independent `check` gate has run.

## Verification

- `git diff --check origin/master...HEAD`
- `SONAR_TOKEN=dummy ./gradlew sonar --dry-run --no-daemon` — only `:sonar SKIPPED` after buildSrc setup; no test or coverage task
- `SONAR_TOKEN=dummy ./gradlew sonar --no-daemon` — `BUILD SUCCESSFUL`; `:sonar SKIPPED`

## Release / project context

- Target branch: `master` (5.0.x; `projectVersion=5.0.3-SNAPSHOT`).
- No matching open Micronaut Platform BOM release board exists for this 5.0.x repository release, so no organization project is selected.

Closes DEV-1473

---
###### ✨ This pull request description was AI-generated using gpt-5.6-terra