### PR TITLE
docs: align GraalVM toolchain environment variable

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -841,8 +841,8 @@ org.gradle.java.installations.auto-download=false
 # Disable auto-detection of Java installations
 org.gradle.java.installations.auto-detect=false
 # Setup explicitly that the Java version to use
-# should be the one from the JAVA_HOME environment variable
-org.gradle.java.installations.fromEnv=JAVA_HOME
+# should be the one from the GRAALVM_HOME environment variable
+org.gradle.java.installations.fromEnv=GRAALVM_HOME
 ----
 
 Alternatively you can pass those options from the command line:
@@ -851,7 +851,7 @@ Alternatively you can pass those options from the command line:
 ----
 ./gradlew -Porg.gradle.java.installations.auto-download=false \
   -Porg.gradle.java.installations.auto-detect=false \
-  -Porg.gradle.java.installations.fromEnv=JAVA_HOME \
+  -Porg.gradle.java.installations.fromEnv=GRAALVM_HOME \
   build
 ----
 


### PR DESCRIPTION
## Summary
- Align the Gradle toolchain recipe with the `GRAALVM_HOME` environment variable it tells users to define.
- Correct both the `gradle.properties` and command-line forms of `org.gradle.java.installations.fromEnv`.

## Validation
- `./gradlew docs` passed and generated `build/docs/index.html`.
- The rendered guide contains only `org.gradle.java.installations.fromEnv=GRAALVM_HOME` for this recipe.
- `git diff --check` passed.
- `./gradlew publishGuide` is not a repository task; the failure was recorded and the repository-defined docs task was used.

---
###### ✨ This pull request description was AI-generated using gpt-5.6-terra